### PR TITLE
Add support for running tests in a disconnected environment.

### DIFF
--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -17,14 +17,11 @@ import (
 	. "github.com/onsi/gomega"
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/images"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/pods"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
 	performancev1alpha1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1alpha1"
-)
-
-const (
-	stressPod = "vish/stress"
 )
 
 var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
@@ -170,7 +167,7 @@ func getStressPod(nodeName string) *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:  "stress-test",
-					Image: stressPod,
+					Image: images.For(images.Stresser),
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("1"),

--- a/functests/1_performance/hugepages.go
+++ b/functests/1_performance/hugepages.go
@@ -16,6 +16,7 @@ import (
 
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/images"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/pods"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
@@ -25,7 +26,6 @@ import (
 
 const (
 	pathHugepages2048kB = "/sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages"
-	centosImage         = "centos:latest"
 )
 
 var _ = Describe("[performance]Hugepages", func() {
@@ -115,10 +115,6 @@ var _ = Describe("[performance]Hugepages", func() {
 			err = pods.WaitForCondition(testclient.Client, testpod, corev1.PodReady, corev1.ConditionTrue, 180*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 
-			cmd1 := []string{"yum", "install", "-y", "libhugetlbfs-utils", "libhugetlbfs", "tmux"}
-			_, err = pods.ExecCommandOnPod(testpod, cmd1)
-			Expect(err).ToNot(HaveOccurred())
-
 			cmd2 := []string{"/bin/bash", "-c", "tmux new -d 'LD_PRELOAD=libhugetlbfs.so HUGETLB_MORECORE=yes top -b > /dev/null'"}
 			_, err = pods.ExecCommandOnPod(testpod, cmd2)
 			Expect(err).ToNot(HaveOccurred())
@@ -168,7 +164,7 @@ func getCentosPod(nodeName string) *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:    "test",
-					Image:   centosImage,
+					Image:   images.For(images.TestUtils),
 					Command: []string{"sleep", "10h"},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/functests/1_performance/rt-kernel.go
+++ b/functests/1_performance/rt-kernel.go
@@ -33,7 +33,7 @@ var _ = Describe("[performance]RT Kernel", func() {
 		Eventually(func() string {
 
 			// run uname -a in a busybox pod and get logs
-			testpod = pods.GetBusybox()
+			testpod = pods.GetTestPod()
 			testpod.Namespace = testutils.NamespaceTesting
 			testpod.Spec.Containers[0].Command = []string{"uname", "-a"}
 			testpod.Spec.RestartPolicy = corev1.RestartPolicyNever

--- a/functests/1_performance/topology_manager.go
+++ b/functests/1_performance/topology_manager.go
@@ -87,7 +87,7 @@ var _ = Describe("[rfe_id:27350][performance]Topology Manager", func() {
 				err = pods.WaitForDeletion(testclient.Client, testpod, 60*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 			}
-			testpod = pods.GetBusybox()
+			testpod = pods.GetTestPod()
 			testpod.Namespace = testutils.NamespaceTesting
 			testpod.Spec.Containers[0].Resources.Requests = map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceCPU:      resource.MustParse("1"),

--- a/functests/utils/images/images.go
+++ b/functests/utils/images/images.go
@@ -1,0 +1,52 @@
+package images
+
+import (
+	"fmt"
+	"os"
+
+	. "github.com/onsi/gomega"
+)
+
+var registry string
+var images map[string]imageLocation
+
+const (
+	// TestUtils is the image name to be used to retrieve the test utils image
+	TestUtils = "testutils"
+	// Stresser is the image name to be used to retrieve the stresser image
+	Stresser = "stresser"
+)
+
+func init() {
+	registry = os.Getenv("IMAGE_REGISTRY")
+
+	images = map[string]imageLocation{
+		TestUtils: {
+			name:    "cnftest-utils",
+			registy: "quay.io/fpaoline/",
+			version: "v1.0",
+		},
+		Stresser: {
+			name:    "stresser",
+			registy: "quay.io/fpaoline/",
+			version: "v1.0",
+		},
+	}
+}
+
+type imageLocation struct {
+	name    string
+	registy string
+	version string
+}
+
+// For returns the image to be used for the given key
+func For(name string) string {
+	img, ok := images[name]
+	Expect(ok).To(BeTrue(), "Image not found")
+
+	if registry != "" {
+		return fmt.Sprintf("%s%s:%s", registry, img.name, img.version)
+	}
+	return fmt.Sprintf("%s%s:%s", img.registy, img.name, img.version)
+}

--- a/functests/utils/pods/pods.go
+++ b/functests/utils/pods/pods.go
@@ -16,10 +16,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/images"
 )
 
-// GetBusybox returns pod with the busybox image
-func GetBusybox() *corev1.Pod {
+// GetTestPod returns pod with the busybox image
+func GetTestPod() *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "test-",
@@ -31,7 +32,7 @@ func GetBusybox() *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:    "test",
-					Image:   "busybox",
+					Image:   images.For(images.TestUtils),
 					Command: []string{"sleep", "10h"},
 				},
 			},


### PR DESCRIPTION
Refactoring the images we use for tests, and provide a way to override the registry
they are fetched from.

The images are built from the dockerfiles being added in https://github.com/openshift-kni/cnf-features-deploy/pull/151 
They are currently being pushed to quay.io/fpaoline , a followup will mirror them on quay.io/openshift-kni