### PR TITLE
Fix CI (several issues)

### DIFF
--- a/functests/performance/performance.go
+++ b/functests/performance/performance.go
@@ -214,8 +214,8 @@ func validatTunedActiveProfile(nodes []corev1.Node) {
 		tunedName := tuned.ObjectMeta.Name
 		By(fmt.Sprintf("executing the command cat /etc/tuned/active_profile inside the pod %s", tunedName))
 		Eventually(func() string {
-			out, err = exec.Command("oc", "rsh", "-n", tuned.ObjectMeta.Namespace,
-				tunedName, "cat", "/etc/tuned/active_profile").CombinedOutput()
+			out, err = exec.Command("oc", "exec", "-i", "-n", tuned.ObjectMeta.Namespace,
+				tunedName, "--", "cat", "/etc/tuned/active_profile").CombinedOutput()
 			return strings.TrimSpace(string(out))
 		}, testTimeout*time.Second, testPollInterval*time.Second).Should(Equal(activeProfileName),
 			fmt.Sprintf("active_profile is not set to %s. %v", activeProfileName, err))

--- a/functests/performance/topology_manager.go
+++ b/functests/performance/topology_manager.go
@@ -140,7 +140,7 @@ var _ = Describe("[rfe_id:27350][performance]Topology Manager", func() {
 
 func getSriovPciDeviceFromPod(pod *corev1.Pod) (string, error) {
 	envBytes, err := exec.Command(
-		"oc", "rsh", "-n", pod.Namespace, pod.Name, "env",
+		"oc", "exec", "-i", "-n", pod.Namespace, pod.Name, "--", "env",
 	).CombinedOutput()
 	if err != nil {
 		return "", err

--- a/functests/utils/nodes/nodes.go
+++ b/functests/utils/nodes/nodes.go
@@ -87,11 +87,13 @@ func ExecCommandOnMachineConfigDaemon(c client.Client, node *corev1.Node, comman
 	}
 
 	initialArgs := []string{
-		"rsh",
+		"exec",
+		"-i",
 		"-n", testutils.NamespaceMachineConfigOperator,
 		"-c", testutils.ContainerMachineConfigDaemon,
 		"--request-timeout", "30",
 		mcd.Name,
+		"--",
 	}
 	initialArgs = append(initialArgs, command...)
 	return exec.Command("oc", initialArgs...).CombinedOutput()

--- a/functests/utils/pods/pods.go
+++ b/functests/utils/pods/pods.go
@@ -113,9 +113,11 @@ func GetLogs(c *kubernetes.Clientset, pod *corev1.Pod) (string, error) {
 // ExecCommandOnPod returns the output of the command execution on the pod
 func ExecCommandOnPod(c client.Client, pod *corev1.Pod, command []string) ([]byte, error) {
 	initialArgs := []string{
-		"rsh",
+		"exec",
+		"-i",
 		"-n", pod.Namespace,
 		pod.Name,
+		"--",
 	}
 	initialArgs = append(initialArgs, command...)
 	return exec.Command("oc", initialArgs...).CombinedOutput()

--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -4,8 +4,12 @@ ARG OPENSHIFT_BUILD_NAMESPACE
 
 COPY deploy/olm-catalog /registry/performance-addon-operator-catalog
 
+# easier switching between CI clusters...
+#ENV REG_URL=default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com
+ENV REG_URL=registry.svc.ci.openshift.org
+
 # replaces performance-addon-operator image with the one built by openshift ci
-RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com/$OPENSHIFT_BUILD_NAMESPACE/stable:performance-addon-operator|g" {} \; || :
+RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|${REG_URL}/${OPENSHIFT_BUILD_NAMESPACE}/stable:performance-addon-operator|g" {} \; || :
 # Initialize the database
 RUN initializer --manifests /registry/performance-addon-operator-catalog --output bundles.db
 


### PR DESCRIPTION
1. CI cluster was reverted to old one, so change registry URL image... again
2. OCP was rebased on k8s 1.18, which resulted in the following issues:
a) `ocp apply -f` fails to deploy ANY resource if ONE of them has an unknown kind. So apply all one by one, else our loop-until-succeed deployment doesn't work (profile can't be deployed because CRD doesn't exist in 1st iteration(s)
b) functests: `oc rsh` aka `kubectl exec` fails with `kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl kubectl exec [POD] -- [COMMAND] instead.`. So let's add some "--". Update: `oc rsh` still does not work, but `oc exec -i` does, so using that on everywhere.