### PR TITLE
Fix realtime kernel argument in base profile

### DIFF
--- a/build/assets/tuned/openshift-node-performance
+++ b/build/assets/tuned/openshift-node-performance
@@ -85,7 +85,7 @@ initrd_add_dir=
 # overrides cpu-partitioning cmdline
 cmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} intel_pstate=disable nosoftlockup
 {{if .StaticIsolation}}
-cmdline_realtime=+tsc=nowatchdog intel_iommu=on iommu=pt isolated_cores={{.IsolatedCpus}} systemd.cpu_affinity=${not_isolated_cores_expanded}
+cmdline_realtime=+tsc=nowatchdog intel_iommu=on iommu=pt isolcpus=${isolated_cores} systemd.cpu_affinity=${not_isolated_cores_expanded}
 {{else}}
 cmdline_realtime=+tsc=nowatchdog intel_iommu=on iommu=pt systemd.cpu_affinity=${not_isolated_cores_expanded}
 {{end}}

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -54,6 +54,15 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 
 	Context("Pre boot tuning adjusted by tuned ", func() {
 
+		It("Should set CPU affinity kernel argument", func() {
+			for _, node := range workerRTNodes {
+				cmdline, err := nodes.ExecCommandOnMachineConfigDaemon(&node, []string{"cat", "/proc/cmdline"})
+				Expect(err).ToNot(HaveOccurred())
+				// since systemd.cpu_affinity is calculated on node level using tuned we can check only the key in this context.
+				Expect(cmdline).To(ContainSubstring("systemd.cpu_affinity="))
+			}
+		})
+
 		It("[test_id:27081][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] Should set workqueue CPU mask", func() {
 			for _, node := range workerRTNodes {
 				By("Getting tuned.non_isolcpus kernel argument")

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -54,7 +54,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 
 	Context("Pre boot tuning adjusted by tuned ", func() {
 
-		It("Should set CPU affinity kernel argument", func() {
+		It("[test_id:31198] Should set CPU affinity kernel argument", func() {
 			for _, node := range workerRTNodes {
 				cmdline, err := nodes.ExecCommandOnMachineConfigDaemon(&node, []string{"cat", "/proc/cmdline"})
 				Expect(err).ToNot(HaveOccurred())

--- a/functests/2_performance_update/updating_profile.go
+++ b/functests/2_performance_update/updating_profile.go
@@ -117,7 +117,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			table.Entry("[test_id:28024] verify that hugepages size and count updated", chkCmdLine, []string{"default_hugepagesz=2M", "hugepagesz=2M", "hugepages=5"}, true, false),
 			table.Entry("[test_id:28070] verify that hugepages updated (NUMA node unspecified)", chkCmdLine, []string{"hugepagesz=2M"}, true, false),
 			table.Entry("[test_id:28025] verify that cpu affinity mask was updated", chkCmdLine, []string{"tuned.non_isolcpus=00000009"}, true, false),
-			table.Entry("[test_id:28071] verify that cpu balancer disabled", chkCmdLine, []string{"isolated_cores=1-2"}, true, false),
+			table.Entry("[test_id:28071] verify that cpu balancer disabled", chkCmdLine, []string{"isolcpus=1-2"}, true, false),
 			table.Entry("[test_id:28071] verify that cpu balancer disabled", chkCmdLine, []string{"systemd.cpu_affinity=0,3"}, true, false),
 			// kubelet.conf changed formatting, there is a space after colons atm. Let's deal with both cases with a regex
 			table.Entry("[test_id:28935] verify that reservedSystemCPUs was updated", chkKubeletConfig, []string{`"reservedSystemCPUs": ?"0,3"`}, true, true),

--- a/functests/3_performance_status/status.go
+++ b/functests/3_performance_status/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"

--- a/pkg/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/controller/performanceprofile/components/tuned/tuned_test.go
@@ -19,7 +19,7 @@ const expectedMatchSelector = `
 
 var cmdlineCPUsPartitioning = regexp.MustCompile(`\s*cmdline_cpu_part=\+\s*nohz=on\s+rcu_nocbs=\${isolated_cores}\s+tuned.non_isolcpus=\${not_isolated_cpumask}\s+intel_pstate=disable\s+nosoftlockup\s*`)
 var cmdlineRealtimeWithCPUBalancing = regexp.MustCompile(`\s*cmdline_realtime=\+\s*tsc=nowatchdog\s+intel_iommu=on\s+iommu=pt\s+systemd.cpu_affinity=\${not_isolated_cores_expanded}\s*`)
-var cmdlineRealtimeWithoutCPUBalancing = regexp.MustCompile(`\s*cmdline_realtime=\+\s*tsc=nowatchdog\s+intel_iommu=on\s+iommu=pt\s+isolated_cores=4-7\s+systemd.cpu_affinity=\${not_isolated_cores_expanded}\s*`)
+var cmdlineRealtimeWithoutCPUBalancing = regexp.MustCompile(`\s*cmdline_realtime=\+\s*tsc=nowatchdog\s+intel_iommu=on\s+iommu=pt\s+isolcpus=\${isolated_cores}\s+systemd.cpu_affinity=\${not_isolated_cores_expanded}\s*`)
 var cmdlineHugepages = regexp.MustCompile(`\s*cmdline_hugepages=\+\s*default_hugepagesz=1G\s+hugepagesz=1G\s+hugepages=4\s*`)
 var cmdlineAdditionalArg = regexp.MustCompile(`\s*cmdline_additionalArg=\+\s*test1=val1\s+test2=val2\s*`)
 var additionalArgs = []string{"test1=val1", "test2=val2"}

--- a/pkg/controller/performanceprofile/performanceprofile_controller_test.go
+++ b/pkg/controller/performanceprofile/performanceprofile_controller_test.go
@@ -347,7 +347,7 @@ var _ = Describe("Controller", func() {
 				t := &tunedv1.Tuned{}
 				err := r.client.Get(context.TODO(), key, t)
 				Expect(err).ToNot(HaveOccurred())
-				cmdlineRealtimeWithoutCPUBalancing := regexp.MustCompile(`\s*cmdline_realtime=\+\s*tsc=nowatchdog\s+intel_iommu=on\s+iommu=pt\s+isolated_cores=` + string(*profile.Spec.CPU.Isolated) + `\s*`)
+				cmdlineRealtimeWithoutCPUBalancing := regexp.MustCompile(`\s*cmdline_realtime=\+\s*tsc=nowatchdog\s+intel_iommu=on\s+iommu=pt\s+isolcpus=\s*`)
 				Expect(cmdlineRealtimeWithoutCPUBalancing.MatchString(*t.Spec.Profile[0].Data)).To(BeTrue())
 			})
 


### PR DESCRIPTION
The wrong kernel argument was set in base profile for cpu isolation (done as an equivalent for tuned realtime profile) 
changed from isolated_cpus to isolcpus

**Note**:  This fix is intended for 4.6 and above (currently fixes an u/s change made in https://github.com/openshift-kni/performance-addon-operators/pull/190)