### PR TITLE
Exclusively select worker node

### DIFF
--- a/hack/label-worker-rt.sh
+++ b/hack/label-worker-rt.sh
@@ -7,5 +7,7 @@ OC_TOOL="${OC_TOOL:-oc}"
 
 # Label 1 worker node
 echo "[INFO]: Labeling 1 worker node with worker-rt"
-node=$(${OC_TOOL} get nodes --selector='node-role.kubernetes.io/worker' -o name | head -1)
+node=$(${OC_TOOL} get nodes --selector='node-role.kubernetes.io/worker' \
+    --selector='!node-role.kubernetes.io/master' -o name | head -1)
+
 ${OC_TOOL} label $node node-role.kubernetes.io/worker-rt=""


### PR DESCRIPTION
Some clusters could have master nodes labeled as 'worker'.
This patch only selects worker node and excludes nodes with
'master' label.