### PR TITLE
Fix CI registry URL

### DIFF
--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -5,7 +5,7 @@ ARG OPENSHIFT_BUILD_NAMESPACE
 COPY deploy/olm-catalog /registry/performance-addon-operator-catalog
 
 # replaces performance-addon-operator image with the one built by openshift ci
-RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:performance-addon-operator|g" {} \; || :
+RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com/$OPENSHIFT_BUILD_NAMESPACE/stable:performance-addon-operator|g" {} \; || :
 # Initialize the database
 RUN initializer --manifests /registry/performance-addon-operator-catalog --output bundles.db
 


### PR DESCRIPTION
CI moved to a new cluster, and there still is no env var availabel during the image build step. So just hardcode the new URL and hope it won't change too often...
