### PR TITLE
Unit test code coverage

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -60,9 +60,9 @@ steps:
   - name: validate-operator-imgage
     image: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator:${DRONE_TAG}
     commands:
-      - ls /usr/local/bin/ | grep performance-operator
-      # FIXME as soon as we report the correct version here
-      - "/usr/local/bin/performance-operator 2>&1 | grep 'Operator Version: 0.0.1'"
+      - ls /usr/local/bin/performance-operator
+      - "/usr/local/bin/performance-operator 2>&1 | grep \"Operator Version: ${DRONE_TAG}\""
+      - "/usr/local/bin/performance-operator 2>&1 | grep \"Git Commit: ${DRONE_COMMIT}\""
 
   - name: build-registry-image
     image: plugins/docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -106,3 +106,68 @@ steps:
         exclude:
           # do not create github releases when the tag contains the word "test"
           - refs/tags/*test*
+
+---
+
+# This pipeline builds the build tool image for each branch, so it does not need to be build for every PR update
+# Builds based on changed files are supported by drone.io extensions only, which can't be installed on cloud.drone.io
+# See https://github.com/drone/drone/issues/1021#issuecomment-596127812
+
+kind: pipeline
+type: docker
+name: build-tools
+
+trigger:
+  event:
+    include:
+      - push
+  branch:
+    include:
+      - master
+      - release-*
+
+steps:
+  - name: build-tools-image
+    image: plugins/docker
+    settings:
+      dockerfile: openshift-ci/Dockerfile.tools
+      username:
+        from_secret: QUAY_USER
+      password:
+        from_secret: QUAY_PASSWORD
+      registry: quay.io
+      # This only works if github user == quay user!
+      repo: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-build-tools
+      tags:
+        - ${DRONE_BRANCH}
+
+---
+
+# This pipeline runs unit tests and creates coverage reports for coveralls.io
+kind: pipeline
+type: docker
+name: coverage
+
+workspace:
+  # This should align with WORKDIR of openshift-ci/Dockerfile.tools
+  path: /go/src/github.com/openshift-kni/performance-addon-operators
+
+trigger:
+  event:
+    include:
+      - push
+      - pull_request
+  branch:
+    include:
+      - master
+      - release-*
+
+steps:
+  - name: coverage
+    image: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-build-tools:${DRONE_BRANCH}
+    environment:
+      COVERALLS_TOKEN:
+        from_secret: COVERALLS_REPO_TOKEN
+    commands:
+      - make unittests
+

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,10 +30,10 @@ steps:
       # This only works if github user == quay user!
       repo: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-build-tools
       tags:
-      - ${DRONE_TAG}
+      - ${DRONE_TAG:-notset}
 
   - name: build
-    image: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-build-tools:${DRONE_TAG}
+    image: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-build-tools:${DRONE_TAG:-notset}
     environment:
       CSV_VERSION: ${DRONE_SEMVER_SHORT}
       REGISTRY_NAMESPACE: ${DRONE_REPO_NAMESPACE}
@@ -58,7 +58,7 @@ steps:
       repo: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator
 
   - name: validate-operator-imgage
-    image: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator:${DRONE_TAG}
+    image: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator:${DRONE_TAG:-notset}
     commands:
       - ls /usr/local/bin/performance-operator
       - "/usr/local/bin/performance-operator 2>&1 | grep \"Operator Version: ${DRONE_TAG}\""
@@ -74,14 +74,14 @@ steps:
         from_secret: QUAY_PASSWORD
       build_args:
         # This only works if github user == quay user!
-        - FULL_OPERATOR_IMAGE=quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator:${DRONE_TAG}
+        - FULL_OPERATOR_IMAGE=quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator:${DRONE_TAG:-notset}
         - OLM_SOURCE=build/_output/olm-catalog
       registry: quay.io
       # This only works if github user == quay user!
       repo: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-registry
 
   - name: validate-registry-image
-    image: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-registry:${DRONE_TAG}
+    image: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-registry:${DRONE_TAG:-notset}
     commands:
       - sqlite3 /registry/bundles.db "select * from package" | grep "performance-addon-operator|${DRONE_SEMVER_SHORT}"
       - sqlite3 /registry/bundles.db "select * from channel" | grep "${DRONE_SEMVER_SHORT}|performance-addon-operator|performance-addon-operator.v${DRONE_SEMVER_SHORT}"
@@ -139,7 +139,7 @@ steps:
       # This only works if github user == quay user!
       repo: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-build-tools
       tags:
-        - ${DRONE_BRANCH}
+        - ${DRONE_BRANCH:-notset}
 
 ---
 
@@ -164,7 +164,7 @@ trigger:
 
 steps:
   - name: coverage
-    image: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-build-tools:${DRONE_BRANCH}
+    image: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-build-tools:${DRONE_BRANCH:-notset}
     environment:
       COVERALLS_TOKEN:
         from_secret: COVERALLS_REPO_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ functests-only:
 
 .PHONY: unittests
 unittests:
-	GOFLAGS=-mod=vendor go test -v ./pkg/...
+	hack/unittests.sh
 
 .PHONY: gofmt
 gofmt:

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -45,6 +45,8 @@ var (
 
 func printVersion() {
 	klog.Infof("Operator Version: %s", version.Version)
+	klog.Infof("Git Commit: %s", version.GitCommit)
+	klog.Infof("Build Date: %s", version.BuildDate)
 	klog.Infof("Go Version: %s", runtime.Version())
 	klog.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
 	klog.Infof("Version of operator-sdk: %v", sdkVersion.Version)

--- a/hack/unittests.sh
+++ b/hack/unittests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+OUTDIR="build/_output/coverage"
+mkdir -p "$OUTDIR"
+
+COVER_FILE="${OUTDIR}/cover.out"
+FUNC_FILE="${OUTDIR}/coverage.txt"
+HTML_FILE="${OUTDIR}/coverage.html"
+
+echo "running unittests with coverage"
+GOFLAGS=-mod=vendor go test -race -covermode=atomic -coverprofile="${COVER_FILE}" -v ./pkg/...
+
+if [[ -n "${DRONE}" ]]; then
+
+  # Uploading coverage report to coveralls.io
+  go get github.com/mattn/goveralls
+  $(go env GOPATH)/bin/goveralls -coverprofile="$COVER_FILE" -service=drone.io
+
+else
+
+  echo "creating coverage reports"
+  go tool cover -func="${COVER_FILE}" > "${FUNC_FILE}"
+  go tool cover -html="${COVER_FILE}" -o "${HTML_FILE}"
+  echo "find coverage reports at ${OUTDIR}"
+
+fi

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,10 @@
 package version
 
 var (
-	// Version api version
+	// Version is the operator version
 	Version = "0.0.1"
+	// GitCommit is the current git commit hash
+	GitCommit = "n/a"
+	// BuildDate is the build date
+	BuildDate = "n/a"
 )


### PR DESCRIPTION
Added unit test code coverage using drone.io and coveralls.io

In order to prevent that the build tool image needs to be built for every PR change, it is built on merges only.

Closes #18 

/hold
Let's see if it works...