### PR TITLE
cleanup: streamline and use csv-generator options

### DIFF
--- a/hack/csv-generate.sh
+++ b/hack/csv-generate.sh
@@ -20,12 +20,14 @@ OUT_CSV_FILE="${OUT_CSV_DIR}/${PACKAGE_NAME}.v${CSV_VERSION}.clusterserviceversi
 EXTRA_ANNOTATIONS=""
 MAINTAINERS=""
 
+if [ -n "$DESCRIPTION_FILE" ]; then
+	DESCRIPTION="-description-from=$DESCRIPTION_FILE"
+fi
 if [ -n "$MAINTAINERS_FILE" ]; then
 	MAINTAINERS="-maintainers-from=$MAINTAINERS_FILE"
 fi
-
 if [ -n "$ANNOTATIONS_FILE" ]; then
-	EXTRA_ANNOTATIONS="-inject-annotations-from=$ANNOTATIONS_FILE"
+	EXTRA_ANNOTATIONS="-annotations-from=$ANNOTATIONS_FILE"
 fi
 
 clean_package() {
@@ -60,6 +62,7 @@ build/_output/bin/csv-generator \
 	--olm-bundle-directory "$OUT_CSV_DIR" \
 	--replaces-csv-version "$REPLACES_CSV_VERSION" \
 	--skip-range "$CSV_SKIP_RANGE" \
+	"${DESCRIPTION}" \
 	"${MAINTAINERS}" \
 	"${EXTRA_ANNOTATIONS}"
 

--- a/tools/csv-generator/csv-generator.go
+++ b/tools/csv-generator/csv-generator.go
@@ -31,7 +31,7 @@ var (
 
 	outputDir = flag.String("olm-bundle-directory", "", "The directory to output the unified CSV and CRDs to")
 
-	annotationsFile = flag.String("inject-annotations-from", "", "inject metadata annotations from given file")
+	annotationsFile = flag.String("annotations-from", "", "add metadata annotations from given file")
 	maintainersFile = flag.String("maintainers-from", "", "add maintainers list from given file")
 	descriptionFile = flag.String("description-from", "", "replace the description with the content of the given file")
 

--- a/tools/csv-generator/csv-generator.go
+++ b/tools/csv-generator/csv-generator.go
@@ -137,6 +137,9 @@ func generateUnifiedCSV(userData csvUserData) {
 	// Set Description
 	operatorCSV.Spec.Description = `
 Performance Addon Operator provides the ability to enable advanced node performance tunings on a set of nodes.`
+	if userData.Description != "" {
+		operatorCSV.Spec.Description = userData.Description
+	}
 
 	operatorCSV.Spec.DisplayName = "Performance Addon Operator"
 


### PR DESCRIPTION
This patch renames for consistency the `-inject-annotations-from`
option to `-annotations-from` - so all the options now look like
`-*-from`. We fix all the usages in the source tree.

Additionally, let's also use in the generator script the option
to replace the CSV description. This is opt-in as the rest of the
replacement options.

Signed-off-by: Francesco Romani <fromani@redhat.com>