### PR TITLE
Divide updating profile tests for better interraction with polarion

### DIFF
--- a/functests/utils/utils.go
+++ b/functests/utils/utils.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+func BeforeAll(fn func()) {
+	first := true
+	BeforeEach(func() {
+		if first {
+			fn()
+			first = false
+		}
+	})
+}


### PR DESCRIPTION
 For better interaction with Polarion it would be good to divide one big test on small parts