### PR TITLE
makefile: add a target to only build the binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,9 @@ OPERATOR_DEV_CSV="0.0.1"
 # Export GO111MODULE=on to enable project to be built from within GOPATH/src
 export GO111MODULE=on
 
-build: gofmt golint govet binary
+build: gofmt golint govet dist
 
-binary:
+dist:
 	@echo "Building operator binary"
 	mkdir -p build/_output/bin
 	env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go build -i -ldflags="-s -w" -mod=vendor -o build/_output/bin/performance-addon-operators ./cmd/manager

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,9 @@ OPERATOR_DEV_CSV="0.0.1"
 # Export GO111MODULE=on to enable project to be built from within GOPATH/src
 export GO111MODULE=on
 
-build: gofmt golint govet
+build: gofmt golint govet binary
+
+binary:
 	@echo "Building operator binary"
 	mkdir -p build/_output/bin
 	env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go build -i -ldflags="-s -w" -mod=vendor -o build/_output/bin/performance-addon-operators ./cmd/manager


### PR DESCRIPTION
To better integrate with isolated build systems, we could make use
of a target which just builds the binary, without the vet/lint/fmt
steps which we can take for granted - code not compliant should
never be committed in the first place.

Signed-off-by: Francesco Romani <fromani@redhat.com>