### PR TITLE
API Isolated and NonIsolated CPU changes

### DIFF
--- a/build/assets/scripts/pre-boot-tuning.sh
+++ b/build/assets/scripts/pre-boot-tuning.sh
@@ -76,7 +76,6 @@ else
 
     type getargs >/dev/null 2>&1 || . /lib/dracut-lib.sh
 
-    #cpumask="$(getargs reserved_cpumask)"
     cpumask='$reserved_cpumask'
 
     log()

--- a/build/assets/tuned/openshift-node-real-time-kernel
+++ b/build/assets/tuned/openshift-node-real-time-kernel
@@ -18,5 +18,7 @@ kernel.timer_migration = 0
 [sysfs]
 /sys/devices/system/machinecheck/machinecheck*/ignore_ce = 1   
 
+{{if .IsolatedCpus}}
 [scheduler]
-{{if .IsolatedCpus}}isolated_cores={{.IsolatedCpus}}{{end}}
+isolated_cores={{.IsolatedCpus}}
+{{end}}

--- a/build/assets/tuned/openshift-node-real-time-kernel
+++ b/build/assets/tuned/openshift-node-real-time-kernel
@@ -19,4 +19,4 @@ kernel.timer_migration = 0
 /sys/devices/system/machinecheck/machinecheck*/ignore_ce = 1   
 
 [scheduler]
-isolated_cores={{.IsolatedCpus}}
+{{if .IsolatedCpus}}isolated_cores={{.IsolatedCpus}}{{end}}

--- a/cluster-setup/base/performance/performance_profile.yaml
+++ b/cluster-setup/base/performance/performance_profile.yaml
@@ -3,6 +3,9 @@ kind: PerformanceProfile
 metadata:
   name: ci
 spec:
+  cpu:
+    isolated: "2-3"
+    reserved: "0-1"
   hugepages:
     defaultHugepagesSize: "1G"
   realTimeKernel:

--- a/deploy/crds/performance.openshift.io_performanceprofiles_crd.yaml
+++ b/deploy/crds/performance.openshift.io_performanceprofiles_crd.yaml
@@ -34,17 +34,16 @@ spec:
             cpu:
               description: CPU defines set of CPU related parameters.
               properties:
-                enableIsolcpus:
-                  description: EnableIsolcpus results in the Isolated CPUset being
-                    listed in the isolcpu kernel arg on the host machines. When this
-                    option is set to "false", the Isolated cpus will be partitioned
-                    by tuned, but load balancing across the Isolated cpus will still
-                    be possible. When this option is set to "true", the Isolated CPU
-                    sets will be static, meaning workloads have to explicitly assign
-                    each thread to a specific cpu in order to work across multiple
-                    cpus. Setting this to "true" offers the most predictable performance
-                    for guaranteed workloads, but it offloads the complexity of cpu
-                    load balancing to the application.
+                balanceIsolated:
+                  description: BalanceIsolated toggles whether or not the Isolated
+                    CPU set is eligible for load balancing work loads. When this option
+                    is set to "false", the Isolated CPU set will be static, meaning
+                    workloads have to explicitly assign each thread to a specific
+                    cpu in order to work across multiple CPUs. Setting this to "true"
+                    allows workloads to be balanced across CPUs. Setting this to "false"
+                    offers the most predictable performance for guaranteed workloads,
+                    but it offloads the complexity of cpu load balancing to the application.
+                    Defaults to "true"
                   type: boolean
                 isolated:
                   description: Isolated defines set of CPU's that will used to give

--- a/deploy/crds/performance.openshift.io_performanceprofiles_crd.yaml
+++ b/deploy/crds/performance.openshift.io_performanceprofiles_crd.yaml
@@ -39,10 +39,6 @@ spec:
                     to application threads the most execution time possible, which
                     means removing as many extraneous tasks off a CPU as possible.
                   type: string
-                nonIsolated:
-                  description: NonIsolated defines set of CPU's that will be used
-                    for OS tasks, like serving interupts or workqueues.
-                  type: string
                 reserved:
                   description: Reserved defines set of CPU's that will not be used
                     for any container workloads initiated by kubelet.

--- a/deploy/crds/performance.openshift.io_performanceprofiles_crd.yaml
+++ b/deploy/crds/performance.openshift.io_performanceprofiles_crd.yaml
@@ -34,6 +34,18 @@ spec:
             cpu:
               description: CPU defines set of CPU related parameters.
               properties:
+                enableIsolcpus:
+                  description: EnableIsolcpus results in the Isolated CPUset being
+                    listed in the isolcpu kernel arg on the host machines. When this
+                    option is set to "false", the Isolated cpus will be partitioned
+                    by tuned, but load balancing across the Isolated cpus will still
+                    be possible. When this option is set to "true", the Isolated CPU
+                    sets will be static, meaning workloads have to explicitly assign
+                    each thread to a specific cpu in order to work across multiple
+                    cpus. Setting this to "true" offers the most predictable performance
+                    for guaranteed workloads, but it offloads the complexity of cpu
+                    load balancing to the application.
+                  type: boolean
                 isolated:
                   description: Isolated defines set of CPU's that will used to give
                     to application threads the most execution time possible, which

--- a/deploy/crds/performance.openshift.io_v1alpha1_performanceprofile_cr.yaml
+++ b/deploy/crds/performance.openshift.io_v1alpha1_performanceprofile_cr.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   cpu:
     isolated: "2-3"
-    nonIsolated: "0"
     reserved: "0-1"
   hugepages:
     defaultHugepagesSize: "1G"

--- a/deploy/olm-catalog/performance-addon-operator/0.0.1/performance-addon-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/0.0.1/performance-addon-operator.v0.0.1.clusterserviceversion.yaml
@@ -14,7 +14,6 @@ metadata:
           "spec": {
             "cpu": {
               "isolated": "2-3",
-              "nonIsolated": "0",
               "reserved": "0-1"
             },
             "hugepages": {

--- a/deploy/olm-catalog/performance-addon-operator/0.0.1/performance.openshift.io_performanceprofiles_crd.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/0.0.1/performance.openshift.io_performanceprofiles_crd.yaml
@@ -34,17 +34,16 @@ spec:
             cpu:
               description: CPU defines set of CPU related parameters.
               properties:
-                enableIsolcpus:
-                  description: EnableIsolcpus results in the Isolated CPUset being
-                    listed in the isolcpu kernel arg on the host machines. When this
-                    option is set to "false", the Isolated cpus will be partitioned
-                    by tuned, but load balancing across the Isolated cpus will still
-                    be possible. When this option is set to "true", the Isolated CPU
-                    sets will be static, meaning workloads have to explicitly assign
-                    each thread to a specific cpu in order to work across multiple
-                    cpus. Setting this to "true" offers the most predictable performance
-                    for guaranteed workloads, but it offloads the complexity of cpu
-                    load balancing to the application.
+                balanceIsolated:
+                  description: BalanceIsolated toggles whether or not the Isolated
+                    CPU set is eligible for load balancing work loads. When this option
+                    is set to "false", the Isolated CPU set will be static, meaning
+                    workloads have to explicitly assign each thread to a specific
+                    cpu in order to work across multiple CPUs. Setting this to "true"
+                    allows workloads to be balanced across CPUs. Setting this to "false"
+                    offers the most predictable performance for guaranteed workloads,
+                    but it offloads the complexity of cpu load balancing to the application.
+                    Defaults to "true"
                   type: boolean
                 isolated:
                   description: Isolated defines set of CPU's that will used to give

--- a/deploy/olm-catalog/performance-addon-operator/0.0.1/performance.openshift.io_performanceprofiles_crd.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/0.0.1/performance.openshift.io_performanceprofiles_crd.yaml
@@ -39,10 +39,6 @@ spec:
                     to application threads the most execution time possible, which
                     means removing as many extraneous tasks off a CPU as possible.
                   type: string
-                nonIsolated:
-                  description: NonIsolated defines set of CPU's that will be used
-                    for OS tasks, like serving interupts or workqueues.
-                  type: string
                 reserved:
                   description: Reserved defines set of CPU's that will not be used
                     for any container workloads initiated by kubelet.

--- a/deploy/olm-catalog/performance-addon-operator/0.0.1/performance.openshift.io_performanceprofiles_crd.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/0.0.1/performance.openshift.io_performanceprofiles_crd.yaml
@@ -34,6 +34,18 @@ spec:
             cpu:
               description: CPU defines set of CPU related parameters.
               properties:
+                enableIsolcpus:
+                  description: EnableIsolcpus results in the Isolated CPUset being
+                    listed in the isolcpu kernel arg on the host machines. When this
+                    option is set to "false", the Isolated cpus will be partitioned
+                    by tuned, but load balancing across the Isolated cpus will still
+                    be possible. When this option is set to "true", the Isolated CPU
+                    sets will be static, meaning workloads have to explicitly assign
+                    each thread to a specific cpu in order to work across multiple
+                    cpus. Setting this to "true" offers the most predictable performance
+                    for guaranteed workloads, but it offloads the complexity of cpu
+                    load balancing to the application.
+                  type: boolean
                 isolated:
                   description: Isolated defines set of CPU's that will used to give
                     to application threads the most execution time possible, which

--- a/pkg/apis/performance/v1alpha1/performanceprofile_types.go
+++ b/pkg/apis/performance/v1alpha1/performanceprofile_types.go
@@ -46,8 +46,6 @@ type CPU struct {
 	// which means removing as many extraneous tasks off a CPU as possible.
 	// +optional
 	Isolated *CPUSet `json:"isolated,omitempty"`
-	// NonIsolated defines set of CPU's that will be used for OS tasks, like serving interupts or workqueues.
-	NonIsolated *CPUSet `json:"nonIsolated,omitempty"`
 }
 
 // HugePageSize defines size of huge pages, can be 2M or 1G.

--- a/pkg/apis/performance/v1alpha1/performanceprofile_types.go
+++ b/pkg/apis/performance/v1alpha1/performanceprofile_types.go
@@ -44,6 +44,7 @@ type CPU struct {
 	Reserved *CPUSet `json:"reserved,omitempty"`
 	// Isolated defines set of CPU's that will used to give to application threads the most execution time possible,
 	// which means removing as many extraneous tasks off a CPU as possible.
+	// +optional
 	Isolated *CPUSet `json:"isolated,omitempty"`
 	// NonIsolated defines set of CPU's that will be used for OS tasks, like serving interupts or workqueues.
 	NonIsolated *CPUSet `json:"nonIsolated,omitempty"`

--- a/pkg/apis/performance/v1alpha1/performanceprofile_types.go
+++ b/pkg/apis/performance/v1alpha1/performanceprofile_types.go
@@ -46,14 +46,15 @@ type CPU struct {
 	// which means removing as many extraneous tasks off a CPU as possible.
 	// +optional
 	Isolated *CPUSet `json:"isolated,omitempty"`
-	// EnableIsolcpus results in the Isolated CPUset being listed in the isolcpu kernel arg on the host machines.
-	// When this option is set to "false", the Isolated cpus will be partitioned by tuned, but load balancing
-	// across the Isolated cpus will still be possible.
-	// When this option is set to "true", the Isolated CPU sets will be static, meaning workloads have to
-	// explicitly assign each thread to a specific cpu in order to work across multiple cpus.
-	// Setting this to "true" offers the most predictable performance for guaranteed workloads, but it offloads
-	// the complexity of cpu load balancing to the application.
-	EnableIsolcpus *bool `json:"enableIsolcpus,omitempty"`
+	// BalanceIsolated toggles whether or not the Isolated CPU set is eligible for load balancing work loads.
+	// When this option is set to "false", the Isolated CPU set will be static, meaning workloads have to
+	// explicitly assign each thread to a specific cpu in order to work across multiple CPUs.
+	// Setting this to "true" allows workloads to be balanced across CPUs.
+	// Setting this to "false" offers the most predictable performance for guaranteed workloads, but it
+	// offloads the complexity of cpu load balancing to the application.
+	// Defaults to "true"
+	// +optional
+	BalanceIsolated *bool `json:"balanceIsolated,omitempty"`
 }
 
 // HugePageSize defines size of huge pages, can be 2M or 1G.

--- a/pkg/apis/performance/v1alpha1/performanceprofile_types.go
+++ b/pkg/apis/performance/v1alpha1/performanceprofile_types.go
@@ -46,6 +46,14 @@ type CPU struct {
 	// which means removing as many extraneous tasks off a CPU as possible.
 	// +optional
 	Isolated *CPUSet `json:"isolated,omitempty"`
+	// EnableIsolcpus results in the Isolated CPUset being listed in the isolcpu kernel arg on the host machines.
+	// When this option is set to "false", the Isolated cpus will be partitioned by tuned, but load balancing
+	// across the Isolated cpus will still be possible.
+	// When this option is set to "true", the Isolated CPU sets will be static, meaning workloads have to
+	// explicitly assign each thread to a specific cpu in order to work across multiple cpus.
+	// Setting this to "true" offers the most predictable performance for guaranteed workloads, but it offloads
+	// the complexity of cpu load balancing to the application.
+	EnableIsolcpus *bool `json:"enableIsolcpus,omitempty"`
 }
 
 // HugePageSize defines size of huge pages, can be 2M or 1G.

--- a/pkg/apis/performance/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/performance/v1alpha1/zz_generated.deepcopy.go
@@ -22,8 +22,8 @@ func (in *CPU) DeepCopyInto(out *CPU) {
 		*out = new(CPUSet)
 		**out = **in
 	}
-	if in.EnableIsolcpus != nil {
-		in, out := &in.EnableIsolcpus, &out.EnableIsolcpus
+	if in.BalanceIsolated != nil {
+		in, out := &in.BalanceIsolated, &out.BalanceIsolated
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/performance/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/performance/v1alpha1/zz_generated.deepcopy.go
@@ -22,11 +22,6 @@ func (in *CPU) DeepCopyInto(out *CPU) {
 		*out = new(CPUSet)
 		**out = **in
 	}
-	if in.NonIsolated != nil {
-		in, out := &in.NonIsolated, &out.NonIsolated
-		*out = new(CPUSet)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/apis/performance/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/performance/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,11 @@ func (in *CPU) DeepCopyInto(out *CPU) {
 		*out = new(CPUSet)
 		**out = **in
 	}
+	if in.EnableIsolcpus != nil {
+		in, out := &in.EnableIsolcpus, &out.EnableIsolcpus
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -177,9 +177,9 @@ func getIgnitionConfig(assetsDir string, profile *performancev1alpha1.Performanc
 		})
 	}
 
-	ReservedCpus := profile.Spec.CPU.Reserved
+	reservedCpus := profile.Spec.CPU.Reserved
 	preBootTuningService, err := getSystemdContent(
-		getPreBootTuningUnitOptions(string(*ReservedCpus)),
+		getPreBootTuningUnitOptions(string(*reservedCpus)),
 	)
 	if err != nil {
 		return nil, err
@@ -282,7 +282,7 @@ func getRebootUnitOptions() []*unit.UnitOption {
 	}
 }
 
-func getPreBootTuningUnitOptions(ReservedCpus string) []*unit.UnitOption {
+func getPreBootTuningUnitOptions(reservedCpus string) []*unit.UnitOption {
 	return []*unit.UnitOption{
 		// [Unit]
 		// Description
@@ -292,7 +292,7 @@ func getPreBootTuningUnitOptions(ReservedCpus string) []*unit.UnitOption {
 		unit.NewUnitOption(systemdSectionUnit, systemdBefore, getSystemdService(reboot)),
 		// [Service]
 		// Environment
-		unit.NewUnitOption(systemdSectionService, systemdEnvironment, getSystemdEnvironment(environmentReservedCpus, ReservedCpus)),
+		unit.NewUnitOption(systemdSectionService, systemdEnvironment, getSystemdEnvironment(environmentReservedCpus, reservedCpus)),
 		// Type
 		unit.NewUnitOption(systemdSectionService, systemdType, systemdServiceTypeOneshot),
 		// RemainAfterExit

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -172,7 +172,7 @@ func getIgnitionConfig(assetsDir string, profile *performancev1alpha1.Performanc
 		})
 	}
 
-	nonIsolatedCpus := profile.Spec.CPU.NonIsolated
+	nonIsolatedCpus := profile.Spec.CPU.Reserved
 	preBootTuningService, err := getSystemdContent(
 		getPreBootTuningUnitOptions(string(*nonIsolatedCpus)),
 	)

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -86,7 +86,12 @@ func New(assetsDir string, profile *performancev1alpha1.PerformanceProfile) (*ma
 	}
 
 	mc.Spec.Config = *ignitionConfig
-	mc.Spec.KernelArguments = getKernelArgs(profile.Spec.HugePages, profile.Spec.CPU.Isolated)
+
+	if profile.Spec.CPU.Isolated != nil && profile.Spec.CPU.EnableIsolcpus != nil && *profile.Spec.CPU.EnableIsolcpus == true {
+		mc.Spec.KernelArguments = getKernelArgs(profile.Spec.HugePages, profile.Spec.CPU.Isolated)
+	} else {
+		mc.Spec.KernelArguments = getKernelArgs(profile.Spec.HugePages, nil)
+	}
 
 	enableRTKernel := profile.Spec.RealTimeKernel != nil &&
 		profile.Spec.RealTimeKernel.Enabled != nil &&

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -87,7 +87,7 @@ func New(assetsDir string, profile *performancev1alpha1.PerformanceProfile) (*ma
 
 	mc.Spec.Config = *ignitionConfig
 
-	if profile.Spec.CPU.Isolated != nil && profile.Spec.CPU.EnableIsolcpus != nil && *profile.Spec.CPU.EnableIsolcpus == true {
+	if profile.Spec.CPU.Isolated != nil && profile.Spec.CPU.BalanceIsolated != nil && *profile.Spec.CPU.BalanceIsolated == false {
 		mc.Spec.KernelArguments = getKernelArgs(profile.Spec.HugePages, profile.Spec.CPU.Isolated)
 	} else {
 		mc.Spec.KernelArguments = getKernelArgs(profile.Spec.HugePages, nil)

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -59,10 +59,10 @@ const (
 )
 
 const (
-	environmentNonIsolatedCpus = "NON_ISOLATED_CPUS"
-	environmentHugepagesSize   = "HUGEPAGES_SIZE"
-	environmentHugepagesCount  = "HUGEPAGES_COUNT"
-	environmentNUMANode        = "NUMA_NODE"
+	environmentHugepagesSize  = "HUGEPAGES_SIZE"
+	environmentHugepagesCount = "HUGEPAGES_COUNT"
+	environmentNUMANode       = "NUMA_NODE"
+	environmentReservedCpus   = "RESERVED_CPUS"
 )
 
 // New returns new machine configuration object for performance sensetive workflows
@@ -177,9 +177,9 @@ func getIgnitionConfig(assetsDir string, profile *performancev1alpha1.Performanc
 		})
 	}
 
-	nonIsolatedCpus := profile.Spec.CPU.Reserved
+	ReservedCpus := profile.Spec.CPU.Reserved
 	preBootTuningService, err := getSystemdContent(
-		getPreBootTuningUnitOptions(string(*nonIsolatedCpus)),
+		getPreBootTuningUnitOptions(string(*ReservedCpus)),
 	)
 	if err != nil {
 		return nil, err
@@ -282,7 +282,7 @@ func getRebootUnitOptions() []*unit.UnitOption {
 	}
 }
 
-func getPreBootTuningUnitOptions(nonIsolatedCpus string) []*unit.UnitOption {
+func getPreBootTuningUnitOptions(ReservedCpus string) []*unit.UnitOption {
 	return []*unit.UnitOption{
 		// [Unit]
 		// Description
@@ -292,7 +292,7 @@ func getPreBootTuningUnitOptions(nonIsolatedCpus string) []*unit.UnitOption {
 		unit.NewUnitOption(systemdSectionUnit, systemdBefore, getSystemdService(reboot)),
 		// [Service]
 		// Environment
-		unit.NewUnitOption(systemdSectionService, systemdEnvironment, getSystemdEnvironment(environmentNonIsolatedCpus, nonIsolatedCpus)),
+		unit.NewUnitOption(systemdSectionService, systemdEnvironment, getSystemdEnvironment(environmentReservedCpus, ReservedCpus)),
 		// Type
 		unit.NewUnitOption(systemdSectionService, systemdType, systemdServiceTypeOneshot),
 		// RemainAfterExit

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
@@ -122,6 +122,8 @@ var _ = Describe("Machine Config", func() {
 			Count: 1024,
 			Size:  "2M",
 		})
+		t := true
+		profile.Spec.CPU.EnableIsolcpus = &t
 		mc, err := New(testAssetsDir, profile)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -138,13 +140,12 @@ var _ = Describe("Machine Config", func() {
 		Expect(manifest).To(ContainSubstring(expectedBootArguments))
 	})
 
-	It("should generate yaml with expected parameters when no isocpus are set", func() {
+	It("should generate yaml with expected parameters when isocpus not enabled", func() {
 		profile := testutils.NewPerformanceProfile("test")
 		profile.Spec.HugePages.Pages = append(profile.Spec.HugePages.Pages, performancev1alpha1.HugePage{
 			Count: 1024,
 			Size:  "2M",
 		})
-		profile.Spec.CPU.Isolated = nil
 		mc, err := New(testAssetsDir, profile)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
@@ -122,8 +122,8 @@ var _ = Describe("Machine Config", func() {
 			Count: 1024,
 			Size:  "2M",
 		})
-		t := true
-		profile.Spec.CPU.EnableIsolcpus = &t
+		f := false
+		profile.Spec.CPU.BalanceIsolated = &f
 		mc, err := New(testAssetsDir, profile)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -140,7 +140,7 @@ var _ = Describe("Machine Config", func() {
 		Expect(manifest).To(ContainSubstring(expectedBootArguments))
 	})
 
-	It("should generate yaml with expected parameters when isocpus not enabled", func() {
+	It("should generate yaml with expected parameters when balanced isolated defaults to true", func() {
 		profile := testutils.NewPerformanceProfile("test")
 		profile.Spec.HugePages.Pages = append(profile.Spec.HugePages.Pages, performancev1alpha1.HugePage{
 			Count: 1024,

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
@@ -23,7 +23,7 @@ const expectedSystemdUnits = `
           Before=reboot.service
 
           [Service]
-          Environment=NON_ISOLATED_CPUS=2-3
+          Environment=NON_ISOLATED_CPUS=0-3
           Type=oneshot
           RemainAfterExit=true
           ExecStart=/usr/local/bin/pre-boot-tuning.sh

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
@@ -23,7 +23,7 @@ const expectedSystemdUnits = `
           Before=reboot.service
 
           [Service]
-          Environment=NON_ISOLATED_CPUS=0-3
+          Environment=RESERVED_CPUS=0-3
           Type=oneshot
           RemainAfterExit=true
           ExecStart=/usr/local/bin/pre-boot-tuning.sh

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
@@ -93,6 +93,28 @@ const expectedBootArguments = `
   - hugepages=1024
 `
 
+const expectedBootArgumentsWithoutIso = `
+  kernelArguments:
+  - nohz=on
+  - nosoftlockup
+  - nmi_watchdog=0
+  - audit=0
+  - mce=off
+  - irqaffinity=0
+  - skew_tick=1
+  - processor.max_cstate=1
+  - idle=poll
+  - intel_pstate=disable
+  - intel_idle.max_cstate=0
+  - intel_iommu=on
+  - iommu=pt
+  - default_hugepagesz=1G
+  - hugepagesz=1G
+  - hugepages=4
+  - hugepagesz=2M
+  - hugepages=1024
+`
+
 var _ = Describe("Machine Config", func() {
 	It("should generate yaml with expected parameters", func() {
 		profile := testutils.NewPerformanceProfile("test")
@@ -114,6 +136,29 @@ var _ = Describe("Machine Config", func() {
 		Expect(manifest).To(ContainSubstring(fmt.Sprintf("%s: %s", labelKey, labelValue)))
 		Expect(manifest).To(ContainSubstring(expectedSystemdUnits))
 		Expect(manifest).To(ContainSubstring(expectedBootArguments))
+	})
+
+	It("should generate yaml with expected parameters when no isocpus are set", func() {
+		profile := testutils.NewPerformanceProfile("test")
+		profile.Spec.HugePages.Pages = append(profile.Spec.HugePages.Pages, performancev1alpha1.HugePage{
+			Count: 1024,
+			Size:  "2M",
+		})
+		profile.Spec.CPU.Isolated = nil
+		mc, err := New(testAssetsDir, profile)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(mc.Spec.KernelType).To(Equal(mcKernelRT))
+
+		y, err := yaml.Marshal(mc)
+		Expect(err).ToNot(HaveOccurred())
+
+		manifest := string(y)
+
+		labelKey, labelValue := components.GetFirstKeyAndValue(profile.Spec.MachineConfigLabel)
+		Expect(manifest).To(ContainSubstring(fmt.Sprintf("%s: %s", labelKey, labelValue)))
+		Expect(manifest).To(ContainSubstring(expectedSystemdUnits))
+		Expect(manifest).To(ContainSubstring(expectedBootArgumentsWithoutIso))
 	})
 
 	Context("with hugepages with specified NUMA node", func() {

--- a/pkg/controller/performanceprofile/components/profile/profile.go
+++ b/pkg/controller/performanceprofile/components/profile/profile.go
@@ -23,10 +23,6 @@ func ValidateParameters(profile *v1alpha1.PerformanceProfile) error {
 		return validationError("you should provide CPU section")
 	}
 
-	if profile.Spec.CPU.Isolated == nil {
-		return validationError("you should provide isolated CPU set")
-	}
-
 	if profile.Spec.CPU.NonIsolated == nil {
 		return validationError("you should provide non isolated CPU set")
 	}
@@ -36,7 +32,7 @@ func ValidateParameters(profile *v1alpha1.PerformanceProfile) error {
 	}
 
 	if profile.Spec.MachineConfigPoolSelector != nil && len(profile.Spec.MachineConfigPoolSelector) > 1 {
-		return validationError("you should provide onlyt 1 MachineConfigPoolSelector")
+		return validationError("you should provide only 1 MachineConfigPoolSelector")
 	}
 
 	if profile.Spec.NodeSelector == nil {

--- a/pkg/controller/performanceprofile/components/profile/profile.go
+++ b/pkg/controller/performanceprofile/components/profile/profile.go
@@ -23,10 +23,6 @@ func ValidateParameters(profile *v1alpha1.PerformanceProfile) error {
 		return validationError("you should provide CPU section")
 	}
 
-	if profile.Spec.CPU.NonIsolated == nil {
-		return validationError("you should provide non isolated CPU set")
-	}
-
 	if profile.Spec.MachineConfigLabel != nil && len(profile.Spec.MachineConfigLabel) > 1 {
 		return validationError("you should provide only 1 MachineConfigLabel")
 	}

--- a/pkg/controller/performanceprofile/components/tuned/tuned.go
+++ b/pkg/controller/performanceprofile/components/tuned/tuned.go
@@ -72,9 +72,14 @@ func NewNetworkLatency(assetsDir string) (*tunedv1.Tuned, error) {
 
 // NewWorkerRealTimeKernel returns tuned profile for performance sensitive workflows on top of real time kernel
 func NewWorkerRealTimeKernel(assetsDir string, profile *performancev1alpha1.PerformanceProfile) (*tunedv1.Tuned, error) {
-	profileData, err := getProfileData(getProfilePath(components.ProfileNameWorkerRT, assetsDir), map[string]string{
-		templateIsolatedCpus: string(*profile.Spec.CPU.Isolated),
-	})
+
+	templateArgs := make(map[string]string)
+
+	if profile.Spec.CPU.Isolated != nil {
+		templateArgs[templateIsolatedCpus] = string(*profile.Spec.CPU.Isolated)
+	}
+
+	profileData, err := getProfileData(getProfilePath(components.ProfileNameWorkerRT, assetsDir), templateArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/performanceprofile/performanceprofile_controller_test.go
+++ b/pkg/controller/performanceprofile/performanceprofile_controller_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Controller", func() {
 			Expect(degradeCondition).ToNot(BeNil())
 			Expect(degradeCondition.Status).To(Equal(corev1.ConditionTrue))
 			Expect(degradeCondition.Reason).To(Equal(conditionReasonValidationFailed))
-			Expect(degradeCondition.Message).To(Equal("you should provide only 1 MachineConfigPoolSelector"))
+			Expect(degradeCondition.Message).To(Equal("validation error: you should provide only 1 MachineConfigPoolSelector"))
 
 			// verify validation event
 			fakeRecorder, ok := r.recorder.(*record.FakeRecorder)

--- a/pkg/controller/performanceprofile/performanceprofile_controller_test.go
+++ b/pkg/controller/performanceprofile/performanceprofile_controller_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should validate scripts required parameters", func() {
-			profile.Spec.CPU.Isolated = nil
+			profile.Spec.MachineConfigPoolSelector = map[string]string{"fake1": "val1", "fake2": "val2"}
 			r := newFakeReconciler(profile)
 
 			// we do not return error, because we do not want to reconcile again, and just print error under the log,
@@ -90,7 +90,7 @@ var _ = Describe("Controller", func() {
 			Expect(degradeCondition).ToNot(BeNil())
 			Expect(degradeCondition.Status).To(Equal(corev1.ConditionTrue))
 			Expect(degradeCondition.Reason).To(Equal(conditionReasonValidationFailed))
-			Expect(degradeCondition.Message).To(ContainSubstring("you should provide isolated CPU set"))
+			Expect(degradeCondition.Message).To(Equal("you should provide only 1 MachineConfigPoolSelector"))
 
 			// verify validation event
 			fakeRecorder, ok := r.recorder.(*record.FakeRecorder)

--- a/pkg/utils/testing/testing.go
+++ b/pkg/utils/testing/testing.go
@@ -13,8 +13,6 @@ const (
 	HugePageSize = performancev1alpha1.HugePageSize("1G")
 	// IsolatedCPUs defines the isolated CPU set used for tests
 	IsolatedCPUs = performancev1alpha1.CPUSet("4-7")
-	// NonIsolateCPUs defines the non-isolated CPU set used for tests
-	NonIsolateCPUs = performancev1alpha1.CPUSet("2-3")
 	// ReservedCPUs defines the reserved CPU set used for tests
 	ReservedCPUs = performancev1alpha1.CPUSet("0-3")
 
@@ -32,7 +30,6 @@ const (
 func NewPerformanceProfile(name string) *performancev1alpha1.PerformanceProfile {
 	size := HugePageSize
 	isolatedCPUs := IsolatedCPUs
-	nonIsolateCPUs := NonIsolateCPUs
 	reservedCPUs := ReservedCPUs
 
 	return &performancev1alpha1.PerformanceProfile{
@@ -43,9 +40,8 @@ func NewPerformanceProfile(name string) *performancev1alpha1.PerformanceProfile 
 		},
 		Spec: performancev1alpha1.PerformanceProfileSpec{
 			CPU: &performancev1alpha1.CPU{
-				Isolated:    &isolatedCPUs,
-				NonIsolated: &nonIsolateCPUs,
-				Reserved:    &reservedCPUs,
+				Isolated: &isolatedCPUs,
+				Reserved: &reservedCPUs,
 			},
 			HugePages: &performancev1alpha1.HugePages{
 				DefaultHugePagesSize: &size,


### PR DESCRIPTION
## Overview

The spec.CPU.NonIsolated option is redundant. It can be represented by the same cpu set that spec.CPU.Reserved represents now. If we find we need fine granular control over how the CPUs in the reserved set are used, we can re-approach making an addition to the API at that point. 

The spec.CPU.Isolated option needs two modes, one that just uses the tuned options for cpu partitioning, and another that includes both the tuned settings plus setting the isolcpu kernel option.

The reasoning here is that using the isolcpus kernel option is not always appropriate depending on the use case. We might want to partition a set of isolated cpus and still allow those cpus to load balance. With the addition of the spec.CPU.EnableIsolcpus boolean value, we can toggle on usage of isolcpus kernel args independently of the tuned partitioning.

## Changes

- Removed NonIsolated API option. This now defaults to Reserved
- Added EnableIsolcpus API option for toggling between using kernel isolcpus arg or not for the isolated cpuset. This option defaults to false.