### PR TITLE
tests: better logs

### DIFF
--- a/functests/performance/performance.go
+++ b/functests/performance/performance.go
@@ -52,8 +52,8 @@ var _ = Describe("[rfe_id:27368]performance", func() {
 	BeforeEach(func() {
 		var err error
 		workerRTNodes, err = nodes.GetByRole(testclient.Client, testutils.RoleWorkerRT)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(workerRTNodes).ToNot(BeEmpty())
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for node with role %q: %v", testutils.RoleWorkerRT, err))
+		Expect(workerRTNodes).ToNot(BeEmpty(), fmt.Sprintf("no nodes with role %q found", testutils.RoleWorkerRT))
 		profile, err = profiles.GetByNodeLabels(
 			testclient.Client,
 			map[string]string{

--- a/functests/utils/nodes/nodes.go
+++ b/functests/utils/nodes/nodes.go
@@ -96,7 +96,9 @@ func ExecCommandOnMachineConfigDaemon(c client.Client, node *corev1.Node, comman
 		"--",
 	}
 	initialArgs = append(initialArgs, command...)
-	return exec.Command("oc", initialArgs...).CombinedOutput()
+	res, err := exec.Command("oc", initialArgs...).CombinedOutput()
+	klog.Infof("run on node %q command 'oc %v': err=%v", node.Name, initialArgs, err)
+	return res, err
 }
 
 // GetKubeletConfig returns KubeletConfiguration loaded from the node /etc/kubernetes/kubelet.conf


### PR DESCRIPTION
borrow/import a tiny part of the k8s e2e test framework
to log messages in our tests, and use it.

We want to test failures to be as easy as possible to troubleshoot,
and for this purpose we add logging to the most critical and common
operations (more to be added in future patches)

The logs will be visible only when/if the test fail.

Signed-off-by: Francesco Romani <fromani@redhat.com>