### PR TITLE
functests: fix CI tests to pass on the latest OpenShift

### DIFF
--- a/functests/utils/nodes/nodes.go
+++ b/functests/utils/nodes/nodes.go
@@ -67,7 +67,7 @@ func ExecCommandOnMachineConfigDaemon(cs *testclient.ClientSet, node *corev1.Nod
 		"rsh",
 		"-n", testutils.NamespaceMachineConfigOperator,
 		"-c", testutils.ContainerMachineConfigDaemon,
-		"--timeout", "30",
+		"--request-timeout", "30",
 		mcd.Name,
 	}
 	initialArgs = append(initialArgs, command...)


### PR DESCRIPTION
Timeout parameter of `oc rsh` parameters started to drop deprecation error, that brake
out CI tests.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>