### PR TITLE
Try to make glcoud client happy with python2

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -16,6 +16,7 @@ RUN dnf -y install \
     which \
     skopeo \
     findutils \
+    python2 \
     && dnf clean all
 
 RUN mkdir ~/bin && \


### PR DESCRIPTION
Hopefully fixes this issue in CI:
```
ERROR: gcloud failed to load: invalid syntax (yaml_command_translator.py, line 241)
    gcloud_main = _import_gcloud_main()
    import googlecloudsdk.gcloud_main
    from googlecloudsdk.command_lib.util.apis import yaml_command_translator
    if self.spec.async:
SyntaxError: invalid syntax

This usually indicates corruption in your gcloud installation or problems with your Python interpreter.

Please verify that the following is the path to a working Python 2.7 executable:
    /usr/bin/python3

If it is not, please set the CLOUDSDK_PYTHON environment variable to point to a working Python 2.7 executable.
```