### PR TITLE
Fix CI by using shorter names...

### DIFF
--- a/cluster-setup/base/performance/operator_catalogsource.yaml
+++ b/cluster-setup/base/performance/operator_catalogsource.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: performance-addon-operator-catalogsource
+  name: performance-addon-operator
   namespace: openshift-marketplace
 spec:
   displayName: Openshift Performance Addon Operator

--- a/cluster-setup/base/performance/operator_operatorgroup.yaml
+++ b/cluster-setup/base/performance/operator_operatorgroup.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: openshift-performance-addon-operatorgroup
+  name: performance-addon-operator
   namespace: openshift-performance-addon
 spec:
   targetNamespaces:

--- a/cluster-setup/base/performance/operator_subscription.yaml
+++ b/cluster-setup/base/performance/operator_subscription.yaml
@@ -1,10 +1,10 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: performance-addon-operator-subscription
+  name: performance-addon-operator
   namespace: openshift-performance-addon
 spec:
   channel: 0.0.1
   name: performance-addon-operator
-  source: performance-addon-operator-catalogsource
+  source: performance-addon-operator
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Hopefully fixes

`E0430 16:32:55.542653       1 queueinformer_operator.go:290] sync {"update" "openshift-performance-addon"} failed: Namespace "openshift-performance-addon" is invalid: metadata.labels: Invalid value: "olm.operatorgroup/openshift-performance-addon.openshift-performance-addon-operatorgroup": name part must be no more than 63 characters`