### PR TITLE
Revert back force_latency to use cstate

### DIFF
--- a/build/assets/tuned/openshift-node-network-latency
+++ b/build/assets/tuned/openshift-node-network-latency
@@ -5,9 +5,7 @@ include=openshift-node
 [cpu]
 # https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf
 # https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf
-force_latency=1
-# Once https://bugzilla.redhat.com/show_bug.cgi?id=1789750 is fixed, change the value to:
-# force_latency=cstate.id:1|3
+force_latency=cstate.id:1|3
 governor=performance
 energy_perf_bias=performance
 min_perf_pct=100


### PR DESCRIPTION
Revert https://github.com/openshift-kni/performance-addon-operators/pull/31.
Performance parameter : `force_latency`  can use cstate now that https://github.com/openshift/cluster-node-tuning-operator/pull/105 is merged. 