### PR TITLE
Add missing performance tags.

### DIFF
--- a/functests/performance/performance.go
+++ b/functests/performance/performance.go
@@ -44,7 +44,7 @@ const (
 	testPollInterval = 2
 )
 
-var _ = Describe("[rfe_id:27368]performance", func() {
+var _ = Describe("[rfe_id:27368][performance]", func() {
 
 	var workerRTNodes []corev1.Node
 	var profile *performancev1alpha1.PerformanceProfile

--- a/functests/performance/updating_profile.go
+++ b/functests/performance/updating_profile.go
@@ -25,7 +25,7 @@ const (
 	mcpUpdateTimeout = 20
 )
 
-var _ = Describe("[rfe_id:28761] Updating parameters in performance profile", func() {
+var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance profile", func() {
 	var workerRTNodes []corev1.Node
 	var profile *performancev1alpha1.PerformanceProfile
 	var err error


### PR DESCRIPTION
This will make it possible to filter tests when consuming as vendored dependencies.