### PR TITLE
Updated alm-example in CSV

### DIFF
--- a/deploy/crds/performance.openshift.io_v1alpha1_performanceprofile_cr.yaml
+++ b/deploy/crds/performance.openshift.io_v1alpha1_performanceprofile_cr.yaml
@@ -4,15 +4,15 @@ metadata:
   name: example-performanceprofile
 spec:
   cpu:
-    isolated: "2-3"
+    isolated: "1-3"
     nonIsolated: "0"
-    reserved: "0-1"
+    reserved: "0"
   hugepages:
     defaultHugepagesSize: "1G"
     pages:
     - size: "1G"
       count: 2
   realTimeKernel:
-    repoURL: "http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.1.1/compose/RT/x86_64/os"
+    enabled: true
   nodeSelector:
-    node-role.kubernetes.io/performance: ""
+    node-role.kubernetes.io/worker-rt: ""

--- a/deploy/olm-catalog/performance-addon-operator/0.0.1/performance-addon-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/0.0.1/performance-addon-operator.v0.0.1.clusterserviceversion.yaml
@@ -13,9 +13,9 @@ metadata:
           },
           "spec": {
             "cpu": {
-              "isolated": "2-3",
+              "isolated": "1-3",
               "nonIsolated": "0",
-              "reserved": "0-1"
+              "reserved": "0"
             },
             "hugepages": {
               "defaultHugepagesSize": "1G",
@@ -27,10 +27,10 @@ metadata:
               ]
             },
             "nodeSelector": {
-              "node-role.kubernetes.io/performance": ""
+              "node-role.kubernetes.io/worker-rt": ""
             },
             "realTimeKernel": {
-              "repoURL": "http://download-node-02.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.1.1/compose/RT/x86_64/os"
+              "enabled": true
             }
           }
         }


### PR DESCRIPTION
- `deploy/crds/performance.openshift.io_v1alpha1_performanceprofile_cr.yaml` is maintained manually
- `make generate-latest-dev-csv` puts it into the CSV