### PR TITLE
let taskset use the reserved CPUs list instead of a mask

### DIFF
--- a/build/assets/scripts/pre-boot-tuning.sh
+++ b/build/assets/scripts/pre-boot-tuning.sh
@@ -56,7 +56,7 @@ if [ -f ${INITRD_NEW_IMAGE} ] && grep -qs "iso_initrd.img" ${CURRENT_ENTRY_FILE}
     echo "Pre boot tuning configuration already applied"
     echo "Setting kernel rcuo* threads to the housekeeping cpus"
     get_cpu_mask 1
-    pgrep rcuo* | while read line; do taskset -p $non_iso_cpumask $line || true; done
+    pgrep rcuo* | while read line; do taskset -pc ${NON_ISOLATED_CPUS} $line || true; done
 else
     # Clean up
     rm -rf ${INITRD_GENERATION_DIR}


### PR DESCRIPTION
This is just a quick update to let taskset use the provided list of reserved CPUs, instead of calculating
a mask that can be delegated to other components soon.

Signed-off-by: Vladik Romanovsky <vromanso@redhat.com>