### PR TITLE
Operator cluster deploy make targets

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,5 +2,5 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 USER nobody
 
-ADD _output/bin/performance-addon-operators /usr/local/bin/performance-addon-operators
+ADD _output/bin/performance-addon-operators /usr/local/bin/performance-operator
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,5 +1,7 @@
 FROM quay.io/openshift/origin-operator-registry:latest
 
+ARG FULL_OPERATOR_IMAGE
+
 COPY deploy/olm-catalog /registry/performance-addon-operators-catalog
 
 # replaces performance-addon-operators image with the one matching our build

--- a/deploy/olm-catalog/performance-addon-operators/0.0.1/performance-addon-operators.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operators/0.0.1/performance-addon-operators.v0.0.1.clusterserviceversion.yaml
@@ -27,6 +27,7 @@ spec:
       kind: CPUPerformanceProfile
       name: cpuperformanceprofiles.performance.openshift.io
       version: v1alpha1
+      displayName: placeholder
   description: Placeholder description
   displayName: Performance Addon Operators
   install:

--- a/hack/clean-deploy.sh
+++ b/hack/clean-deploy.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# expect oc to be in PATH by default
+OC_TOOL="${OC_TOOL:-oc}"
+
+$OC_TOOL delete -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: performance-addon-operators-subscription
+  namespace: openshift-performance-addon
+spec:
+  channel: alpha
+  name: performance-addon-operators
+  source: performance-addon-operators-catalogsource
+  sourceNamespace: openshift-marketplace
+EOF
+
+$OC_TOOL delete -f - <<EOF
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: performance-addon-operators-catalogsource
+  namespace: openshift-marketplace
+spec:
+  displayName: Openshift Performance Addon Operators
+  icon:
+    base64data: ""
+    mediatype: ""
+  image: ${FULL_REGISTRY_IMAGE}
+  publisher: Red Hat
+  sourceType: grpc
+EOF

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -e
+
+# expect oc to be in PATH by default
+OC_TOOL="${OC_TOOL:-oc}"
+
+# Override the image name when this is invoked from openshift ci                               
+if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then                                                   
+        FULL_REGISTRY_IMAGE="registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:performance-addon-operators-registry"
+        echo "Openshift CI detected, deploying using image $FULL_REGISTRY_IMAGE"                   
+fi   
+
+$OC_TOOL apply -f - <<EOF
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: openshift-performance-addon
+spec: {}
+EOF
+
+$OC_TOOL apply -f - <<EOF
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-performance-addon-operatorgroup
+  namespace: openshift-performance-addon
+spec:
+  serviceAccount:
+    metadata:
+      creationTimestamp: null
+  targetNamespaces:
+  - openshift-performance-addon
+EOF
+  
+$OC_TOOL apply -f - <<EOF
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: performance-addon-operators-catalogsource
+  namespace: openshift-marketplace
+spec:
+  displayName: Openshift Performance Addon Operators
+  icon:
+    base64data: ""
+    mediatype: ""
+  image: ${FULL_REGISTRY_IMAGE}
+  publisher: Red Hat
+  sourceType: grpc
+EOF
+
+$OC_TOOL apply -f - <<EOF
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: performance-addon-operators-subscription
+  namespace: openshift-performance-addon
+spec:
+  channel: alpha
+  name: performance-addon-operators
+  source: performance-addon-operators-catalogsource
+  sourceNamespace: openshift-marketplace
+EOF
+

--- a/openshift-ci/Dockerfile.deploy
+++ b/openshift-ci/Dockerfile.deploy
@@ -3,7 +3,7 @@ LABEL com.redhat.delivery.appregistry=true
 
 ENV LANG=en_US.utf8
 
-COPY performance-addon-operators /usr/local/bin/performance-addon-operators
+COPY performance-addon-operators /usr/local/bin/performance-operator
 USER 1001
 
 ENTRYPOINT [ "/usr/local/bin/performance-addon-operators" ]

--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -1,5 +1,7 @@
 FROM quay.io/openshift/origin-operator-registry:latest
 
+ARG OPENSHIFT_BUILD_NAMESPACE
+
 COPY deploy/olm-catalog /registry/performance-addon-operators-catalog
 
 # replaces performance-addon-operators image with the one built by openshift ci


### PR DESCRIPTION
dev flow logic for testing the operator. 


```
export REGISTRY_NAMESPACE=<your quay.io namespace>
make build-containers
make push-containers
```

Make sure your images are made public in your quay.io account.

Then deploy the operator using this make target.

```
make cluster-deploy
```

There currently isn't any logic to verify the deployment. This simply posts the manifests for now.

Verify the install by checking the csv is posted.

```
$ oc get csv --all-namespaces | grep performance-addon
openshift-performance-addon            performance-addon-operators.v0.0.1   Performance Addon Operators   0.0.1                InstallReady
```

That the catalog container is online.

```
$ oc get pods --all-namespaces | grep performance
openshift-marketplace                            performance-addon-operators-catalogsource-87bjk                   1/1     Running     0          42m
openshift-performance-addon                 performance-operator-6ff4977f8b-ljk42   1/1     Running   0          19s
```

