### PR TITLE
Adjust pre boot tunings

### DIFF
--- a/build/assets/scripts/pre-boot-tuning.sh
+++ b/build/assets/scripts/pre-boot-tuning.sh
@@ -2,113 +2,26 @@
 
 set -euo pipefail
 
-reserved_cpumask=""
-cpu_affinity=""
+SYSTEM_CONFIG_FILE="/etc/systemd/system.conf"
+SYSTEM_CONFIG_CUSTOM_FILE="/etc/systemd/system.conf.d/setAffinity.conf"
 
-get_reserved_cores() {
-    cores=()
-    while read part; do
-        if [[ $part =~ - ]]; then
-            cores+=($(seq ${part/-/ }))
-        elif [[ $part =~ , ]]; then
-            continue 
-        else
-            cores+=($part)
-        fi
-    done < <( echo ${RESERVED_CPUS} | tr ',' '\n' )
-}
-
-# $1 - 0 for irq balance banned cpus masking , 1 for reserved cpus masking
-get_cpu_mask() {
-    if [ "$1" = "1" ]; then
-        mask=( 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 )
-    else
-        mask=( 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 ) 
-    fi    
-    get_reserved_cores
-    for core in ${cores[*]}; do
-        mask[$core]=$1
-    done
-    cpumaskBinary=`echo ${mask[@]}| rev`
-    cpumaskBinary=${cpumaskBinary//[[:space:]]/}
-    reserved_cpumask=`printf '%08x\n' "$((2#$cpumaskBinary))"`
-}
-
-get_cpu_affinity() {
-    cpu_affinity=""
-    get_reserved_cores
-    for core in ${cores[*]}; do
-        cpu_affinity+=" $core"
-    done
-    echo "CPU Affinity set to $cpu_affinity"
-}
-
-# TODO - find a more robust approach than keeping the last timestamp
-RHCOS_OSTREE_PATH=$(ls -td /boot/ostree/*/ | head -1)
-RHCOS_OSTREE_BOOTLOADER_PATH=${RHCOS_OSTREE_PATH#"/boot"}
-INITRD_GENERATION_DIR="/root/initrd"
-INITRD_NEW_IMAGE="${RHCOS_OSTREE_PATH}/iso_initrd.img"
-
-OSTREE_VERSION=$(rpm-ostree status -b | grep Version | awk '{print $2}')
-CURRENT_ENTRY_FILE=$(grep -Rls ${OSTREE_VERSION} /boot/loader/entries/)
-
-if [ -f ${INITRD_NEW_IMAGE} ] && grep -qs "iso_initrd.img" ${CURRENT_ENTRY_FILE}; then
+if [ -f /etc/sysconfig/irqbalance ] && [ -f ${SYSTEM_CONFIG_CUSTOM_FILE} ] && grep -ls "IRQBALANCE_BANNED_CPUS=${RESERVED_CPU_MASK_INVERT}" /etc/sysconfig/irqbalance; then
     echo "Pre boot tuning configuration already applied"
     echo "Setting kernel rcuo* threads to the housekeeping cpus"
-    get_cpu_mask 1
     pgrep rcuo* | while read line; do taskset -pc ${RESERVED_CPUS} $line || true; done
 else
-    # Clean up
-    rm -rf ${INITRD_GENERATION_DIR}
-    
-    # Create initrd image
-    mkdir ${INITRD_GENERATION_DIR}
-    mkdir -p ${INITRD_GENERATION_DIR}/usr/lib/dracut/hooks/pre-udev/
-    mkdir -p ${INITRD_GENERATION_DIR}/etc/systemd/
-    mkdir -p ${INITRD_GENERATION_DIR}/etc/sysconfig/
-    touch ${INITRD_GENERATION_DIR}/etc/systemd/system.conf
-    touch ${INITRD_GENERATION_DIR}/etc/sysconfig/irqbalance
-    touch ${INITRD_GENERATION_DIR}/usr/lib/dracut/hooks/pre-udev/00-tuned-pre-udev.sh
-    chmod +x ${INITRD_GENERATION_DIR}/usr/lib/dracut/hooks/pre-udev/00-tuned-pre-udev.sh
+    #Set IRQ balance banned cpus
+    if [ ! -f /etc/sysconfig/irqbalance ]; then
+        touch /etc/sysconfig/irqbalance
+    fi
 
-    get_cpu_mask 1
-    echo '#!/bin/sh
+    if grep -ls "IRQBALANCE_BANNED_CPUS=" /etc/sysconfig/irqbalance; then
+        sed -i "s/^.*IRQBALANCE_BANNED_CPUS=.*$/IRQBALANCE_BANNED_CPUS=${RESERVED_CPU_MASK_INVERT}/" /etc/sysconfig/irqbalance
+    else
+        echo "IRQBALANCE_BANNED_CPUS=${RESERVED_CPU_MASK_INVERT}" >>/etc/sysconfig/irqbalance
+    fi
 
-    type getargs >/dev/null 2>&1 || . /lib/dracut-lib.sh
+    rpm-ostree initramfs --enable --arg=-I --arg="${SYSTEM_CONFIG_FILE} ${SYSTEM_CONFIG_CUSTOM_FILE}" 
 
-    cpumask='$reserved_cpumask'
-
-    log()
-    {
-    echo "tuned: $@" >> /dev/kmsg
-    }
-
-    if [ -n "$cpumask" ]; then
-    for file in /sys/devices/virtual/workqueue/cpumask /sys/bus/workqueue/devices/writeback/cpumask; do
-        log "setting $file CPU mask to $cpumask"
-        if ! echo $cpumask > $file 2>/dev/null; then
-        log "ERROR: could not write CPU mask for $file"
-        fi
-    done
-    fi' > ${INITRD_GENERATION_DIR}/usr/lib/dracut/hooks/pre-udev/00-tuned-pre-udev.sh
-
-    # Set CPU affinity according to RESERVED_CPUS
-    get_cpu_affinity
-    echo "[Manager]" >> ${INITRD_GENERATION_DIR}/etc/systemd/system.conf
-    echo "CPUAffinity=$cpu_affinity" >> ${INITRD_GENERATION_DIR}/etc/systemd/system.conf
-
-    # Set IRQ banned cpu according to RESERVED_CPUS
-    get_cpu_mask 0
-    echo "IRQBALANCE_BANNED_CPUS=$reserved_cpumask" >> ${INITRD_GENERATION_DIR}/etc/sysconfig/irqbalance
-    
-    cd ${INITRD_GENERATION_DIR}
-    find . | cpio -co >${INITRD_NEW_IMAGE}
-
-    sed -i "s^initrd .*\$^& ${RHCOS_OSTREE_BOOTLOADER_PATH}iso_initrd.img^" ${CURRENT_ENTRY_FILE}
-
-    #TODO - once RHCOS image contains the initrd content we can set parameters with rpm-ostree:
-    #rpm-ostree initramfs --enable --arg=-I --arg=/etc/systemd/system.conf
-    #rpm-ostree initramfs --enable --arg=-I --arg=/etc/sysconfig/irqbalance
-    
     touch /var/reboot
 fi

--- a/build/assets/tuned/openshift-node-real-time-kernel
+++ b/build/assets/tuned/openshift-node-real-time-kernel
@@ -16,7 +16,8 @@ vm.stat_interval = 10
 kernel.timer_migration = 0
 
 [sysfs]
-/sys/devices/system/machinecheck/machinecheck*/ignore_ce = 1   
+/sys/devices/system/machinecheck/machinecheck*/ignore_ce = 1
+/sys/bus/workqueue/devices/writeback/cpumask = {{.NotIsolatedCpumask}}  
 
 {{if .IsolatedCpus}}
 [scheduler]

--- a/build/assets/tuned/openshift-node-real-time-kernel
+++ b/build/assets/tuned/openshift-node-real-time-kernel
@@ -17,7 +17,7 @@ kernel.timer_migration = 0
 
 [sysfs]
 /sys/devices/system/machinecheck/machinecheck*/ignore_ce = 1
-/sys/bus/workqueue/devices/writeback/cpumask = {{.NotIsolatedCpumask}}  
+{{if .NotIsolatedCpumask}}/sys/bus/workqueue/devices/writeback/cpumask = {{.NotIsolatedCpumask}}{{end}}
 
 {{if .IsolatedCpus}}
 [scheduler]

--- a/build/assets/tuned/openshift-node-real-time-kernel
+++ b/build/assets/tuned/openshift-node-real-time-kernel
@@ -17,7 +17,7 @@ kernel.timer_migration = 0
 
 [sysfs]
 /sys/devices/system/machinecheck/machinecheck*/ignore_ce = 1
-{{if .NotIsolatedCpumask}}/sys/bus/workqueue/devices/writeback/cpumask = {{.NotIsolatedCpumask}}{{end}}
+{{if .ReservedCpumask}}/sys/bus/workqueue/devices/writeback/cpumask = {{.ReservedCpumask}}{{end}}
 
 {{if .IsolatedCpus}}
 [scheduler]

--- a/cluster-setup/ci-cluster/performance/performance_profile.patch.yaml
+++ b/cluster-setup/ci-cluster/performance/performance_profile.patch.yaml
@@ -4,8 +4,8 @@ metadata:
   name: ci
 spec:
   cpu:
+    balanceIsolated: false
     isolated: "1-3"
-    nonIsolated: "0"
     reserved: "0"
   hugepages:
     pages:

--- a/functests/performance/performance.go
+++ b/functests/performance/performance.go
@@ -3,9 +3,9 @@ package performance
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 	"time"
 
@@ -58,21 +58,22 @@ var _ = Describe("performance", func() {
 		It("Should set workqueue CPU mask", func() {
 			for _, node := range workerRTNodes {
 				By("Getting tuned.non_isolcpus kernel argument")
-				cmdline, err := nodes.ExecCommandOnMachineConfigDaemon(testclient.Client, &node,[]string{"cat","/proc/cmdline"})
+				cmdline, err := nodes.ExecCommandOnMachineConfigDaemon(testclient.Client, &node, []string{"cat", "/proc/cmdline"})
 				re := regexp.MustCompile(`tuned.non_isolcpus=\S+`)
 				nonIsolcpusFullArgument := re.FindString(string(cmdline))
+				Expect(nonIsolcpusFullArgument).To(ContainSubstring("tuned.non_isolcpus="))
 				nonIsolcpusMask := strings.Split(string(nonIsolcpusFullArgument), "=")[1]
 				Expect(err).ToNot(HaveOccurred())
 				By("executing the command \"cat /sys/devices/virtual/workqueue/cpumask\"")
-				workqueueMask, err := nodes.ExecCommandOnMachineConfigDaemon(testclient.Client, &node, []string{"cat","/sys/devices/virtual/workqueue/cpumask"})
+				workqueueMask, err := nodes.ExecCommandOnMachineConfigDaemon(testclient.Client, &node, []string{"cat", "/sys/devices/virtual/workqueue/cpumask"})
 				Expect(err).ToNot(HaveOccurred())
 				workqueueMaskTrimmed := strings.TrimSpace(string(workqueueMask))
-				Expect(strings.TrimLeft(nonIsolcpusMask,"0")).Should(Equal(strings.TrimLeft(workqueueMaskTrimmed,"0")), "workqueueMask is not set to "+workqueueMaskTrimmed)
+				Expect(strings.TrimLeft(nonIsolcpusMask, "0")).Should(Equal(strings.TrimLeft(workqueueMaskTrimmed, "0")), "workqueueMask is not set to "+workqueueMaskTrimmed)
 				By("executing the command \"cat /sys/bus/workqueue/devices/writeback/cpumask\"")
-				workqueueWritebackMask, err := nodes.ExecCommandOnMachineConfigDaemon(testclient.Client, &node, []string{"cat","/sys/bus/workqueue/devices/writeback/cpumask"})
+				workqueueWritebackMask, err := nodes.ExecCommandOnMachineConfigDaemon(testclient.Client, &node, []string{"cat", "/sys/bus/workqueue/devices/writeback/cpumask"})
 				Expect(err).ToNot(HaveOccurred())
 				workqueueWritebackMaskTrimmed := strings.TrimSpace(string(workqueueWritebackMask))
-				Expect(strings.TrimLeft(nonIsolcpusMask,"0")).Should(Equal(strings.TrimLeft(workqueueWritebackMaskTrimmed,"0")), "workqueueMask is not set to "+workqueueWritebackMaskTrimmed)
+				Expect(strings.TrimLeft(nonIsolcpusMask, "0")).Should(Equal(strings.TrimLeft(workqueueWritebackMaskTrimmed, "0")), "workqueueMask is not set to "+workqueueWritebackMaskTrimmed)
 			}
 		})
 

--- a/functests/performance/performance.go
+++ b/functests/performance/performance.go
@@ -57,7 +57,7 @@ var _ = Describe("performance", func() {
 		It("Should set workqueue CPU mask", func() {
 			for _, node := range workerRTNodes {
 				By("Getting tuned.non_isolcpus kernel argument")	
-				nonIsolcpusMask, err := nodes.ExecCommandOnMachineConfigDaemon(testclient.Client, &node, []string{"awk","-F","'tuned.non_isolcpus='","'{sub(/ .*$/, \"\", $2); print $2}'","/proc/cmdline"})
+				nonIsolcpusMask, err := nodes.ExecCommandOnMachineConfigDaemon(testclient.Client, &node, []string{"awk","-F 'tuned.non_isolcpus=' '{sub(/ .*$/, \"\", $2); print $2}' /proc/cmdline"})
 				Expect(err).ToNot(HaveOccurred())
 				By("executing the command \"cat /sys/devices/virtual/workqueue/cpumask\"")
 				workqueueMask, err := nodes.ExecCommandOnMachineConfigDaemon(testclient.Client, &node, []string{"cat","/sys/devices/virtual/workqueue/cpumask"})

--- a/functests/performance/performance.go
+++ b/functests/performance/performance.go
@@ -56,8 +56,8 @@ var _ = Describe("performance", func() {
 
 		It("Should set workqueue CPU mask", func() {
 			for _, node := range workerRTNodes {
-				By("Getting tuned.non_isolcpus kernel argument")	
-				nonIsolcpusMask, err := nodes.ExecCommandOnMachineConfigDaemon(testclient.Client, &node, []string{"awk","-F 'tuned.non_isolcpus=' '{sub(/ .*$/, \"\", $2); print $2}' /proc/cmdline"})
+				By("Getting tuned.non_isolcpus kernel argument")
+				nonIsolcpusMask, err := nodes.ExecCommandOnMachineConfigDaemon(testclient.Client, &node,[]string{"grep","-oP","'tuned.non_isolcpus=\\K\\S+'","/proc/cmdline"})
 				Expect(err).ToNot(HaveOccurred())
 				By("executing the command \"cat /sys/devices/virtual/workqueue/cpumask\"")
 				workqueueMask, err := nodes.ExecCommandOnMachineConfigDaemon(testclient.Client, &node, []string{"cat","/sys/devices/virtual/workqueue/cpumask"})

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -183,17 +183,7 @@ func getIgnitionConfig(assetsDir string, profile *performancev1alpha1.Performanc
 	}
 
 	reservedCpus := profile.Spec.CPU.Reserved
-
-	err := ioutil.WriteFile(fmt.Sprintf("%s/setAffinity.conf", assetsDir), []byte("[Manager]\nCPUAffinity="+string(*reservedCpus)), 0700)
-	if err != nil {
-		return nil, err
-	}
-	content, err := ioutil.ReadFile(fmt.Sprintf("%s/setAffinity.conf", assetsDir))
-	if err != nil {
-		return nil, err
-	}
-
-	contentBase64 := base64.StdEncoding.EncodeToString(content)
+	contentBase64 := base64.StdEncoding.EncodeToString([]byte("[Manager]\nCPUAffinity=" + string(*reservedCpus)))
 	ignitionConfig.Storage.Files = append(ignitionConfig.Storage.Files, igntypes.File{
 		Node: igntypes.Node{
 			Filesystem: defaultFileSystem,

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -107,7 +107,7 @@ func New(assetsDir string, profile *performancev1alpha1.PerformanceProfile) (*ma
 	return mc, nil
 }
 
-func getKernelArgs(hugePages *performancev1alpha1.HugePages, isolatedCPUs *performancev1alpha1.CPUSet, nonIsolatedCPUs *performancev1alpha1.CPUSet) []string {
+func getKernelArgs(hugePages *performancev1alpha1.HugePages, isolatedCPUs *performancev1alpha1.CPUSet, reservedCPUs *performancev1alpha1.CPUSet) []string {
 	kargs := []string{
 		"nohz=on",
 		"nosoftlockup",
@@ -128,8 +128,8 @@ func getKernelArgs(hugePages *performancev1alpha1.HugePages, isolatedCPUs *perfo
 		kargs = append(kargs, fmt.Sprintf("isolcpus=%s", string(*isolatedCPUs)))
 	}
 
-	if nonIsolatedCPUs != nil {
-		cpuMask, err := components.CPUListToHexMask(string(*nonIsolatedCPUs))
+	if reservedCPUs != nil {
+		cpuMask, err := components.CPUListToHexMask(string(*reservedCPUs))
 		if err == nil {
 			kargs = append(kargs, fmt.Sprintf("tuned.non_isolcpus=%s", cpuMask))
 		}
@@ -200,7 +200,7 @@ func getIgnitionConfig(assetsDir string, profile *performancev1alpha1.Performanc
 		},
 	})
 
-	cpuInvertedMask, err := components.CPUListToInvertedMask(string(*reservedCpus))
+	cpuInvertedMask, err := components.CPUListTo32BitsMaskList(string(*reservedCpus))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -91,7 +91,7 @@ func New(assetsDir string, profile *performancev1alpha1.PerformanceProfile) (*ma
 	if profile.Spec.CPU.Isolated != nil && profile.Spec.CPU.BalanceIsolated != nil && *profile.Spec.CPU.BalanceIsolated == false {
 		mc.Spec.KernelArguments = getKernelArgs(profile.Spec.HugePages, profile.Spec.CPU.Isolated, profile.Spec.CPU.Reserved)
 	} else {
-		mc.Spec.KernelArguments = getKernelArgs(profile.Spec.HugePages, nil, nil)
+		mc.Spec.KernelArguments = getKernelArgs(profile.Spec.HugePages, nil, profile.Spec.CPU.Reserved)
 	}
 
 	enableRTKernel := profile.Spec.RealTimeKernel != nil &&

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -320,7 +320,7 @@ func getPreBootTuningUnitOptions(reservedCpus string, cpuInvertedMask string) []
 		// [Service]
 		// Environment
 		unit.NewUnitOption(systemdSectionService, systemdEnvironment, getSystemdEnvironment(environmentReservedCpus, reservedCpus)),
-		unit.NewUnitOption(systemdSectionService, systemdEnvironment, getSystemdEnvironment(environmentReservedCPUMaskInverted, components.CPUListToInvertedMask(reservedCpus))),
+		unit.NewUnitOption(systemdSectionService, systemdEnvironment, getSystemdEnvironment(environmentReservedCPUMaskInverted, cpuInvertedMask)),
 		// Type
 		unit.NewUnitOption(systemdSectionService, systemdType, systemdServiceTypeOneshot),
 		// RemainAfterExit

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
@@ -24,7 +24,7 @@ const expectedSystemdUnits = `
 
           [Service]
           Environment=RESERVED_CPUS=0-3
-          Environment=RESERVED_CPU_MASK_INVERT=3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3
+          Environment=RESERVED_CPU_MASK_INVERT=ffffffff,fffffff0
           Type=oneshot
           RemainAfterExit=true
           ExecStart=/usr/local/bin/pre-boot-tuning.sh
@@ -87,7 +87,7 @@ const expectedBootArguments = `
   - intel_iommu=on
   - iommu=pt
   - isolcpus=4-7
-  - tuned.non_isolcpus=0c
+  - tuned.non_isolcpus=0f
   - default_hugepagesz=1G
   - hugepagesz=1G
   - hugepages=4

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
@@ -110,6 +110,7 @@ const expectedBootArgumentsWithoutIso = `
   - intel_idle.max_cstate=0
   - intel_iommu=on
   - iommu=pt
+  - tuned.non_isolcpus=0f
   - default_hugepagesz=1G
   - hugepagesz=1G
   - hugepages=4

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
@@ -24,6 +24,7 @@ const expectedSystemdUnits = `
 
           [Service]
           Environment=RESERVED_CPUS=0-3
+          Environment=RESERVED_CPU_MASK_INVERT=3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3
           Type=oneshot
           RemainAfterExit=true
           ExecStart=/usr/local/bin/pre-boot-tuning.sh
@@ -86,6 +87,7 @@ const expectedBootArguments = `
   - intel_iommu=on
   - iommu=pt
   - isolcpus=4-7
+  - tuned.non_isolcpus=0c
   - default_hugepagesz=1G
   - hugepagesz=1G
   - hugepages=4

--- a/pkg/controller/performanceprofile/components/tuned/tuned.go
+++ b/pkg/controller/performanceprofile/components/tuned/tuned.go
@@ -81,7 +81,11 @@ func NewWorkerRealTimeKernel(assetsDir string, profile *performancev1alpha1.Perf
 	}
 
 	if profile.Spec.CPU.Reserved != nil {
-		templateArgs[templateNotIsolatedCpumask] = components.CPUListToHexMask(string(*profile.Spec.CPU.Reserved))
+		cpuMask, err := components.CPUListToHexMask(string(*profile.Spec.CPU.Reserved))
+		if err != nil {
+			return nil, err
+		}
+		templateArgs[templateNotIsolatedCpumask] = cpuMask
 	}
 
 	profileData, err := getProfileData(getProfilePath(components.ProfileNameWorkerRT, assetsDir), templateArgs)

--- a/pkg/controller/performanceprofile/components/tuned/tuned.go
+++ b/pkg/controller/performanceprofile/components/tuned/tuned.go
@@ -20,7 +20,8 @@ const (
 )
 
 const (
-	templateIsolatedCpus = "IsolatedCpus"
+	templateIsolatedCpus       = "IsolatedCpus"
+	templateNotIsolatedCpumask = "NotIsolatedCpumask"
 )
 
 func new(name string, profiles []tunedv1.TunedProfile, recommends []tunedv1.TunedRecommend) *tunedv1.Tuned {
@@ -79,7 +80,12 @@ func NewWorkerRealTimeKernel(assetsDir string, profile *performancev1alpha1.Perf
 		templateArgs[templateIsolatedCpus] = string(*profile.Spec.CPU.Isolated)
 	}
 
+	if profile.Spec.CPU.Reserved != nil {
+		templateArgs[templateNotIsolatedCpumask] = components.CPUListToHexMask(string(*profile.Spec.CPU.Reserved))
+	}
+
 	profileData, err := getProfileData(getProfilePath(components.ProfileNameWorkerRT, assetsDir), templateArgs)
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/performanceprofile/components/tuned/tuned.go
+++ b/pkg/controller/performanceprofile/components/tuned/tuned.go
@@ -20,8 +20,8 @@ const (
 )
 
 const (
-	templateIsolatedCpus       = "IsolatedCpus"
-	templateNotIsolatedCpumask = "NotIsolatedCpumask"
+	templateIsolatedCpus    = "IsolatedCpus"
+	templateReservedCpumask = "ReservedCpumask"
 )
 
 func new(name string, profiles []tunedv1.TunedProfile, recommends []tunedv1.TunedRecommend) *tunedv1.Tuned {
@@ -85,7 +85,7 @@ func NewWorkerRealTimeKernel(assetsDir string, profile *performancev1alpha1.Perf
 		if err != nil {
 			return nil, err
 		}
-		templateArgs[templateNotIsolatedCpumask] = cpuMask
+		templateArgs[templateReservedCpumask] = cpuMask
 	}
 
 	profileData, err := getProfileData(getProfilePath(components.ProfileNameWorkerRT, assetsDir), templateArgs)

--- a/pkg/controller/performanceprofile/components/utils.go
+++ b/pkg/controller/performanceprofile/components/utils.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const maxSystemCpus = 254
+const maxSystemCpus = 64
 
 // GetComponentName returns the component name for the specific performance profile
 func GetComponentName(profileName string, prefix string) string {
@@ -95,5 +95,15 @@ func CPUListToInvertedMask(cpulist string) (hexMask string, err error) {
 		x := new(big.Int).Lsh(big.NewInt(1), uint(cpu))
 		currMask.Or(currMask, x)
 	}
-	return fmt.Sprintf("%02x", currMask), nil
+	return fmt.Sprintf("%016x", currMask), nil
+}
+
+// CPUListTo32BitsMaskList converts a list of cpus into an inverted cpu mask represented
+// in a list of 32bit hexadecimal masks devided by a delimiter ","
+func CPUListTo32BitsMaskList(cpulist string) (hexMask string, err error) {
+	maskStr, err := CPUListToInvertedMask(cpulist)
+	if err != nil {
+		return "", nil
+	}
+	return fmt.Sprintf("%s,%s", maskStr[:8], maskStr[8:]), nil
 }

--- a/pkg/controller/performanceprofile/components/utils.go
+++ b/pkg/controller/performanceprofile/components/utils.go
@@ -63,20 +63,25 @@ func cpusListToArray(cpusListStr string) ([]int, error) {
 }
 
 // CPUListToHexMask converts a list of cpus into a cpu mask represented in hexdecimal
-func CPUListToHexMask(cpulist string) (hexMask string) {
-	reservedCpus, _ := cpusListToArray(cpulist)
+func CPUListToHexMask(cpulist string) (hexMask string, err error) {
+	reservedCpus, err := cpusListToArray(cpulist)
+	if err != nil {
+		return "", err
+	}
 	currMask := big.NewInt(0)
 	for _, cpu := range reservedCpus {
 		x := new(big.Int).Lsh(big.NewInt(1), uint(cpu))
 		currMask.Or(currMask, x)
 	}
-	return fmt.Sprintf("%02x", currMask)
+	return fmt.Sprintf("%02x", currMask), nil
 }
 
 // CPUListToInvertedMask converts a list of cpus into an inverted cpu mask represented in hexdecimal
-func CPUListToInvertedMask(cpulist string) (hexMask string) {
-	reservedCpus, _ := cpusListToArray(cpulist)
-
+func CPUListToInvertedMask(cpulist string) (hexMask string, err error) {
+	reservedCpus, err := cpusListToArray(cpulist)
+	if err != nil {
+		return "", err
+	}
 	reservedCpusLookup := make(map[int]bool)
 	for _, cpu := range reservedCpus {
 		reservedCpusLookup[cpu] = true
@@ -90,5 +95,5 @@ func CPUListToInvertedMask(cpulist string) (hexMask string) {
 		x := new(big.Int).Lsh(big.NewInt(1), uint(cpu))
 		currMask.Or(currMask, x)
 	}
-	return fmt.Sprintf("%02x", currMask)
+	return fmt.Sprintf("%02x", currMask), nil
 }

--- a/pkg/controller/performanceprofile/components/utils.go
+++ b/pkg/controller/performanceprofile/components/utils.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+const maxSystemCpus = 254
+
 // GetComponentName returns the component name for the specific performance profile
 func GetComponentName(profileName string, prefix string) string {
 	return fmt.Sprintf("%s-%s", prefix, profileName)
@@ -81,7 +83,7 @@ func CPUListToInvertedMask(cpulist string) (hexMask string) {
 	}
 
 	currMask := big.NewInt(0)
-	for cpu := 0; cpu < 254; cpu++ {
+	for cpu := 0; cpu < maxSystemCpus; cpu++ {
 		if _, reserved := reservedCpusLookup[cpu]; reserved {
 			continue
 		}

--- a/pkg/controller/performanceprofile/components/utils.go
+++ b/pkg/controller/performanceprofile/components/utils.go
@@ -26,3 +26,16 @@ func SplitLabelKey(s string) (domain, role string, err error) {
 	}
 	return parts[0], parts[1], nil
 }
+
+// CPUListToHexMask converts a list of cpus into a cpu mask represented in hexdecimal
+func CPUListToHexMask(cpulist string) (hexMask string) {
+	return ""
+}
+
+// CPUListToInvertedMask converts a list of cpus into an inverted cpu mask represented in hexdecimal
+func CPUListToInvertedMask(cpulist string) (hexMask string) {
+	return ""
+}
+
+
+

--- a/pkg/controller/performanceprofile/components/utils.go
+++ b/pkg/controller/performanceprofile/components/utils.go
@@ -2,6 +2,8 @@ package components
 
 import (
 	"fmt"
+	"math/big"
+	"strconv"
 	"strings"
 )
 
@@ -27,15 +29,64 @@ func SplitLabelKey(s string) (domain, role string, err error) {
 	return parts[0], parts[1], nil
 }
 
+func cpusListToArray(cpusListStr string) ([]int, error) {
+	var cpusList []int
+	elements := strings.Split(cpusListStr, ",")
+	for _, item := range elements {
+		cpuRange := strings.Split(item, "-")
+		// provided a range: 1-3
+		if len(cpuRange) > 1 {
+			start, err := strconv.Atoi(cpuRange[0])
+			if err != nil {
+				return nil, err
+			}
+			end, err := strconv.Atoi(cpuRange[1])
+			if err != nil {
+				return nil, err
+			}
+			// Add cpus to the list. Assuming it's a valid range.
+			for cpuNum := start; cpuNum <= end; cpuNum++ {
+				cpusList = append(cpusList, cpuNum)
+			}
+		} else {
+			cpuNum, err := strconv.Atoi(cpuRange[0])
+			if err != nil {
+				return nil, err
+			}
+			cpusList = append(cpusList, cpuNum)
+		}
+	}
+
+	return cpusList, nil
+}
+
 // CPUListToHexMask converts a list of cpus into a cpu mask represented in hexdecimal
 func CPUListToHexMask(cpulist string) (hexMask string) {
-	return ""
+	reservedCpus, _ := cpusListToArray(cpulist)
+	currMask := big.NewInt(0)
+	for _, cpu := range reservedCpus {
+		x := new(big.Int).Lsh(big.NewInt(1), uint(cpu))
+		currMask.Or(currMask, x)
+	}
+	return fmt.Sprintf("%02x", currMask)
 }
 
 // CPUListToInvertedMask converts a list of cpus into an inverted cpu mask represented in hexdecimal
 func CPUListToInvertedMask(cpulist string) (hexMask string) {
-	return ""
+	reservedCpus, _ := cpusListToArray(cpulist)
+
+	reservedCpusLookup := make(map[int]bool)
+	for _, cpu := range reservedCpus {
+		reservedCpusLookup[cpu] = true
+	}
+
+	currMask := big.NewInt(0)
+	for cpu := 0; cpu < 254; cpu++ {
+		if _, reserved := reservedCpusLookup[cpu]; reserved {
+			continue
+		}
+		x := new(big.Int).Lsh(big.NewInt(1), uint(cpu))
+		currMask.Or(currMask, x)
+	}
+	return fmt.Sprintf("%02x", currMask)
 }
-
-
-

--- a/pkg/controller/performanceprofile/components/utils_suite_test.go
+++ b/pkg/controller/performanceprofile/components/utils_suite_test.go
@@ -1,0 +1,13 @@
+package components
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestComponetsUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Tuned Suite")
+}

--- a/pkg/controller/performanceprofile/components/utils_test.go
+++ b/pkg/controller/performanceprofile/components/utils_test.go
@@ -14,7 +14,7 @@ var cpuListToMask = []listToMask{
 	{"0", "01"}, {"2-3", "0c"}, {"3,4,53-55,61-63", "e0e0000000000018"},
 }
 var cpuListToInvertMask = []listToMask{
-	{"0", "3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"}, {"2-3", "3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3"}, {"3,4,53-55,61-63", "3fffffffffffffffffffffffffffffffffffffffffffffff1f1fffffffffffe7"},
+	{"0", "ffffffff,fffffffe"}, {"2-3", "ffffffff,fffffff3"}, {"3,4,53-55,61-63", "1f1fffff,ffffffe7"},
 }
 
 var _ = Describe("Components utils", func() {
@@ -28,7 +28,7 @@ var _ = Describe("Components utils", func() {
 		})
 		It("should generate a valid CPU inverted mask from CPU list ", func() {
 			for _, cpuEntry := range cpuListToInvertMask {
-				cpuMask, err := CPUListToInvertedMask(cpuEntry.cpuList)
+				cpuMask, err := CPUListTo32BitsMaskList(cpuEntry.cpuList)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(cpuMask).Should(Equal(cpuEntry.cpuMask))
 			}

--- a/pkg/controller/performanceprofile/components/utils_test.go
+++ b/pkg/controller/performanceprofile/components/utils_test.go
@@ -1,0 +1,37 @@
+package components
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type listToMask struct {
+	cpuList string
+	cpuMask string
+}
+
+var cpuListToMask = []listToMask{
+	{"0", "01"}, {"2-3", "0c"}, {"3,4,53-55,61-63", "e0e0000000000018"},
+}
+var cpuListToInvertMask = []listToMask{
+	{"0", "3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"}, {"2-3", "3ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3"}, {"3,4,53-55,61-63", "3fffffffffffffffffffffffffffffffffffffffffffffff1f1fffffffffffe7"},
+}
+
+var _ = Describe("Components utils", func() {
+	Context("Convert CPU list to CPU mask", func() {
+		It("should generate a valid CPU mask from CPU list ", func() {
+			for _, cpuEntry := range cpuListToMask {
+				cpuMask, err := CPUListToHexMask(cpuEntry.cpuList)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cpuMask).Should(Equal(cpuEntry.cpuMask))
+			}
+		})
+		It("should generate a valid CPU inverted mask from CPU list ", func() {
+			for _, cpuEntry := range cpuListToInvertMask {
+				cpuMask, err := CPUListToInvertedMask(cpuEntry.cpuList)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cpuMask).Should(Equal(cpuEntry.cpuMask))
+			}
+		})
+	})
+})


### PR DESCRIPTION
Pre boot tuning was changed to operate as following:
- Compute non_isolated_cpus_mask and its invert in the operator code
- Set kernel argument for tuned.non_isolcpus=<non isolated cpus mask> to set `/sys/devices/virtual/workqueue/cpumask` using RHCOS hooks in early boot stage
- openshift-node-real-time-kernel will set cpumask for `/sys/bus/workqueue/devices/writeback/cpumask`. (Tuned)
- Add to ignition file a custom CPUAffinity file : `/etc/systemd/system.conf.d/setAffinity.conf`
- Set systemd with the custom file:
  `rpm-ostree initramfs --enable --arg=-I --arg="/etc/systemd/system.conf /etc/systemd/system.conf.d/setAffinity.conf"`
- Set irqbalance in the script (no need to set it in initramfs)

**Additional Info**
The operator takes the NON_ISOLATED_CPUS (=reserved cpus) parameter and creates from that:
- CPUAffinity (encapsulated in the setAffinity.conf file passed to early tuning script
- NON_ISOLATED_CPU_MASK_INVERT environment variable for the pre-boot script to consume (for irqbalance setting)
- Calculates NotIsolatedCpumask passed to tuned (openshift-node-real-time-kernel profile)
 
