### PR TITLE
Add additional kerenel arguments option in CRD

### DIFF
--- a/cluster-setup/ci-cluster/performance/performance_profile.patch.yaml
+++ b/cluster-setup/ci-cluster/performance/performance_profile.patch.yaml
@@ -3,6 +3,13 @@ kind: PerformanceProfile
 metadata:
   name: ci
 spec:
+  additionalKernelArgs:
+  - "nmi_watchdog=0"
+  - "audit=0"
+  - "mce=off"
+  - "processor.max_cstate=1"
+  - "idle=poll"
+  - "intel_idle.max_cstate=0"    
   cpu:
     isolated: "1-3"
     reserved: "0"

--- a/deploy/crds/performance.openshift.io_performanceprofiles_crd.yaml
+++ b/deploy/crds/performance.openshift.io_performanceprofiles_crd.yaml
@@ -31,6 +31,11 @@ spec:
         spec:
           description: PerformanceProfileSpec defines the desired state of PerformanceProfile.
           properties:
+            additionalKernelArgs:
+              description: Addional kernel arguments.
+              items:
+                type: string
+              type: array
             cpu:
               description: CPU defines set of CPU related parameters.
               properties:

--- a/deploy/crds/performance.openshift.io_v1alpha1_performanceprofile_cr.yaml
+++ b/deploy/crds/performance.openshift.io_v1alpha1_performanceprofile_cr.yaml
@@ -4,12 +4,12 @@ metadata:
   name: example-performanceprofile
 spec:
   additionalKernelArgs:
-    - "nmi_watchdog=0"
-    - "audit=0"
-    - "mce=off"
-    - "processor.max_cstate=1"
-    - "idle=poll"
-    - "intel_idle.max_cstate=0"  
+  - "nmi_watchdog=0"
+  - "audit=0"
+  - "mce=off"
+  - "processor.max_cstate=1"
+  - "idle=poll"
+  - "intel_idle.max_cstate=0"  
   cpu:
     isolated: "2-3"
     reserved: "0-1"

--- a/deploy/crds/performance.openshift.io_v1alpha1_performanceprofile_cr.yaml
+++ b/deploy/crds/performance.openshift.io_v1alpha1_performanceprofile_cr.yaml
@@ -3,6 +3,13 @@ kind: PerformanceProfile
 metadata:
   name: example-performanceprofile
 spec:
+  additionalKernelArgs:
+    - "nmi_watchdog=0"
+    - "audit=0"
+    - "mce=off"
+    - "processor.max_cstate=1"
+    - "idle=poll"
+    - "intel_idle.max_cstate=0"  
   cpu:
     isolated: "2-3"
     reserved: "0-1"

--- a/deploy/olm-catalog/performance-addon-operator/0.0.1/performance-addon-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/0.0.1/performance-addon-operator.v0.0.1.clusterserviceversion.yaml
@@ -12,6 +12,14 @@ metadata:
             "name": "example-performanceprofile"
           },
           "spec": {
+            "additionalKernelArgs": [
+              "nmi_watchdog=0",
+              "audit=0",
+              "mce=off",
+              "processor.max_cstate=1",
+              "idle=poll",
+              "intel_idle.max_cstate=0"
+            ],
             "cpu": {
               "isolated": "2-3",
               "reserved": "0-1"

--- a/deploy/olm-catalog/performance-addon-operator/0.0.1/performance.openshift.io_performanceprofiles_crd.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/0.0.1/performance.openshift.io_performanceprofiles_crd.yaml
@@ -31,6 +31,11 @@ spec:
         spec:
           description: PerformanceProfileSpec defines the desired state of PerformanceProfile.
           properties:
+            additionalKernelArgs:
+              description: Addional kernel arguments.
+              items:
+                type: string
+              type: array
             cpu:
               description: CPU defines set of CPU related parameters.
               properties:

--- a/functests/performance/performance.go
+++ b/functests/performance/performance.go
@@ -116,12 +116,11 @@ var _ = Describe("performance", func() {
 	Context("Additional kernel arguments added from perfomance profile", func() {
 		It("Should set additional kernel arguments on the machine", func() {
 			if profile.Spec.AdditionalKernelArgs != nil {
+				additionalArgs := strings.Join(profile.Spec.AdditionalKernelArgs, " ")
 				for _, node := range workerRTNodes {
 					cmdline, err := nodes.ExecCommandOnMachineConfigDaemon(testclient.Client, &node, []string{"cat", "/proc/cmdline"})
 					Expect(err).ToNot(HaveOccurred())
-					for _, arg := range profile.Spec.AdditionalKernelArgs {
-						Expect(cmdline).To(ContainSubstring(arg))
-					}
+					Expect(cmdline).To(ContainSubstring(additionalArgs))
 				}
 			}
 		})

--- a/pkg/apis/performance/v1alpha1/performanceprofile_types.go
+++ b/pkg/apis/performance/v1alpha1/performanceprofile_types.go
@@ -33,6 +33,9 @@ type PerformanceProfileSpec struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 	// RealTimeKernel defines set of real time kernel related parameters.
 	RealTimeKernel *RealTimeKernel `json:"realTimeKernel,omitempty"`
+	// Addional kernel arguments.
+	// +optional
+	AdditionalKernelArgs []string `json:"additionalKernelArgs,omitempty"`
 	// NUMA defines options related to topology aware affinities
 	// +optional
 	NUMA *NUMA `json:"numa,omitempty"`

--- a/pkg/apis/performance/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/performance/v1alpha1/zz_generated.deepcopy.go
@@ -210,6 +210,11 @@ func (in *PerformanceProfileSpec) DeepCopyInto(out *PerformanceProfileSpec) {
 		*out = new(RealTimeKernel)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.AdditionalKernelArgs != nil {
+		in, out := &in.AdditionalKernelArgs, &out.AdditionalKernelArgs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.NUMA != nil {
 		in, out := &in.NUMA, &out.NUMA
 		*out = new(NUMA)

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
@@ -108,7 +108,7 @@ const expectedBootArgumentsWithoutIso = `
   - hugepages=1024
 `
 
-const expectedBootArgumentsWithoutAdditionalKerenlArgs = `
+const expectedBootArgumentsWithAdditionalKerenlArgs = `
   kernelArguments:
   - nohz=on
   - nosoftlockup
@@ -196,7 +196,7 @@ var _ = Describe("Machine Config", func() {
 		labelKey, labelValue := components.GetFirstKeyAndValue(profile.Spec.MachineConfigLabel)
 		Expect(manifest).To(ContainSubstring(fmt.Sprintf("%s: %s", labelKey, labelValue)))
 		Expect(manifest).To(ContainSubstring(expectedSystemdUnits))
-		Expect(manifest).To(ContainSubstring(expectedBootArgumentsWithoutAdditionalKerenlArgs))
+		Expect(manifest).To(ContainSubstring(expectedBootArgumentsWithAdditionalKerenlArgs))
 	})
 
 	Context("with hugepages with specified NUMA node", func() {


### PR DESCRIPTION
- Added an additional field to the performance profile CRD: `additionalKernelArgs` which is optional and can contain a string list of additional kernel argument that are not included as base arguments.
This gives the field engineer the capability to add more kargs (idle=poll and etc) via the performance_profile.yaml when they deem it necessary.

- Set the following kargs as base 
`intel_iommu=on iommu=pt default_hugepagesz=1GB hugepagesz=1G hugepages=32 intel_pstate=disable skew_tick=1 nohz=on nohz_full=<isolated list> rcu_nocbs=<isolated list> tuned.non_isolcpus=<reserved mask> nosoftlockup`

