### PR TITLE
Add ability to "pause" a performance profile's reconcile loop

### DIFF
--- a/pkg/apis/performance/v1alpha1/performanceprofile_types.go
+++ b/pkg/apis/performance/v1alpha1/performanceprofile_types.go
@@ -6,6 +6,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// PerformanceProfilePauseAnnotation allows an admin to suspend the operator's
+// reconcile loop in order to perform manual changes to performance profile owned
+// objects.
+const PerformanceProfilePauseAnnotation = "performance.openshift.io/pause-reconcile"
+
 // PerformanceProfileSpec defines the desired state of PerformanceProfile.
 type PerformanceProfileSpec struct {
 	// CPU defines set of CPU related parameters.

--- a/pkg/controller/performanceprofile/components/profile/profile.go
+++ b/pkg/controller/performanceprofile/components/profile/profile.go
@@ -80,3 +80,18 @@ func getDefaultLabel(profile v1alpha1.PerformanceProfile) map[string]string {
 
 	return labels
 }
+
+// IsPaused returns whether or not a performance profile's reconcile loop is paused
+func IsPaused(profile *v1alpha1.PerformanceProfile) bool {
+
+	if profile.Annotations == nil {
+		return false
+	}
+
+	isPaused, ok := profile.Annotations[v1alpha1.PerformanceProfilePauseAnnotation]
+	if ok && isPaused == "true" {
+		return true
+	}
+
+	return false
+}

--- a/pkg/controller/performanceprofile/performanceprofile_controller.go
+++ b/pkg/controller/performanceprofile/performanceprofile_controller.go
@@ -296,7 +296,27 @@ func (r *ReconcilePerformanceProfile) Reconcile(request reconcile.Request) (reco
 	return reconcile.Result{}, nil
 }
 
+func isPaused(profile *performancev1alpha1.PerformanceProfile) bool {
+
+	if profile.Annotations == nil {
+		return false
+	}
+
+	isPaused, ok := profile.Annotations[performancev1alpha1.PerformanceProfilePauseAnnotation]
+	if ok && isPaused == "true" {
+		return true
+	}
+
+	return false
+}
+
 func (r *ReconcilePerformanceProfile) applyComponents(profile *performancev1alpha1.PerformanceProfile) (*reconcile.Result, error) {
+
+	if isPaused(profile) {
+		klog.Infof("Ignoring reconcile loop for pause performance profile %s", profile.Name)
+		return nil, nil
+	}
+
 	// get mutated machine config
 	mc, err := machineconfig.New(r.assetsDir, profile)
 	if err != nil {

--- a/pkg/controller/performanceprofile/performanceprofile_controller.go
+++ b/pkg/controller/performanceprofile/performanceprofile_controller.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/featuregate"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/kubeletconfig"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/machineconfig"
-	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/profile"
+	profileutil "github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/profile"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/tuned"
 	configv1 "github.com/openshift/api/config/v1"
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
@@ -253,7 +253,7 @@ func (r *ReconcilePerformanceProfile) Reconcile(request reconcile.Request) (reco
 	// TODO: we need to check if all under performance profiles values != nil
 	// first we need to decide if each of values required and we should move the check into validation webhook
 	// for now let's assume that all parameters needed for assets scrips are required
-	if err := profile.ValidateParameters(*instance); err != nil {
+	if err := profileutil.ValidateParameters(*instance); err != nil {
 		klog.Errorf("failed to reconcile: %v", err)
 		r.recorder.Eventf(instance, corev1.EventTypeWarning, "Validation failed", "Profile validation failed: %v", err)
 		conditions := r.getDegradedConditions(conditionReasonValidationFailed, err.Error())
@@ -296,23 +296,9 @@ func (r *ReconcilePerformanceProfile) Reconcile(request reconcile.Request) (reco
 	return reconcile.Result{}, nil
 }
 
-func isPaused(profile *performancev1alpha1.PerformanceProfile) bool {
-
-	if profile.Annotations == nil {
-		return false
-	}
-
-	isPaused, ok := profile.Annotations[performancev1alpha1.PerformanceProfilePauseAnnotation]
-	if ok && isPaused == "true" {
-		return true
-	}
-
-	return false
-}
-
 func (r *ReconcilePerformanceProfile) applyComponents(profile *performancev1alpha1.PerformanceProfile) (*reconcile.Result, error) {
 
-	if isPaused(profile) {
+	if profileutil.IsPaused(profile) {
 		klog.Infof("Ignoring reconcile loop for pause performance profile %s", profile.Name)
 		return nil, nil
 	}


### PR DESCRIPTION
Placing the "performance.openshift.io/pause-reconcile=true" annotation on a performance profile object will prevent the operator from reconciling on that object.

This is an escape hatch that allows someone to manually modify a configuration owned by the performance profile and not have our operator stomp on their changes. 