### PR TITLE
Adds dockerfile for building and promoting upstream dev public images

### DIFF
--- a/openshift-ci/Dockerfile.registry.upstream.dev
+++ b/openshift-ci/Dockerfile.registry.upstream.dev
@@ -1,0 +1,14 @@
+FROM quay.io/openshift/origin-operator-registry:latest
+
+COPY deploy/olm-catalog /registry/performance-addon-operator-catalog
+
+# replaces performance-addon-operator image with the one built by openshift ci
+RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|quay.io/performance-addon-operator/performance-addon-operator:latest|g" {} \; || :
+
+# Initialize the database
+RUN initializer --manifests /registry/performance-addon-operator-catalog --output bundles.db
+
+# There are multiple binaries in the origin-operator-registry
+# We want the registry-server
+ENTRYPOINT ["registry-server"]
+CMD ["--database", "bundles.db"]


### PR DESCRIPTION
we need this as part of the Openshift CI integration which will promote our images to quay. I registered the performance-addon-operator quay account which is what we'll sync our builds to. 