### PR TITLE
[release-4.4] Use correct operator tag in upstream registry image

### DIFF
--- a/openshift-ci/Dockerfile.registry.upstream.dev
+++ b/openshift-ci/Dockerfile.registry.upstream.dev
@@ -3,7 +3,7 @@ FROM quay.io/openshift/origin-operator-registry:latest
 COPY deploy/olm-catalog /registry/performance-addon-operator-catalog
 
 # replaces performance-addon-operator image with the one built by openshift ci
-RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|quay.io/openshift-kni/performance-addon-operator:latest|g" {} \; || :
+RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|quay.io/openshift-kni/performance-addon-operator:v4.4|g" {} \; || :
 
 # Initialize the database
 RUN initializer --manifests /registry/performance-addon-operator-catalog --output bundles.db


### PR DESCRIPTION
No way to detect branch when building the image, so we need to hardcode the tag for now