### PR TITLE
csv: add more metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,15 @@ dist:
 	mkdir -p build/_output/bin
 	env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go build -i -ldflags="-s -w" -mod=vendor -o build/_output/bin/performance-addon-operators ./cmd/manager
 
+dist-csv-generator:
+	@if [ ! -x build/_output/bin/csv-generator ]; then\
+		echo "Building csv-generator tool";\
+		mkdir -p build/_output/bin;\
+		env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go build -i -ldflags="-s -w" -mod=vendor -o build/_output/bin/csv-generator ./tools/csv-generator;\
+	else \
+		echo "Using pre-built csv-generator tool";\
+	fi
+
 build-containers: registry-container operator-container
 
 operator-container: build
@@ -79,14 +88,14 @@ operator-sdk:
 		echo "Using operator-sdk cached at $(OPERATOR_SDK)";\
 	fi
 
-generate-csv: operator-sdk
+generate-csv: operator-sdk dist-csv-generator
 	@if [ -z "$(REGISTRY_NAMESPACE)" ]; then\
 		echo "REGISTRY_NAMESPACE env-var must be set to your $(IMAGE_REGISTRY) namespace";\
 		exit 1;\
 	fi
 	OPERATOR_SDK=$(OPERATOR_SDK) FULL_OPERATOR_IMAGE=$(FULL_OPERATOR_IMAGE) hack/csv-generate.sh
 
-generate-latest-dev-csv: operator-sdk
+generate-latest-dev-csv: operator-sdk dist-csv-generator
 	@echo Generating developer csv
 	@echo
 	OPERATOR_SDK=$(OPERATOR_SDK) FULL_OPERATOR_IMAGE="REPLACE_IMAGE" CSV_VERSION=$(OPERATOR_DEV_CSV) hack/csv-generate.sh

--- a/hack/csv-generate.sh
+++ b/hack/csv-generate.sh
@@ -18,8 +18,6 @@ if [ -n "$ANNOTATIONS_FILE" ]; then
 	EXTRA_ANNOTATIONS="-inject-annotations-from=$ANNOTATIONS_FILE"
 fi
 
-(cd tools/csv-generator/ && go build)
-
 clean_tmp_csv() {
 	rm -rf $TMP_CSV_DIR
 }
@@ -36,7 +34,7 @@ $OPERATOR_SDK olm-catalog gen-csv --operator-name="performance-addon-operator" -
 $OPERATOR_SDK generate crds
 
 # using the generated CSV, create the real CSV by injecting all the right data into it
-tools/csv-generator/csv-generator \
+build/_output/bin/csv-generator \
 	--csv-version "${CSV_VERSION}" \
 	--operator-csv-template-file "${TMP_CSV_FILE}" \
 	--operator-image "${FULL_OPERATOR_IMAGE}" \

--- a/hack/csv-generate.sh
+++ b/hack/csv-generate.sh
@@ -8,6 +8,11 @@ TMP_CSV_DIR="deploy/olm-catalog/performance-addon-operator/$TMP_CSV_VERSION"
 TMP_CSV_FILE="$TMP_CSV_DIR/performance-addon-operator.v${TMP_CSV_VERSION}.clusterserviceversion.yaml"
 FINAL_CSV_DIR="deploy/olm-catalog/performance-addon-operator/$CSV_VERSION"
 EXTRA_ANNOTATIONS=""
+MAINTAINERS=""
+
+if [ -n "$MAINTAINERS_FILE" ]; then
+	MAINTAINERS="-maintainers-from=$MAINTAINERS_FILE"
+fi
 
 if [ -n "$ANNOTATIONS_FILE" ]; then
 	EXTRA_ANNOTATIONS="-inject-annotations-from=$ANNOTATIONS_FILE"
@@ -38,6 +43,7 @@ tools/csv-generator/csv-generator \
 	--olm-bundle-directory "$FINAL_CSV_DIR" \
 	--replaces-csv-version "$REPLACES_CSV_VERSION" \
 	--skip-range "$CSV_SKIP_RANGE" \
+	"${MAINTAINERS}" \
 	"${EXTRA_ANNOTATIONS}"
 
 cp deploy/crds/*_crd.yaml $FINAL_CSV_DIR/

--- a/tools/csv-generator/csv-generator.go
+++ b/tools/csv-generator/csv-generator.go
@@ -195,6 +195,7 @@ func generateUnifiedCSV(extraAnnotations map[string]string) {
 	}
 	operatorCSV.Spec.InstallStrategy.StrategySpecRaw = updatedStrat
 
+	operatorCSV.Annotations["containerImage"] = *operatorImage
 	for key, value := range extraAnnotations {
 		operatorCSV.Annotations[key] = value
 	}

--- a/tools/csv-generator/csv-generator.go
+++ b/tools/csv-generator/csv-generator.go
@@ -54,6 +54,7 @@ var (
 	outputDir = flag.String("olm-bundle-directory", "", "The directory to output the unified CSV and CRDs to")
 
 	annotationsFile = flag.String("inject-annotations-from", "", "inject metadata annotations from given file")
+	maintainersFile = flag.String("maintainers-from", "", "add maintainers list from given file")
 
 	semverVersion *semver.Version
 )
@@ -167,7 +168,7 @@ func marshallObject(obj interface{}, writer io.Writer) error {
 	return nil
 }
 
-func generateUnifiedCSV(extraAnnotations map[string]string) {
+func generateUnifiedCSV(extraAnnotations, maintainers map[string]string) {
 
 	operatorCSV := unmarshalCSV(*operatorCSVTemplate)
 
@@ -240,6 +241,15 @@ Performance Addon Operator provides the ability to enable advanced node performa
 
 	operatorCSV.Spec.DisplayName = "Performance Addon Operator"
 
+	if maintainers != nil {
+		for name, email := range maintainers {
+			operatorCSV.Spec.Maintainers = append(operatorCSV.Spec.Maintainers, csvv1.Maintainer{
+				Name:  name,
+				Email: email,
+			})
+		}
+	}
+
 	// Set Annotations
 	if *skipRange != "" {
 		operatorCSV.Annotations["olm.skipRange"] = *skipRange
@@ -255,6 +265,19 @@ Performance Addon Operator provides the ability to enable advanced node performa
 	}
 
 	fmt.Printf("CSV written to %s\n", outputFilename)
+}
+
+func readKeyValueMapFromFileOrPanic(filename string) map[string]string {
+	kvMap := make(map[string]string)
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		panic(err)
+	}
+	err = json.Unmarshal(data, &kvMap)
+	if err != nil {
+		panic(err)
+	}
+	return kvMap
 }
 
 func main() {
@@ -279,14 +302,12 @@ func main() {
 
 	extraAnnotations := make(map[string]string)
 	if *annotationsFile != "" {
-		data, err := ioutil.ReadFile(*annotationsFile)
-		if err != nil {
-			panic(err)
-		}
-		err = json.Unmarshal(data, &extraAnnotations)
-		if err != nil {
-			panic(err)
-		}
+		extraAnnotations = readKeyValueMapFromFileOrPanic(*annotationsFile)
+	}
+
+	maintainers := make(map[string]string)
+	if *maintainersFile != "" {
+		maintainers = readKeyValueMapFromFileOrPanic(*maintainersFile)
 	}
 
 	// start with a fresh output directory if it already exists
@@ -295,5 +316,5 @@ func main() {
 	// create output directory
 	os.MkdirAll(*outputDir, os.FileMode(0775))
 
-	generateUnifiedCSV(extraAnnotations)
+	generateUnifiedCSV(extraAnnotations, maintainers)
 }


### PR DESCRIPTION
Add metadata to make the CSV look a bit nicer in the operatorHUB ui.

Signed-off-by: Francesco Romani <fromani@redhat.com>