### PR TITLE
Add sriov feature deployment using kustomize

### DIFF
--- a/cluster-setup/base/feature_sriov/01-sriov-namespace.yaml
+++ b/cluster-setup/base/feature_sriov/01-sriov-namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-sriov-network-operator
+  labels:
+    openshift.io/run-level: "1"

--- a/cluster-setup/base/feature_sriov/02-sriov-operatorgroup.yaml
+++ b/cluster-setup/base/feature_sriov/02-sriov-operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: sriov-network-operators
+  namespace: openshift-sriov-network-operator
+spec:
+  targetNamespaces:
+  - openshift-sriov-network-operator

--- a/cluster-setup/base/feature_sriov/03-sriov-subscription.yaml
+++ b/cluster-setup/base/feature_sriov/03-sriov-subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sriov-network-operator-subscription
+  namespace: openshift-sriov-network-operator
+spec:
+  channel: "4.4"
+  name: sriov-network-operator
+  source: redhat-operators 
+  sourceNamespace: openshift-marketplace

--- a/cluster-setup/base/feature_sriov/kustomization.yaml
+++ b/cluster-setup/base/feature_sriov/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - 01-sriov-namespace.yaml
+  - 02-sriov-operatorgroup.yaml
+  - 03-sriov-subscription.yaml

--- a/cluster-setup/ci-cluster/feature_sriov/10-sriov-daemonset.yaml
+++ b/cluster-setup/ci-cluster/feature_sriov/10-sriov-daemonset.yaml
@@ -1,0 +1,66 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: sriov-unsupported-nics-entrypoint
+data:
+  entrypoint.sh: |
+    #!/bin/sh
+    set -euo pipefail
+    echo "########################################"
+    echo "# Apply udev rules in unsupported NICs #"
+    echo "########################################"
+    OPERATORUDEVRULES="/etc/udev/rules.d/10-nm-unmanaged.rules"
+    CUSTOMUDEVRULES="/etc/udev/rules.d/11-custom-nm-unmanaged.rules"
+
+    if [ -f ${CUSTOMUDEVRULES} ] || [ -f ${OPERATORUDEVRULES} ]; then
+      while true ; do
+        echo "udev rules already applied, sleep loop"
+        sleep 3600
+      done
+    else
+      UDEVDEVICE=$(cat /sys/class/net/${nic}/device/sriov_vf_device)
+      echo "ACTION==\"add|change\", ATTRS{device}==\"0x${UDEVDEVICE}\", ENV{NM_UNMANAGED}=\"1\"" > ${CUSTOMUDEVRULES}
+      udevadm control --reload-rules 
+      udevadm trigger
+    fi
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: sriov-unsupported-nics-ds
+  labels:
+    app: sriov-unsupported-nics-ds
+spec:
+  selector:
+    matchLabels:
+      app: sriov-unsupported-nics-ds
+  template:
+    metadata:
+      labels:
+        app: sriov-unsupported-nics-ds
+    spec:
+      serviceAccountName: sriov-network-config-daemon
+      nodeSelector:
+        feature.node.kubernetes.io/network-sriov.capable: true
+      containers:
+      - name: sriov-unsupported-nics
+        image: ubi8/ubi-minimal
+        command: ['sh', '-c', 'cp /script/entrypoint.sh /host/tmp && chmod +x /host/tmp/entrypoint.sh && echo "Creating udev rules" && chroot /host /tmp/entrypoint.sh && sleep infinity']
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /script
+          name: sriov-unsupported-nics-script
+        - mountPath: /host
+          name: host
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - configMap:
+          name: sriov-unsupported-nics-entrypoint
+        name: sriov-unsupported-nics-script
+      - hostPath:
+          path: /
+          type: Directory
+        name: host

--- a/cluster-setup/ci-cluster/feature_sriov/11-sriov-networknodepolicy.yaml
+++ b/cluster-setup/ci-cluster/feature_sriov/11-sriov-networknodepolicy.yaml
@@ -1,0 +1,19 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: sriov-network-node-policy
+  namespace: openshift-sriov-network-operator
+spec:
+  deviceType: netdevice
+  isRdma: false
+  mtu: 1500
+  nicSelector:
+    pfNames:
+    - eno1
+    rootDevices:
+    - "0000:01:00.0"
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: true
+  numVfs: 5
+  priority: 10
+  resourceName: sriovnic

--- a/cluster-setup/ci-cluster/feature_sriov/12-sriov-network.yaml
+++ b/cluster-setup/ci-cluster/feature_sriov/12-sriov-network.yaml
@@ -1,0 +1,13 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: sriov-network
+  namespace: openshift-sriov-network-operator
+spec:
+  ipam: |
+    {
+      "type": "dhcp"
+    }
+  networkNamespace: sriov-testing
+  resourceName: sriovnic
+  vlan: 0

--- a/cluster-setup/ci-cluster/feature_sriov/20-sriov-testing-namespace.yaml
+++ b/cluster-setup/ci-cluster/feature_sriov/20-sriov-testing-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sriov-testing

--- a/cluster-setup/ci-cluster/feature_sriov/21-sriov-testing-deployment.yaml
+++ b/cluster-setup/ci-cluster/feature_sriov/21-sriov-testing-deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sriov-test
+  namespace: sriov-testing
+  labels:
+    app: sriov-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sriov-test
+  template:
+    metadata:
+      labels:
+        app: sriov-test
+      annotations:
+        k8s.v1.cni.cncf.io/networks: "sriov-testing/sriov-network"
+    spec:
+      containers:
+      - image: gcr.io/hello-minikube-zero-install/hello-node
+        name: hello-node
+        ports:
+        - containerPort: 8080

--- a/cluster-setup/ci-cluster/feature_sriov/kustomization.yaml
+++ b/cluster-setup/ci-cluster/feature_sriov/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base/feature_sriov
+patches:
+  - sriov-subscription.yaml
+resources:
+  - 10-sriov-daemonset.yaml
+  - 11-sriov-networknodepolicy.yaml
+  - 12-sriov-network.yaml
+  - 20-sriov-testing-namespace.yaml
+  - 21-sriov-testing-deployment.yaml

--- a/cluster-setup/ci-cluster/feature_sriov/sriov-subscription.yaml
+++ b/cluster-setup/ci-cluster/feature_sriov/sriov-subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sriov-network-operator-subscription
+  namespace: openshift-sriov-network-operator
+spec:
+  channel: "4.3"
+  name: sriov-network-operator
+  source: opsrctest
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
This PR add the SRIOV features.

There is an open question here that I will like to discuss on this PR.
There are some configuration that are specific to the hardware the sriov operator is running on like number of virtual functions and the PCI addresses of the network cards

Example:
```yaml
apiVersion: sriovnetwork.openshift.io/v1
kind: SriovNetworkNodePolicy
metadata:
  name: sriov-network-node-policy
  namespace: openshift-sriov-network-operator
spec:
  deviceType: netdevice
  isRdma: false
  mtu: 1500
  nicSelector:
    pfNames:
    - eno1
    rootDevices:
    - "0000:01:00.0"
  nodeSelector:
    feature.node.kubernetes.io/network-sriov.capable: true
  numVfs: 5
  priority: 10
  resourceName: sriovnic
```

I wasn't able to find a way to do it using kustomize this is why this PR should be on hold until we agree on a solution.

/hold

Signed-off-by: Sebastian Sch <sebassch@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openshift-kni/performance-addon-operators/28)
<!-- Reviewable:end -->
