### PR TITLE
Fix events permissions

### DIFF
--- a/deploy/olm-catalog/performance-addon-operator/0.0.1/performance-addon-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/0.0.1/performance-addon-operator.v0.0.1.clusterserviceversion.yaml
@@ -35,6 +35,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
+    containerImage: REPLACE_IMAGE
   name: performance-addon-operator.v0.0.1
   namespace: placeholder
 spec:
@@ -54,6 +55,12 @@ spec:
     spec:
       clusterPermissions:
       - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - '*'
         - apiGroups:
           - performance.openshift.io
           resources:
@@ -124,7 +131,6 @@ spec:
           - services
           - services/finalizers
           - configmaps
-          - events
           verbs:
           - '*'
         - apiGroups:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -5,6 +5,12 @@ metadata:
   name: performance-operator
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - '*'
+- apiGroups:
   - performance.openshift.io
   resources:
   - performanceprofiles
@@ -46,7 +52,6 @@ rules:
   - services
   - services/finalizers
   - configmaps
-  - events
   verbs:
   - '*'
 - apiGroups:


### PR DESCRIPTION
Performance profile is cluster scope resource, so events creation should be done on the cluster level.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>