### PR TITLE
point our upstream images to the openshift-kni quay.io org

### DIFF
--- a/openshift-ci/Dockerfile.registry.upstream.dev
+++ b/openshift-ci/Dockerfile.registry.upstream.dev
@@ -3,7 +3,7 @@ FROM quay.io/openshift/origin-operator-registry:latest
 COPY deploy/olm-catalog /registry/performance-addon-operator-catalog
 
 # replaces performance-addon-operator image with the one built by openshift ci
-RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|quay.io/performance-addon-operator/performance-addon-operator:latest|g" {} \; || :
+RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|quay.io/openshift-kni/performance-addon-operator:latest|g" {} \; || :
 
 # Initialize the database
 RUN initializer --manifests /registry/performance-addon-operator-catalog --output bundles.db


### PR DESCRIPTION
reflect the change to use the newly created openshift-kni org in quay.io. 