### PR TITLE
Don't exit if the client configuration is not valid.

### DIFF
--- a/functests/0_config/test_suite_performance_config_test.go
+++ b/functests/0_config/test_suite_performance_config_test.go
@@ -3,10 +3,12 @@
 package __performance_config_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"testing"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/junit"
@@ -22,3 +24,8 @@ func TestPerformanceConfig(t *testing.T) {
 	rr = append(rr, junit.NewJUnitReporter("performance_config"))
 	RunSpecsWithDefaultAndCustomReporters(t, "Performance Addon Operator configuration", rr)
 }
+
+var _ = BeforeSuite(func() {
+	Expect(testclient.ClientsEnabled).To(BeTrue())
+
+})

--- a/functests/1_performance/test_suite_performance_test.go
+++ b/functests/1_performance/test_suite_performance_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 var _ = BeforeSuite(func() {
+	Expect(testclient.ClientsEnabled).To(BeTrue())
 	// create test namespace
 	err := testclient.Client.Create(context.TODO(), namespaces.TestingNamespace)
 	if errors.IsAlreadyExists(err) {

--- a/functests/2_performance_update/test_suite_performance_update_test.go
+++ b/functests/2_performance_update/test_suite_performance_update_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 var _ = BeforeSuite(func() {
+	Expect(testclient.ClientsEnabled).To(BeTrue())
 	// create test namespace
 	err := testclient.Client.Create(context.TODO(), namespaces.TestingNamespace)
 	if errors.IsAlreadyExists(err) {


### PR DESCRIPTION
Exiting in init() do not allow the tests to run in dryRun mode because the tests exit before constructing the gingko tree and calling it.

Here we publish the information in a variable and check it before running the suite.
