### PR TITLE
Force latency is not supported with cstate in tuned 2.11

### DIFF
--- a/build/assets/tuned/openshift-node-network-latency
+++ b/build/assets/tuned/openshift-node-network-latency
@@ -5,7 +5,9 @@ include=openshift-node
 [cpu]
 # https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf
 # https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf
-force_latency=cstate.id:1|3
+force_latency=1
+# Once https://bugzilla.redhat.com/show_bug.cgi?id=1789750 is fixed, change the value to:
+# force_latency=cstate.id:1|3
 governor=performance
 energy_perf_bias=performance
 min_perf_pct=100


### PR DESCRIPTION
force_latency parameter in tuned profile is supported only for versions greater than 2.11. 
Tuned 2.11 is the current version we are using (matching RHEL 7.7/RHCOS in ocp 4.4) 
Change for supporting cstate can be found here:
https://github.com/redhat-performance/tuned/commit/0ec40e036019c4c062d76a31d676565a09c615dd#diff-6abf9f63e8d9fbfe6bddc23b8addfa1a 
