### PR TITLE
Add Informational status reporting on Performance Profile CR against Machine config pools

### DIFF
--- a/pkg/controller/performanceprofile/performanceprofile_controller.go
+++ b/pkg/controller/performanceprofile/performanceprofile_controller.go
@@ -304,7 +304,6 @@ func (r *ReconcilePerformanceProfile) Reconcile(request reconcile.Request) (reco
 
 func (r *ReconcilePerformanceProfile) ppRequestsFromMCP(o handler.MapObject) []reconcile.Request {
 
-	klog.Infof("Getting performance profile requests from machine config pool %q", namespacedName(o.Meta).String())
 	mcp := &mcov1.MachineConfigPool{}
 
 	if err := r.client.Get(context.Background(),
@@ -328,8 +327,10 @@ func (r *ReconcilePerformanceProfile) ppRequestsFromMCP(o handler.MapObject) []r
 	for k := range ppList.Items {
 		if hasMatchingLabels(&ppList.Items[k], mcp) {
 			requests = append(requests, reconcile.Request{NamespacedName: namespacedName(&ppList.Items[k])})
+			klog.Infof("Adding performance profile %q request from machine config pool %q", ppList.Items[k].GetName(), namespacedName(o.Meta).String())
 		}
 	}
+
 	return requests
 }
 

--- a/pkg/controller/performanceprofile/performanceprofile_controller.go
+++ b/pkg/controller/performanceprofile/performanceprofile_controller.go
@@ -275,7 +275,10 @@ func (r *ReconcilePerformanceProfile) Reconcile(request reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	conditions := r.getAvailableConditions()
+	conditions := r.getConditionsByMCPStatus(instance)
+	if conditions == nil {
+		conditions = r.getAvailableConditions()
+	}
 	if err := r.updateStatus(instance, conditions); err != nil {
 		klog.Errorf("failed to update performance profile %q status: %v", instance.Name, err)
 		// we still want to requeue after some, also in case of error, to avoid chance of multiple reboots
@@ -288,15 +291,6 @@ func (r *ReconcilePerformanceProfile) Reconcile(request reconcile.Request) (reco
 
 	if result != nil {
 		return *result, nil
-	}
-
-	conditions = r.getConditionsByMCPStatus(instance)
-	if conditions != nil {
-		err := r.updateStatus(instance, conditions)
-		if err != nil {
-			klog.Errorf("failed to update performance profile %q status: %v", instance.Name, err)
-			return reconcile.Result{}, err
-		}
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/controller/performanceprofile/performanceprofile_controller.go
+++ b/pkg/controller/performanceprofile/performanceprofile_controller.go
@@ -275,7 +275,7 @@ func (r *ReconcilePerformanceProfile) Reconcile(request reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	conditions := r.getConditionsByMCPStatus(instance)
+	conditions := r.getMCPConditionsByProfile(instance)
 	if conditions == nil {
 		conditions = r.getAvailableConditions()
 	}
@@ -301,7 +301,7 @@ func (r *ReconcilePerformanceProfile) ppRequestsFromMCP(o handler.MapObject) []r
 	mcp := &mcov1.MachineConfigPool{}
 
 	if err := r.client.Get(context.Background(),
-		client.ObjectKey{
+		types.NamespacedName{
 			Namespace: o.Meta.GetNamespace(),
 			Name:      o.Meta.GetName(),
 		},

--- a/pkg/controller/performanceprofile/performanceprofile_controller.go
+++ b/pkg/controller/performanceprofile/performanceprofile_controller.go
@@ -289,7 +289,15 @@ func (r *ReconcilePerformanceProfile) Reconcile(request reconcile.Request) (reco
 	if result != nil {
 		return *result, nil
 	}
-	//UPDATE MACHINE CONFIG
+
+	conditions = r.getConditionsByMCPStatus(instance)
+	if conditions != nil {
+		err := r.updateStatus(instance, conditions)
+		if err != nil {
+			klog.Errorf("failed to update performance profile %q status: %v", instance.Name, err)
+			return reconcile.Result{}, err
+		}
+	}
 
 	return reconcile.Result{}, nil
 }

--- a/pkg/controller/performanceprofile/performanceprofile_controller.go
+++ b/pkg/controller/performanceprofile/performanceprofile_controller.go
@@ -513,7 +513,7 @@ func hasMatchingLabels(performanceprofile *performancev1alpha1.PerformanceProfil
 		return false
 	}
 
-	if !selector.Matches(labels.Set(performanceprofile.Spec.MachineConfigPoolSelector)) {
+	if !selector.Matches(labels.Set(profileutil.GetMachineConfigPoolSelector(performanceprofile))) {
 		return false
 	}
 	return true

--- a/pkg/controller/performanceprofile/performanceprofile_controller.go
+++ b/pkg/controller/performanceprofile/performanceprofile_controller.go
@@ -15,11 +15,13 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
-
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
 
@@ -44,11 +46,12 @@ const finalizer = "foreground-deletion"
 // Add creates a new PerformanceProfile Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
+	r := newReconciler(mgr)
+	return add(mgr, r, r.ppRequestsFromMCP)
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager) *ReconcilePerformanceProfile {
 	return &ReconcilePerformanceProfile{
 		client:    mgr.GetClient(),
 		scheme:    mgr.GetScheme(),
@@ -58,7 +61,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(mgr manager.Manager, r reconcile.Reconciler, mapMCPToPC handler.ToRequestsFunc) error {
 	// Create a new controller
 	c, err := controller.New("performanceprofile-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
@@ -165,11 +168,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		},
 	}
 
-	// Watch for changes to machine config pools owned by our controller
-	err = c.Watch(&source.Kind{Type: &mcov1.MachineConfigPool{}}, &handler.EnqueueRequestForOwner{
-		IsController: true,
-		OwnerType:    &performancev1alpha1.PerformanceProfile{},
-	}, mcpPredicates)
+	err = c.Watch(&source.Kind{Type: &mcov1.MachineConfigPool{}}, &handler.EnqueueRequestsFromMapFunc{ToRequests: mapMCPToPC}, mcpPredicates)
 	if err != nil {
 		return err
 	}
@@ -290,8 +289,40 @@ func (r *ReconcilePerformanceProfile) Reconcile(request reconcile.Request) (reco
 	if result != nil {
 		return *result, nil
 	}
+	//UPDATE MACHINE CONFIG
 
 	return reconcile.Result{}, nil
+}
+
+func (r *ReconcilePerformanceProfile) ppRequestsFromMCP(o handler.MapObject) []reconcile.Request {
+
+	klog.Infof("Getting performance profile requests from machine config pool %q", namespacedName(o.Meta).String())
+	mcp := &mcov1.MachineConfigPool{}
+
+	if err := r.client.Get(context.Background(),
+		client.ObjectKey{
+			Namespace: o.Meta.GetNamespace(),
+			Name:      o.Meta.GetName(),
+		},
+		mcp,
+	); err != nil {
+		klog.Errorf("No-op: Unable to retrieve mcp %q from store: %v", namespacedName(o.Meta).String(), err)
+		return nil
+	}
+
+	ppList := &performancev1alpha1.PerformanceProfileList{}
+	if err := r.client.List(context.Background(), ppList); err != nil {
+		klog.Errorf("No-op: Unable to list performance profiles: %v", err)
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for k := range ppList.Items {
+		if hasMatchingLabels(&ppList.Items[k], mcp) {
+			requests = append(requests, reconcile.Request{NamespacedName: namespacedName(&ppList.Items[k])})
+		}
+	}
+	return requests
 }
 
 func (r *ReconcilePerformanceProfile) applyComponents(profile *performancev1alpha1.PerformanceProfile) (*reconcile.Result, error) {
@@ -459,4 +490,28 @@ func removeFinalizer(profile *performancev1alpha1.PerformanceProfile, finalizer 
 		finalizers = append(finalizers, f)
 	}
 	profile.Finalizers = finalizers
+}
+
+func namespacedName(obj metav1.Object) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+}
+
+func hasMatchingLabels(performanceprofile *performancev1alpha1.PerformanceProfile, mcp *mcov1.MachineConfigPool) bool {
+
+	selector, err := metav1.LabelSelectorAsSelector(mcp.Spec.MachineConfigSelector)
+	if err != nil {
+		return false
+	}
+	// If a deployment with a nil or empty selector creeps in, it should match nothing, not everything.
+	if selector.Empty() {
+		return false
+	}
+
+	if !selector.Matches(labels.Set(performanceprofile.Spec.MachineConfigPoolSelector)) {
+		return false
+	}
+	return true
 }

--- a/pkg/controller/performanceprofile/status.go
+++ b/pkg/controller/performanceprofile/status.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	conditionReasonValidationFailed         = "validation failed"
-	conditionReasonComponentsCreationFailed = "failed to create components"
-	conditionReasonMCPDegraded              = "MCP degraded"
-	conditionFailedGettingMCPStatus         = "failed getting MCP status"
+	conditionReasonValidationFailed         = "ValidationFailed"
+	conditionReasonComponentsCreationFailed = "ComponentCreationFailed"
+	conditionReasonMCPDegraded              = "MCPDegraded"
+	conditionFailedGettingMCPStatus         = "GettingMCPStatusFailed"
 )
 
 func (r *ReconcilePerformanceProfile) updateStatus(profile *performancev1alpha1.PerformanceProfile, conditions []conditionsv1.Condition) error {

--- a/pkg/controller/performanceprofile/status.go
+++ b/pkg/controller/performanceprofile/status.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	performancev1alpha1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1alpha1"
+	profileutil "github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/profile"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -163,7 +164,7 @@ func (r *ReconcilePerformanceProfile) getMCPConditionsByProfile(profile *perform
 	message := bytes.Buffer{}
 
 	for _, mcp := range mcpList.Items {
-		if reflect.DeepEqual(profile.Spec.MachineConfigPoolSelector, mcp.Spec.MachineConfigSelector.MatchLabels) {
+		if reflect.DeepEqual(profileutil.GetMachineConfigPoolSelector(profile), mcp.Spec.MachineConfigSelector.MatchLabels) {
 			for _, condition := range mcp.Status.Conditions {
 				if condition.Type == mcov1.MachineConfigPoolDegraded && condition.Status == corev1.ConditionTrue {
 					reason.WriteString(mcp.GetName() + " ")

--- a/pkg/controller/performanceprofile/status.go
+++ b/pkg/controller/performanceprofile/status.go
@@ -148,11 +148,12 @@ func (r *ReconcilePerformanceProfile) getProgressingConditions(reason string, me
 	}
 }
 
-func (r *ReconcilePerformanceProfile) getConditionsByMCPStatus(profile *performancev1alpha1.PerformanceProfile) []conditionsv1.Condition {
+func (r *ReconcilePerformanceProfile) getMCPConditionsByProfile(profile *performancev1alpha1.PerformanceProfile) []conditionsv1.Condition {
 
 	mcpList := &mcov1.MachineConfigPoolList{}
-	err := r.client.List(context.TODO(), mcpList)
-	if err != nil {
+
+	if err := r.client.List(context.TODO(), mcpList); err != nil {
+		klog.Warningf("Cannot list Machine config pools to match with profile %q : %v", profile.Name, err)
 		return nil
 	}
 

--- a/pkg/controller/performanceprofile/status.go
+++ b/pkg/controller/performanceprofile/status.go
@@ -18,6 +18,8 @@ import (
 const (
 	conditionReasonValidationFailed         = "validation failed"
 	conditionReasonComponentsCreationFailed = "failed to create components"
+	conditionReasonMCPDegraded              = "MCP degraded"
+	conditionFailedGettingMCPStatus         = "failed getting MCP status"
 )
 
 func (r *ReconcilePerformanceProfile) updateStatus(profile *performancev1alpha1.PerformanceProfile, conditions []conditionsv1.Condition) error {
@@ -159,11 +161,7 @@ func (r *ReconcilePerformanceProfile) getMCPConditionsByProfile(profile *perform
 	}
 
 	mcpItems := removeMCPDuplicateEntries(mcpList.Items)
-
 	performanceProfileLabels := labels.Set(profileutil.GetMachineConfigPoolSelector(profile))
-
-	reason := bytes.Buffer{}
-	reason.WriteString("Matching Machine Config Pools are in a degraded state")
 	message := bytes.Buffer{}
 
 	for _, mcp := range mcpItems {
@@ -191,8 +189,7 @@ func (r *ReconcilePerformanceProfile) getMCPConditionsByProfile(profile *perform
 		return nil, nil
 	}
 
-	reasonString := reason.String()
-	return r.getDegradedConditions(reasonString, messageString), nil
+	return r.getDegradedConditions(conditionReasonMCPDegraded, messageString), nil
 }
 
 func removeMCPDuplicateEntries(mcps []mcov1.MachineConfigPool) []mcov1.MachineConfigPool {


### PR DESCRIPTION
Add additional status fields to the Performance Profile CR that would provide additional information that would be useful for an admin to debug in case of issue:
When status of machine config pools that are attached to the performance profile are in a degraded state the performance profile status will be degraded and will contain the machine config pool failure message.
