### PR TITLE
Remove nonIsolated from test config

### DIFF
--- a/cluster-setup/ci-cluster/performance/performance_profile.patch.yaml
+++ b/cluster-setup/ci-cluster/performance/performance_profile.patch.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   cpu:
     isolated: "1-3"
-    nonIsolated: "0"
     reserved: "0"
   hugepages:
     pages:


### PR DESCRIPTION
The nonIsolated option no longer exists and shouldn't be referenced in the deployment config