### PR TITLE
Remove worker-rt MCP with deploy clean-up

### DIFF
--- a/hack/clean-deploy.sh
+++ b/hack/clean-deploy.sh
@@ -8,3 +8,6 @@ $OC_TOOL delete performanceprofile --all
 $OC_TOOL delete ns openshift-performance-addon
 
 $OC_TOOL -n openshift-marketplace delete catalogsource performance-addon-operator-catalogsource
+
+$OC_TOOL delete mcp worker-rt
+


### PR DESCRIPTION
Remove worker-rt MCP while performing 'make cluster-clean'