### PR TITLE
[release-4.4] align the csv processing tools with the improvements in the 4.5 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/_output
 build/_test
 _cache
 tools/csv-generator/csv-generator
+tools/csv-replace-imageref/csv-replace-imageref
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,11 @@ dist:
 	mkdir -p build/_output/bin
 	env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go build -i -ldflags="-s -w" -mod=vendor -o build/_output/bin/performance-addon-operators ./cmd/manager
 
+dist-tools: dist-csv-generator dist-csv-replace-imageref
+
+dist-clean:
+	rm -rf build/_output/bin
+
 dist-csv-generator:
 	@if [ ! -x build/_output/bin/csv-generator ]; then\
 		echo "Building csv-generator tool";\
@@ -58,6 +63,15 @@ dist-csv-generator:
 		env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go build -i -ldflags="-s -w" -mod=vendor -o build/_output/bin/csv-generator ./tools/csv-generator;\
 	else \
 		echo "Using pre-built csv-generator tool";\
+	fi
+
+dist-csv-replace-imageref:
+	@if [ ! -x build/_output/bin/csv-replace-imageref ]; then\
+		echo "Building csv-replace-imageref tool";\
+		mkdir -p build/_output/bin;\
+		env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go build -i -ldflags="-s -w" -mod=vendor -o build/_output/bin/csv-replace-imageref ./tools/csv-replace-imageref;\
+	else \
+		echo "Using pre-built csv-replace-imageref tool";\
 	fi
 
 build-containers: registry-container operator-container

--- a/hack/csv-generate.sh
+++ b/hack/csv-generate.sh
@@ -10,12 +10,14 @@ FINAL_CSV_DIR="deploy/olm-catalog/performance-addon-operator/$CSV_VERSION"
 EXTRA_ANNOTATIONS=""
 MAINTAINERS=""
 
+if [ -n "$DESCRIPTION_FILE" ]; then
+	DESCRIPTION="-description-from=$DESCRIPTION_FILE"
+fi
 if [ -n "$MAINTAINERS_FILE" ]; then
 	MAINTAINERS="-maintainers-from=$MAINTAINERS_FILE"
 fi
-
 if [ -n "$ANNOTATIONS_FILE" ]; then
-	EXTRA_ANNOTATIONS="-inject-annotations-from=$ANNOTATIONS_FILE"
+	EXTRA_ANNOTATIONS="-annotations-from=$ANNOTATIONS_FILE"
 fi
 
 clean_tmp_csv() {
@@ -41,6 +43,7 @@ build/_output/bin/csv-generator \
 	--olm-bundle-directory "$FINAL_CSV_DIR" \
 	--replaces-csv-version "$REPLACES_CSV_VERSION" \
 	--skip-range "$CSV_SKIP_RANGE" \
+	"${DESCRIPTION}" \
 	"${MAINTAINERS}" \
 	"${EXTRA_ANNOTATIONS}"
 

--- a/pkg/utils/csvtools/csvtools.go
+++ b/pkg/utils/csvtools/csvtools.go
@@ -13,27 +13,32 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// CSVClusterPermissions is the cluster permissions part of a CSV
 type CSVClusterPermissions struct {
 	ServiceAccountName string              `json:"serviceAccountName"`
 	Rules              []rbacv1.PolicyRule `json:"rules"`
 }
 
+// CSVPermissions is the permissions part of a CSV
 type CSVPermissions struct {
 	ServiceAccountName string              `json:"serviceAccountName"`
 	Rules              []rbacv1.PolicyRule `json:"rules"`
 }
 
+// CSVDeployments describes the deployments for a CSV
 type CSVDeployments struct {
 	Name string                `json:"name"`
 	Spec appsv1.DeploymentSpec `json:"spec,omitempty"`
 }
 
+// CSVStrategySpec describes the installation strategy of a CSV
 type CSVStrategySpec struct {
 	ClusterPermissions []CSVClusterPermissions `json:"clusterPermissions"`
 	Permissions        []CSVPermissions        `json:"permissions"`
 	Deployments        []CSVDeployments        `json:"deployments"`
 }
 
+// UnmarshalCSV decodes a YAML file, by path, and returns a CSV
 func UnmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
 	bytes, err := ioutil.ReadFile(filePath)
 	if err != nil {
@@ -49,6 +54,7 @@ func UnmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
 	return csvStruct
 }
 
+// UnmarshalStrategySpec decodes the StrategySpec object inside a CSV and returns it
 func UnmarshalStrategySpec(csv *csvv1.ClusterServiceVersion) *CSVStrategySpec {
 	templateStrategySpec := &CSVStrategySpec{}
 	err := json.Unmarshal(csv.Spec.InstallStrategy.StrategySpecRaw, templateStrategySpec)
@@ -59,6 +65,7 @@ func UnmarshalStrategySpec(csv *csvv1.ClusterServiceVersion) *CSVStrategySpec {
 	return templateStrategySpec
 }
 
+// MarshallObject mashals an object, usually a CSV into YAML
 func MarshallObject(obj interface{}, writer io.Writer) error {
 	jsonBytes, err := json.Marshal(obj)
 	if err != nil {

--- a/pkg/utils/csvtools/csvtools.go
+++ b/pkg/utils/csvtools/csvtools.go
@@ -1,0 +1,118 @@
+package csvtools
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"strings"
+
+	yaml "github.com/ghodss/yaml"
+	csvv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type CSVClusterPermissions struct {
+	ServiceAccountName string              `json:"serviceAccountName"`
+	Rules              []rbacv1.PolicyRule `json:"rules"`
+}
+
+type CSVPermissions struct {
+	ServiceAccountName string              `json:"serviceAccountName"`
+	Rules              []rbacv1.PolicyRule `json:"rules"`
+}
+
+type CSVDeployments struct {
+	Name string                `json:"name"`
+	Spec appsv1.DeploymentSpec `json:"spec,omitempty"`
+}
+
+type CSVStrategySpec struct {
+	ClusterPermissions []CSVClusterPermissions `json:"clusterPermissions"`
+	Permissions        []CSVPermissions        `json:"permissions"`
+	Deployments        []CSVDeployments        `json:"deployments"`
+}
+
+func UnmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
+	bytes, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		panic(err)
+	}
+
+	csvStruct := &csvv1.ClusterServiceVersion{}
+	err = yaml.Unmarshal(bytes, csvStruct)
+	if err != nil {
+		panic(err)
+	}
+
+	return csvStruct
+}
+
+func UnmarshalStrategySpec(csv *csvv1.ClusterServiceVersion) *CSVStrategySpec {
+	templateStrategySpec := &CSVStrategySpec{}
+	err := json.Unmarshal(csv.Spec.InstallStrategy.StrategySpecRaw, templateStrategySpec)
+	if err != nil {
+		panic(err)
+	}
+
+	return templateStrategySpec
+}
+
+func MarshallObject(obj interface{}, writer io.Writer) error {
+	jsonBytes, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	var r unstructured.Unstructured
+	if err := json.Unmarshal(jsonBytes, &r.Object); err != nil {
+		return err
+	}
+
+	// remove status and metadata.creationTimestamp
+	unstructured.RemoveNestedField(r.Object, "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(r.Object, "template", "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(r.Object, "spec", "template", "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(r.Object, "status")
+
+	deployments, exists, err := unstructured.NestedSlice(r.Object, "spec", "install", "spec", "deployments")
+	if exists {
+		for _, obj := range deployments {
+			deployment := obj.(map[string]interface{})
+			unstructured.RemoveNestedField(deployment, "metadata", "creationTimestamp")
+			unstructured.RemoveNestedField(deployment, "spec", "template", "metadata", "creationTimestamp")
+			unstructured.RemoveNestedField(deployment, "status")
+		}
+		unstructured.SetNestedSlice(r.Object, deployments, "spec", "install", "spec", "deployments")
+	}
+
+	jsonBytes, err = json.Marshal(r.Object)
+	if err != nil {
+		return err
+	}
+
+	yamlBytes, err := yaml.JSONToYAML(jsonBytes)
+	if err != nil {
+		return err
+	}
+
+	// fix double quoted strings by removing unneeded single quotes...
+	s := string(yamlBytes)
+	s = strings.Replace(s, " '\"", " \"", -1)
+	s = strings.Replace(s, "\"'\n", "\"\n", -1)
+
+	yamlBytes = []byte(s)
+
+	_, err = writer.Write([]byte("---\n"))
+	if err != nil {
+		return err
+	}
+
+	_, err = writer.Write(yamlBytes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tools/csv-generator/csv-generator.go
+++ b/tools/csv-generator/csv-generator.go
@@ -31,7 +31,7 @@ var (
 
 	outputDir = flag.String("olm-bundle-directory", "", "The directory to output the unified CSV and CRDs to")
 
-	annotationsFile = flag.String("inject-annotations-from", "", "inject metadata annotations from given file")
+	annotationsFile = flag.String("annotations-from", "", "add metadata annotations from given file")
 	maintainersFile = flag.String("maintainers-from", "", "add maintainers list from given file")
 	descriptionFile = flag.String("description-from", "", "replace the description with the content of the given file")
 

--- a/tools/csv-generator/csv-generator.go
+++ b/tools/csv-generator/csv-generator.go
@@ -137,6 +137,9 @@ func generateUnifiedCSV(userData csvUserData) {
 	// Set Description
 	operatorCSV.Spec.Description = `
 Performance Addon Operator provides the ability to enable advanced node performance tunings on a set of nodes.`
+	if userData.Description != "" {
+		operatorCSV.Spec.Description = userData.Description
+	}
 
 	operatorCSV.Spec.DisplayName = "Performance Addon Operator"
 

--- a/tools/csv-replace-imageref/csv-replace-imageref.go
+++ b/tools/csv-replace-imageref/csv-replace-imageref.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	yaml "github.com/ghodss/yaml"
+	csvv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type csvClusterPermissions struct {
+	ServiceAccountName string              `json:"serviceAccountName"`
+	Rules              []rbacv1.PolicyRule `json:"rules"`
+}
+
+type csvPermissions struct {
+	ServiceAccountName string              `json:"serviceAccountName"`
+	Rules              []rbacv1.PolicyRule `json:"rules"`
+}
+
+type csvDeployments struct {
+	Name string                `json:"name"`
+	Spec appsv1.DeploymentSpec `json:"spec,omitempty"`
+}
+
+type csvStrategySpec struct {
+	ClusterPermissions []csvClusterPermissions `json:"clusterPermissions"`
+	Permissions        []csvPermissions        `json:"permissions"`
+	Deployments        []csvDeployments        `json:"deployments"`
+}
+
+var (
+	csvInput      = flag.String("csv-input", "", "path to csv to update")
+	operatorImage = flag.String("operator-image", "", "operator container image")
+)
+
+func unmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
+	bytes, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		panic(err)
+	}
+
+	csvStruct := &csvv1.ClusterServiceVersion{}
+	err = yaml.Unmarshal(bytes, csvStruct)
+	if err != nil {
+		panic(err)
+	}
+
+	return csvStruct
+}
+
+func unmarshalStrategySpec(csv *csvv1.ClusterServiceVersion) *csvStrategySpec {
+
+	templateStrategySpec := &csvStrategySpec{}
+	err := json.Unmarshal(csv.Spec.InstallStrategy.StrategySpecRaw, templateStrategySpec)
+	if err != nil {
+		panic(err)
+	}
+
+	return templateStrategySpec
+}
+
+func marshallObject(obj interface{}, writer io.Writer) error {
+	jsonBytes, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	var r unstructured.Unstructured
+	if err := json.Unmarshal(jsonBytes, &r.Object); err != nil {
+		return err
+	}
+
+	// remove status and metadata.creationTimestamp
+	unstructured.RemoveNestedField(r.Object, "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(r.Object, "template", "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(r.Object, "spec", "template", "metadata", "creationTimestamp")
+	unstructured.RemoveNestedField(r.Object, "status")
+
+	deployments, exists, err := unstructured.NestedSlice(r.Object, "spec", "install", "spec", "deployments")
+	if exists {
+		for _, obj := range deployments {
+			deployment := obj.(map[string]interface{})
+			unstructured.RemoveNestedField(deployment, "metadata", "creationTimestamp")
+			unstructured.RemoveNestedField(deployment, "spec", "template", "metadata", "creationTimestamp")
+			unstructured.RemoveNestedField(deployment, "status")
+		}
+		unstructured.SetNestedSlice(r.Object, deployments, "spec", "install", "spec", "deployments")
+	}
+
+	jsonBytes, err = json.Marshal(r.Object)
+	if err != nil {
+		return err
+	}
+
+	yamlBytes, err := yaml.JSONToYAML(jsonBytes)
+	if err != nil {
+		return err
+	}
+
+	// fix double quoted strings by removing unneeded single quotes...
+	s := string(yamlBytes)
+	s = strings.Replace(s, " '\"", " \"", -1)
+	s = strings.Replace(s, "\"'\n", "\"\n", -1)
+
+	yamlBytes = []byte(s)
+
+	_, err = writer.Write([]byte("---\n"))
+	if err != nil {
+		return err
+	}
+
+	_, err = writer.Write(yamlBytes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func processCSV(operatorImage, csvInput string, dst io.Writer) {
+	operatorCSV := unmarshalCSV(csvInput)
+
+	strategySpec := unmarshalStrategySpec(operatorCSV)
+
+	// this forces us to update this logic if another deployment is introduced.
+	if len(strategySpec.Deployments) != 1 {
+		panic(fmt.Errorf("expected 1 deployment, found %d", len(strategySpec.Deployments)))
+	}
+
+	strategySpec.Deployments[0].Spec.Template.Spec.Containers[0].Image = operatorImage
+
+	// Re-serialize deployments and permissions into csv strategy.
+	updatedStrat, err := json.Marshal(strategySpec)
+	if err != nil {
+		panic(err)
+	}
+	operatorCSV.Spec.InstallStrategy.StrategySpecRaw = updatedStrat
+
+	operatorCSV.Annotations["containerImage"] = operatorImage
+
+	marshallObject(operatorCSV, dst)
+}
+
+func main() {
+	flag.Parse()
+
+	if *csvInput == "" {
+		log.Fatal("--csv-input is required")
+	} else if *operatorImage == "" {
+		log.Fatal("--operator-image is required")
+	}
+
+	processCSV(*operatorImage, *csvInput, os.Stdout)
+}

--- a/tools/csv-replace-imageref/csv-replace-imageref.go
+++ b/tools/csv-replace-imageref/csv-replace-imageref.go
@@ -5,132 +5,21 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
-	"strings"
 
-	yaml "github.com/ghodss/yaml"
-	csvv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	appsv1 "k8s.io/api/apps/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"github.com/openshift-kni/performance-addon-operators/pkg/utils/csvtools"
 )
-
-type csvClusterPermissions struct {
-	ServiceAccountName string              `json:"serviceAccountName"`
-	Rules              []rbacv1.PolicyRule `json:"rules"`
-}
-
-type csvPermissions struct {
-	ServiceAccountName string              `json:"serviceAccountName"`
-	Rules              []rbacv1.PolicyRule `json:"rules"`
-}
-
-type csvDeployments struct {
-	Name string                `json:"name"`
-	Spec appsv1.DeploymentSpec `json:"spec,omitempty"`
-}
-
-type csvStrategySpec struct {
-	ClusterPermissions []csvClusterPermissions `json:"clusterPermissions"`
-	Permissions        []csvPermissions        `json:"permissions"`
-	Deployments        []csvDeployments        `json:"deployments"`
-}
 
 var (
 	csvInput      = flag.String("csv-input", "", "path to csv to update")
 	operatorImage = flag.String("operator-image", "", "operator container image")
 )
 
-func unmarshalCSV(filePath string) *csvv1.ClusterServiceVersion {
-	bytes, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		panic(err)
-	}
-
-	csvStruct := &csvv1.ClusterServiceVersion{}
-	err = yaml.Unmarshal(bytes, csvStruct)
-	if err != nil {
-		panic(err)
-	}
-
-	return csvStruct
-}
-
-func unmarshalStrategySpec(csv *csvv1.ClusterServiceVersion) *csvStrategySpec {
-
-	templateStrategySpec := &csvStrategySpec{}
-	err := json.Unmarshal(csv.Spec.InstallStrategy.StrategySpecRaw, templateStrategySpec)
-	if err != nil {
-		panic(err)
-	}
-
-	return templateStrategySpec
-}
-
-func marshallObject(obj interface{}, writer io.Writer) error {
-	jsonBytes, err := json.Marshal(obj)
-	if err != nil {
-		return err
-	}
-
-	var r unstructured.Unstructured
-	if err := json.Unmarshal(jsonBytes, &r.Object); err != nil {
-		return err
-	}
-
-	// remove status and metadata.creationTimestamp
-	unstructured.RemoveNestedField(r.Object, "metadata", "creationTimestamp")
-	unstructured.RemoveNestedField(r.Object, "template", "metadata", "creationTimestamp")
-	unstructured.RemoveNestedField(r.Object, "spec", "template", "metadata", "creationTimestamp")
-	unstructured.RemoveNestedField(r.Object, "status")
-
-	deployments, exists, err := unstructured.NestedSlice(r.Object, "spec", "install", "spec", "deployments")
-	if exists {
-		for _, obj := range deployments {
-			deployment := obj.(map[string]interface{})
-			unstructured.RemoveNestedField(deployment, "metadata", "creationTimestamp")
-			unstructured.RemoveNestedField(deployment, "spec", "template", "metadata", "creationTimestamp")
-			unstructured.RemoveNestedField(deployment, "status")
-		}
-		unstructured.SetNestedSlice(r.Object, deployments, "spec", "install", "spec", "deployments")
-	}
-
-	jsonBytes, err = json.Marshal(r.Object)
-	if err != nil {
-		return err
-	}
-
-	yamlBytes, err := yaml.JSONToYAML(jsonBytes)
-	if err != nil {
-		return err
-	}
-
-	// fix double quoted strings by removing unneeded single quotes...
-	s := string(yamlBytes)
-	s = strings.Replace(s, " '\"", " \"", -1)
-	s = strings.Replace(s, "\"'\n", "\"\n", -1)
-
-	yamlBytes = []byte(s)
-
-	_, err = writer.Write([]byte("---\n"))
-	if err != nil {
-		return err
-	}
-
-	_, err = writer.Write(yamlBytes)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func processCSV(operatorImage, csvInput string, dst io.Writer) {
-	operatorCSV := unmarshalCSV(csvInput)
+	operatorCSV := csvtools.UnmarshalCSV(csvInput)
 
-	strategySpec := unmarshalStrategySpec(operatorCSV)
+	strategySpec := csvtools.UnmarshalStrategySpec(operatorCSV)
 
 	// this forces us to update this logic if another deployment is introduced.
 	if len(strategySpec.Deployments) != 1 {
@@ -148,7 +37,7 @@ func processCSV(operatorImage, csvInput string, dst io.Writer) {
 
 	operatorCSV.Annotations["containerImage"] = operatorImage
 
-	marshallObject(operatorCSV, dst)
+	csvtools.MarshallObject(operatorCSV, dst)
 }
 
 func main() {


### PR DESCRIPTION
In this PR we backport all the improvements made in the 4.5 branch, to make 4.4 maintenance easier and more like 4.5.
No one of these patches actually affects the operator, but rather only the release process and the metadata handling, so the risk is very low.

Signed-off-by: Francesco Romani <fromani@redhat.com>