### PR TITLE
Reboot from rpm-ostree injection in pre-boot

### DIFF
--- a/build/assets/scripts/pre-boot-tuning.sh
+++ b/build/assets/scripts/pre-boot-tuning.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 SYSTEM_CONFIG_FILE="/etc/systemd/system.conf"
 SYSTEM_CONFIG_CUSTOM_FILE="/etc/systemd/system.conf.d/setAffinity.conf"
 
-if [ -f /etc/sysconfig/irqbalance ] && [ -f ${SYSTEM_CONFIG_CUSTOM_FILE} ] && egrep -wq "^IRQBALANCE_BANNED_CPUS=${RESERVED_CPU_MASK_INVERT}" /etc/sysconfig/irqbalance; then
+if [ -f /etc/sysconfig/irqbalance ] && [ -f ${SYSTEM_CONFIG_CUSTOM_FILE} ] && rpm-ostree status -b | grep -q -e '-I /etc/systemd/system.conf /etc/systemd/system.conf.d/setAffinity.conf' && egrep -wq "^IRQBALANCE_BANNED_CPUS=${RESERVED_CPU_MASK_INVERT}" /etc/sysconfig/irqbalance; then
     echo "Pre boot tuning configuration already applied"
     echo "Setting kernel rcuo* threads to the housekeeping cpus"
     pgrep rcuo* | while read line; do taskset -pc ${RESERVED_CPUS} $line || true; done
@@ -20,6 +20,11 @@ else
     else
         echo "IRQBALANCE_BANNED_CPUS=${RESERVED_CPU_MASK_INVERT}" >>/etc/sysconfig/irqbalance
     fi
+
+    if [[ ! -f /var/restarts ]]; then
+        echo 0 > /var/restarts
+    fi
+    echo "$(expr $(cat /var/restarts) + 1)" > /var/restarts
 
     rpm-ostree initramfs -r --enable --arg=-I --arg="${SYSTEM_CONFIG_FILE} ${SYSTEM_CONFIG_CUSTOM_FILE}" 
 fi

--- a/build/assets/scripts/pre-boot-tuning.sh
+++ b/build/assets/scripts/pre-boot-tuning.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 SYSTEM_CONFIG_FILE="/etc/systemd/system.conf"
 SYSTEM_CONFIG_CUSTOM_FILE="/etc/systemd/system.conf.d/setAffinity.conf"
 
-if [ -f /etc/sysconfig/irqbalance ] && [ -f ${SYSTEM_CONFIG_CUSTOM_FILE} ] && rpm-ostree status -b | grep -q -e '-I /etc/systemd/system.conf /etc/systemd/system.conf.d/setAffinity.conf' && egrep -wq "^IRQBALANCE_BANNED_CPUS=${RESERVED_CPU_MASK_INVERT}" /etc/sysconfig/irqbalance; then
+if [ -f /etc/sysconfig/irqbalance ] && [ -f ${SYSTEM_CONFIG_CUSTOM_FILE} ] && rpm-ostree status -b | grep -q -e "-I ${SYSTEM_CONFIG_FILE} ${SYSTEM_CONFIG_CUSTOM_FILE}" && egrep -wq "^IRQBALANCE_BANNED_CPUS=${RESERVED_CPU_MASK_INVERT}" /etc/sysconfig/irqbalance; then
     echo "Pre boot tuning configuration already applied"
     echo "Setting kernel rcuo* threads to the housekeeping cpus"
     pgrep rcuo* | while read line; do taskset -pc ${RESERVED_CPUS} $line || true; done
@@ -20,11 +20,6 @@ else
     else
         echo "IRQBALANCE_BANNED_CPUS=${RESERVED_CPU_MASK_INVERT}" >>/etc/sysconfig/irqbalance
     fi
-
-    if [[ ! -f /var/restarts ]]; then
-        echo 0 > /var/restarts
-    fi
-    echo "$(expr $(cat /var/restarts) + 1)" > /var/restarts
 
     rpm-ostree initramfs -r --enable --arg=-I --arg="${SYSTEM_CONFIG_FILE} ${SYSTEM_CONFIG_CUSTOM_FILE}" 
 fi

--- a/build/assets/scripts/pre-boot-tuning.sh
+++ b/build/assets/scripts/pre-boot-tuning.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 SYSTEM_CONFIG_FILE="/etc/systemd/system.conf"
 SYSTEM_CONFIG_CUSTOM_FILE="/etc/systemd/system.conf.d/setAffinity.conf"
 
-if [ -f /etc/sysconfig/irqbalance ] && [ -f ${SYSTEM_CONFIG_CUSTOM_FILE} ] && grep -ls "IRQBALANCE_BANNED_CPUS=${RESERVED_CPU_MASK_INVERT}" /etc/sysconfig/irqbalance; then
+if [ -f /etc/sysconfig/irqbalance ] && [ -f ${SYSTEM_CONFIG_CUSTOM_FILE} ] && egrep -wq "^IRQBALANCE_BANNED_CPUS=${RESERVED_CPU_MASK_INVERT}" /etc/sysconfig/irqbalance; then
     echo "Pre boot tuning configuration already applied"
     echo "Setting kernel rcuo* threads to the housekeeping cpus"
     pgrep rcuo* | while read line; do taskset -pc ${RESERVED_CPUS} $line || true; done
@@ -21,7 +21,5 @@ else
         echo "IRQBALANCE_BANNED_CPUS=${RESERVED_CPU_MASK_INVERT}" >>/etc/sysconfig/irqbalance
     fi
 
-    rpm-ostree initramfs --enable --arg=-I --arg="${SYSTEM_CONFIG_FILE} ${SYSTEM_CONFIG_CUSTOM_FILE}" 
-
-    touch /var/reboot
+    rpm-ostree initramfs -r --enable --arg=-I --arg="${SYSTEM_CONFIG_FILE} ${SYSTEM_CONFIG_CUSTOM_FILE}" 
 fi

--- a/build/assets/scripts/reboot.sh
+++ b/build/assets/scripts/reboot.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-if [[ -f /var/reboot ]]; then 
-    rm -f /var/reboot
-    echo "File /var/reboot exists, initiate reboot"
-    systemctl reboot
-fi

--- a/functests/performance/performance.go
+++ b/functests/performance/performance.go
@@ -85,6 +85,15 @@ var _ = Describe("performance", func() {
 		It(perfRtKernelPrebootTuningScript+" should exist on the nodes", func() {
 			checkFileExistence(workerRTNodes, perfRtKernelPrebootTuningScript)
 		})
+
+		It("Should inject systemd configuration files into initramfs", func() {
+			for _, node := range workerRTNodes {
+				ostreeStatus, err := nodes.ExecCommandOnMachineConfigDaemon(testclient.Client, &node, []string{"rpm-ostree", "status", "-b"})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ostreeStatus).To(ContainSubstring("-I /etc/systemd/system.conf /etc/systemd/system.conf.d/setAffinity.conf"))
+			}
+		})
+
 	})
 
 	Context("FeatureGate - FeatureSet configuration", func() {

--- a/functests/performance/performance.go
+++ b/functests/performance/performance.go
@@ -97,7 +97,8 @@ var _ = Describe("performance", func() {
 						[]string{"lsinitrd", strings.TrimSpace(imagePath)})
 					Expect(err).ToNot(HaveOccurred())
 					initrdString := string(initrd)
-					if strings.Contains(initrdString, "'/etc/systemd/system.conf /etc/systemd/system.conf.d/setAffinity.conf'") {
+					if (strings.Count(initrdString, "etc/systemd/system.conf") == 1) &&
+						(strings.Count(initrdString, "etc/systemd/system.conf.d/setAffinity.conf") == 1) {
 						found = true
 						break
 					}

--- a/functests/performance/performance.go
+++ b/functests/performance/performance.go
@@ -97,8 +97,7 @@ var _ = Describe("performance", func() {
 						[]string{"lsinitrd", strings.TrimSpace(imagePath)})
 					Expect(err).ToNot(HaveOccurred())
 					initrdString := string(initrd)
-					if (strings.Count(initrdString, "etc/systemd/system.conf") == 1) &&
-						(strings.Count(initrdString, "etc/systemd/system.conf.d/setAffinity.conf") == 1) {
+					if strings.Contains(initrdString, "'/etc/systemd/system.conf /etc/systemd/system.conf.d/setAffinity.conf'") {
 						found = true
 						break
 					}

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
@@ -19,8 +19,9 @@ const expectedSystemdUnits = `
       - contents: |
           [Unit]
           Description=Preboot tuning patch
+          Wants=network-online.target
+          After=network-online.target
           Before=kubelet.service
-          Before=reboot.service
 
           [Service]
           Environment=RESERVED_CPUS=0-3
@@ -33,22 +34,6 @@ const expectedSystemdUnits = `
           WantedBy=multi-user.target
         enabled: true
         name: pre-boot-tuning.service
-      - contents: |
-          [Unit]
-          Description=Reboot initiated by pre-boot-tuning
-          Wants=network-online.target
-          After=network-online.target
-          Before=kubelet.service
-
-          [Service]
-          Type=oneshot
-          RemainAfterExit=true
-          ExecStart=/usr/local/bin/reboot.sh
-
-          [Install]
-          WantedBy=multi-user.target
-        enabled: true
-        name: reboot.service
 `
 
 const hugepagesAllocationService = `


### PR DESCRIPTION
**What is the problem**
There are inconsistent results of rpm-ostree status after pre-boot service have run initramfs injection: `rpm-ostree initramfs --enable --arg=-I --arg="/etc/systemd/system.conf /etc/systemd/system.conf.d/setAffinity.conf" `
The expectation is that the deployment will contain these files:
`Initramfs: -I /etc/systemd/system.conf /etc/systemd/system.conf.d/setAffinity.conf `  (can be viewed by running `rpm-ostree status -b` after a successful deployment)
Its seems that the reason for that might be connected to out-of-sync issues or race conditions.

**What was fixed**
- Pre boot script was changed to initiate a reboot directly from rpm-ostree (using -r flag) to try and be in sync.
- Reboot service was removed since it is not needed anymore (reboot is done in pre-boot script as mentioned above)
- CI test added for checking rpm-ostree status after deployment
