### PR TITLE
Make it possible to run tests against an external cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,9 @@ cluster-clean:
 	@echo "Deleting operator"
 	FULL_REGISTRY_IMAGE=$(FULL_REGISTRY_IMAGE) hack/clean-deploy.sh
 
-functests: cluster-label-worker-rt cluster-wait-for-mcp
+functests: cluster-label-worker-rt cluster-wait-for-mcp functests-only
+
+functests-only:
 	@echo "Running Functional Tests"
 	hack/run-functests.sh
 

--- a/functests/utils/consts.go
+++ b/functests/utils/consts.go
@@ -1,19 +1,26 @@
 package utils
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// RoleWorkerRT contains the worker-rt role
+var RoleWorkerRT string
+
+func init() {
+	RoleWorkerRT = os.Getenv("ROLE_WORKER_RT")
+	if RoleWorkerRT == "" {
+		RoleWorkerRT = "worker-rt"
+	}
+}
 
 const (
 	// LabelRole contains the key for the role label
 	LabelRole = "node-role.kubernetes.io"
 	// LabelHostname contains the key for the hostname label
 	LabelHostname = "kubernetes.io/hostname"
-)
-
-const (
-	// RoleWorker contains the worker role
-	RoleWorker = "worker"
-	// RoleWorkerRT contains the worker-rt role
-	RoleWorkerRT = "worker-rt"
 )
 
 const (

--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -6,6 +6,4 @@ if [ $? -ne 0 ]; then
 	go install github.com/onsi/ginkgo/ginkgo
 fi
 
-FOCUS=$(echo "$FEATURES" | tr ' ' '|') 
-echo "Focusing on $FOCUS"
-GOFLAGS=-mod=vendor ginkgo --focus=$FOCUS functests -- -junit /tmp/artifacts/unit_report.xml
+GOFLAGS=-mod=vendor ginkgo functests -- -junit /tmp/artifacts/unit_report.xml


### PR DESCRIPTION
`make functests` also setup labels and deploy the operator (see https://github.com/openshift-kni/performance-addon-operators/blob/f8ca736d9c83ef39dd1e581d855c94865a565400/Makefile#L126)

Also, the tests are pinned to the labels / profiles applied in the setup phase.
This PR makes those configurable and adds a makefile rule that only runs tests.