### PR TITLE
Ensure non-RT Kernel installed when realTimeKernel is false

### DIFF
--- a/functests/utils/profiles/profiles.go
+++ b/functests/utils/profiles/profiles.go
@@ -28,7 +28,7 @@ func GetByNodeLabels(c client.Client, nodeLabels map[string]string) (*performanc
 	}
 
 	if result == nil {
-		return nil, fmt.Errorf("failed to found performance profile with specified node selector %v", nodeLabels)
+		return nil, fmt.Errorf("failed to find performance profile with specified node selector %v", nodeLabels)
 	}
 
 	return result, nil


### PR DESCRIPTION
The additional check in this PR ensures that non-RT kernel is
installed when realTimeKernel is set to false