### PR TITLE
Be less verbose, decrease wait times

### DIFF
--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -25,18 +25,31 @@ do
 
   echo "[INFO] Deploying performance operator and profile."
   set +e
-  if ! ${OC_TOOL} kustomize $feature_dir | envsubst | ${OC_TOOL} apply -f -
-  then
-    set -e
+
+  # be verbose on last iteration only
+  if [[ $iterations -eq $((max_iterations - 1)) ]] || [[ -n "${VERBOSE}" ]]; then
+    ${OC_TOOL} kustomize $feature_dir | envsubst | ${OC_TOOL} apply -f -
+  else
+    ${OC_TOOL} kustomize $feature_dir | envsubst | ${OC_TOOL} apply -f - &> /dev/null
+  fi
+
+  # shellcheck disable=SC2181
+  if [[ $? != 0 ]];then
+
     iterations=$((iterations + 1))
     iterations_left=$((max_iterations - iterations))
-    echo "[WARN] Deployment failed, retrying in $sleep_time sec, $iterations_left retries left."
-    sleep $sleep_time
-    continue
+    if [[ $iterations_left != 0  ]]; then
+      echo "[WARN] Deployment did not fully succeed yet, retrying in $sleep_time sec, $iterations_left retries left"
+      sleep $sleep_time
+    else
+      echo "[WARN] At least one deployment failed, giving up"
+    fi
+
+  else
+    # All features deployed successfully
+    success=1
   fi
   set -e
-
-  success=1
 
 done
 


### PR DESCRIPTION
- Suppress some output during deployment (except during last iteration) and waiting for MCP
- Give operator less time for doimg its work, 30s should be enough
- Revert MCP wait time to old value (there always was a real issue when we run into the timeout)