### PR TITLE
Pin registry image to version 4.5

### DIFF
--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-operator-registry:latest
+FROM quay.io/openshift/origin-operator-registry:4.5
 
 ARG OPENSHIFT_BUILD_NAMESPACE
 

--- a/openshift-ci/Dockerfile.registry.intermediate
+++ b/openshift-ci/Dockerfile.registry.intermediate
@@ -1,1 +1,1 @@
-FROM quay.io/openshift/origin-operator-registry:latest
+FROM quay.io/openshift/origin-operator-registry:4.5

--- a/openshift-ci/Dockerfile.registry.upstream.dev
+++ b/openshift-ci/Dockerfile.registry.upstream.dev
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-operator-registry:latest
+FROM quay.io/openshift/origin-operator-registry:4.5
 
 COPY deploy/olm-catalog /registry/performance-addon-operator-catalog
 


### PR DESCRIPTION
`master` branch is for OCP version 4.5, so let's use the correct registry base image.