### PR TITLE
Revert "Temporarily disable RT kernel"

### DIFF
--- a/cluster-setup/ci-cluster/performance/performance_profile.patch.yaml
+++ b/cluster-setup/ci-cluster/performance/performance_profile.patch.yaml
@@ -18,7 +18,5 @@ spec:
     - size: "1G"
       count: 1
       node: 0
-  realTimeKernel:
-    enabled: false
   nodeSelector:
     node-role.kubernetes.io/worker-rt: ""


### PR DESCRIPTION
Reverts openshift-kni/performance-addon-operators#134

The 4.5 rehearsal on https://github.com/openshift/release/pull/7154 installed the RT kernel...