### PR TITLE
Container building make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ export FEATURES?=mcp performance sctp
 	deploy \
 	generate \
 	verify-generate \
+	ci-job
 
 TARGET_GOOS=linux
 TARGET_GOARCH=amd64
@@ -54,9 +55,7 @@ functests:
 	@echo "Running Functional Tests"
 	hack/run-functests.sh
 
-unittests: verify-generate
-	# TODO - eventually remove verify-generate here and have a prow job just
-	# to execute verify generation logic.
+unittests:
 	# functests are marked with "// +build !unittests" and will be skipped
 	GOFLAGS=-mod=vendor go test -v --tags unittests ./...
 	#TODO - copy in unit tests
@@ -83,3 +82,5 @@ generate: operator-sdk
 verify-generate: generate
 	@echo "Verifying generated code"
 	hack/verify-generated.sh
+
+ci-job: gofmt golint govet verify-generate build unittests

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -2,8 +2,8 @@ FROM quay.io/openshift/origin-operator-registry:latest
 
 COPY deploy/olm-catalog /registry/performance-addon-operators-catalog
 
-# replaces performance-addon-operators image with the one built by openshift ci
-RUN find /registry/performance-addon-operators-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:performance-addon-operators|g" {} \; || :
+# replaces performance-addon-operators image with the one matching our build
+RUN find /registry/performance-addon-operators-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|${FULL_OPERATOR_IMAGE}|g" {} \; || :
 
 # Initialize the database
 RUN initializer --manifests /registry/performance-addon-operators-catalog --output bundles.db

--- a/deploy/olm-catalog/performance-addon-operators/0.0.1/performance-addon-operators.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operators/0.0.1/performance-addon-operators.v0.0.1.clusterserviceversion.yaml
@@ -1,0 +1,143 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "performance.openshift.io/v1alpha1",
+          "kind": "CPUPerformanceProfile",
+          "metadata": {
+            "name": "example-cpuperformanceprofile"
+          },
+          "spec": {
+            "size": 3
+          }
+        }
+      ]
+    capabilities: Basic Install
+  name: performance-addon-operators.v0.0.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: CPUPerformanceProfile is the Schema for the cpuperformanceprofiles
+        API
+      kind: CPUPerformanceProfile
+      name: cpuperformanceprofiles.performance.openshift.io
+      version: v1alpha1
+  description: Placeholder description
+  displayName: Performance Addon Operators
+  install:
+    spec:
+      deployments:
+      - name: performance-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: performance-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: performance-operator
+            spec:
+              containers:
+              - command:
+                - performance-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: performance-operator
+                image: REPLACE_IMAGE
+                imagePullPolicy: Always
+                name: performance-operator
+                resources: {}
+              serviceAccountName: performance-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - performance-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+        - apiGroups:
+          - performance.openshift.io
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: performance-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  maturity: alpha
+  provider: {}
+  version: 0.0.1

--- a/deploy/olm-catalog/performance-addon-operators/0.0.1/performance.openshift.io_cpuperformanceprofiles_crd.yaml
+++ b/deploy/olm-catalog/performance-addon-operators/0.0.1/performance.openshift.io_cpuperformanceprofiles_crd.yaml
@@ -1,0 +1,43 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cpuperformanceprofiles.performance.openshift.io
+spec:
+  group: performance.openshift.io
+  names:
+    kind: CPUPerformanceProfile
+    listKind: CPUPerformanceProfileList
+    plural: cpuperformanceprofiles
+    singular: cpuperformanceprofile
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: CPUPerformanceProfile is the Schema for the cpuperformanceprofiles
+        API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CPUPerformanceProfileSpec defines the desired state of CPUPerformanceProfile
+          type: object
+        status:
+          description: CPUPerformanceProfileStatus defines the observed state of CPUPerformanceProfile
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/performance-addon-operators/performance-addon-operators.package.yaml
+++ b/deploy/olm-catalog/performance-addon-operators/performance-addon-operators.package.yaml
@@ -1,0 +1,5 @@
+channels:
+- currentCSV: performance-addon-operators.v0.0.1
+  name: alpha
+defaultChannel: alpha
+packageName: performance-addon-operators


### PR DESCRIPTION
adds the following new make targets + add adds default CSV

- build-containers: builds registry and operator containers.
- push-containers: pushes dev containers to an external repo (defaults to quay)
- generate-latest-dev-csv : generates a CSV we use for dev deployments
- ci-job: executes lots of validation checks plus unit tests