### PR TITLE
Disable CPUCFSQuota to improve containerized DPDK performance

### DIFF
--- a/pkg/controller/performanceprofile/components/kubeletconfig/kubeletconfig.go
+++ b/pkg/controller/performanceprofile/components/kubeletconfig/kubeletconfig.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 const (
@@ -41,6 +42,7 @@ func New(profile *performancev1alpha1.PerformanceProfile) (*machineconfigv1.Kube
 			"cpu":    defaultSystemReservedCPU,
 			"memory": defaultSystemReservedMemory,
 		},
+		CPUCFSQuota: utilpointer.BoolPtr(false),
 	}
 
 	if profile.Spec.CPU != nil && profile.Spec.CPU.Reserved != nil {


### PR DESCRIPTION
"nohz_full" has a negative impact on containerized DPDK performance. More details in:
https://bugzilla.redhat.com/show_bug.cgi?id=1760644

We have three options:
1) remove "nohz_full" from kargs. The performance team is still debating on the 'tickless' benefit, so the impact of this removal is unknown,
2) disable CPUCFSQuota. I did a quick test using testpmd and confirmed it does work around the aforementioned BZ.
3) change quota period to 1 second. I did a quick test using testpmd and it does not work well - traffic throughput still suffers.

There are a lot of upstream discussion about disabling CPUCFSQuota:
https://github.com/kubernetes/kubernetes/issues/51135

@derekwaynecarr what's the common view for option 2) outside redhat ?