### PR TITLE
Use the cnf tests image as container image for tests pod.

### DIFF
--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -166,7 +166,7 @@ func getStressPod(nodeName string) *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:  "stress-test",
-					Image: images.For(images.Stresser),
+					Image: images.Test(),
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("1"),

--- a/functests/1_performance/hugepages.go
+++ b/functests/1_performance/hugepages.go
@@ -163,7 +163,7 @@ func getCentosPod(nodeName string) *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:    "test",
-					Image:   images.For(images.TestUtils),
+					Image:   images.Test(),
 					Command: []string{"sleep", "10h"},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/functests/utils/images/images.go
+++ b/functests/utils/images/images.go
@@ -3,50 +3,25 @@ package images
 import (
 	"fmt"
 	"os"
-
-	. "github.com/onsi/gomega"
 )
 
 var registry string
-var images map[string]imageLocation
-
-const (
-	// TestUtils is the image name to be used to retrieve the test utils image
-	TestUtils = "testutils"
-	// Stresser is the image name to be used to retrieve the stresser image
-	Stresser = "stresser"
-)
+var cnfTestsImage string
 
 func init() {
 	registry = os.Getenv("IMAGE_REGISTRY")
+	cnfTestsImage = os.Getenv("CNF_TESTS_IMAGE")
 
-	images = map[string]imageLocation{
-		TestUtils: {
-			name:    "cnftest-utils",
-			registy: "quay.io/openshift-kni/",
-			version: "4.5",
-		},
-		Stresser: {
-			name:    "stresser",
-			registy: "quay.io/openshift-kni/",
-			version: "4.5",
-		},
+	if cnfTestsImage == "" {
+		cnfTestsImage = "cnf-tests:4.5"
+	}
+
+	if registry == "" {
+		registry = "quay.io/openshift-kni/"
 	}
 }
 
-type imageLocation struct {
-	name    string
-	registy string
-	version string
-}
-
-// For returns the image to be used for the given key
-func For(name string) string {
-	img, ok := images[name]
-	Expect(ok).To(BeTrue(), "Image not found")
-
-	if registry != "" {
-		return fmt.Sprintf("%s%s:%s", registry, img.name, img.version)
-	}
-	return fmt.Sprintf("%s%s:%s", img.registy, img.name, img.version)
+// Test returns the image to be used for tests
+func Test() string {
+	return fmt.Sprintf("%s%s", registry, cnfTestsImage)
 }

--- a/functests/utils/pods/pods.go
+++ b/functests/utils/pods/pods.go
@@ -31,7 +31,7 @@ func GetTestPod() *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:    "test",
-					Image:   images.For(images.TestUtils),
+					Image:   images.Test(),
 					Command: []string{"sleep", "10h"},
 				},
 			},


### PR DESCRIPTION
We are replacing the various test images packing everything inside the cnf tests image.
This reduces the number of images we need to ship.
