### PR TITLE
Updated CI image registry URL

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -5,9 +5,10 @@ set -e
 # expect oc to be in PATH by default
 OC_TOOL="${OC_TOOL:-oc}"
 
-# Override the image name when this is invoked from openshift ci
-if [ -n "${OPENSHIFT_BUILD_NAMESPACE}" ]; then
-  FULL_REGISTRY_IMAGE="registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:performance-addon-operator-registry"
+# Override the image name in the CSV when this is invoked from openshift ci
+# See https://github.com/openshift/ci-tools/blob/master/TEMPLATES.md#image_format
+if [ -n "${IMAGE_FORMAT}" ]; then
+  FULL_REGISTRY_IMAGE=${IMAGE_FORMAT/'${component}'/performance-addon-operator-registry}
 fi
 
 echo "Deploying using image $FULL_REGISTRY_IMAGE."

--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -1,11 +1,14 @@
 FROM quay.io/openshift/origin-operator-registry:latest
 
 ARG OPENSHIFT_BUILD_NAMESPACE
+ARG IMAGE_FORMAT
+
+RUN env
 
 COPY deploy/olm-catalog /registry/performance-addon-operator-catalog
 
 # replaces performance-addon-operator image with the one built by openshift ci
-RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:performance-addon-operator|g" {} \; || :
+RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com/${OPENSHIFT_BUILD_NAMESPACE}/stable:performance-addon-operator|g" {} \; || :
 
 # Initialize the database
 RUN initializer --manifests /registry/performance-addon-operator-catalog --output bundles.db


### PR DESCRIPTION
WIP

Checking if we have the IMAGE_FORMAT env var available in the image build step now.
Otherwise maybe just updated hardcoded URL.
Or get rid of registry image like in #87 