### PR TITLE
must-gather: initial integration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -87,6 +87,26 @@ steps:
       - sqlite3 /registry/bundles.db "select * from channel" | grep "${DRONE_SEMVER_SHORT}|performance-addon-operator|performance-addon-operator.v${DRONE_SEMVER_SHORT}"
       - sqlite3 /registry/bundles.db "select * from operatorbundle" | grep "\"image\":\"quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator:${DRONE_TAG}\""
 
+  - name: build-must-gather-image
+    image: plugins/docker
+    settings:
+      dockerfile: openshift-ci/Dockerfile.must-gather
+      username:
+        from_secret: QUAY_USER
+      password:
+        from_secret: QUAY_PASSWORD
+      build_args:
+        - COLLECTION_SCRIPTS_DIR=must-gather/collection-scripts
+      registry: quay.io
+      # This only works if github user == quay user!
+      repo: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-must-gather
+
+  - name: validate-must-gather-image
+    image: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-must-gather:${DRONE_TAG:-notset}
+    commands:
+      # This is simplistic, need to figure out something smarter
+      - grep performance /usr/bin/gather
+
   - name: github-release
     image: plugins/github-release
     settings:

--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,0 +1,3 @@
+FROM quay.io/openshift/origin-must-gather:4.6.0
+COPY collection-scripts/* /usr/bin/
+ENTRYPOINT /usr/bin/gather

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -1,16 +1,24 @@
 #!/bin/bash
 
+# generate /must-gather/version file
+. version
+echo "performance-addon-operator/must-gather" > /must-gather/version
+version >> /must-gather/version
+
+. namespace
+PAO_NAMESPACE=$( namespace )
+
 # resource list
 resources=()
 
 # performance operator namespace
-resources+=(ns/openshift-performance-addon)
+resources+=(ns/${PAO_NAMESPACE})
 
 # performance operator profiles
 resources+=(performanceprofile)
 
 # machine/node resources
-resources+=(nodes machineconfigs machineconfigpools featuregates kubeletconfigs)
+resources+=(nodes machineconfigs machineconfigpools featuregates kubeletconfigs tuneds)
 
 # run the collection of resources using must-gather
 for resource in ${resources[@]}; do

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# resource list
+resources=()
+
+# performance operator namespace
+resources+=(ns/openshift-performance-addon)
+
+# performance operator profiles
+resources+=(performanceprofile)
+
+# machine/node resources
+resources+=(nodes machineconfigs machineconfigpools featuregates kubeletconfigs)
+
+# run the collection of resources using must-gather
+for resource in ${resources[@]}; do
+  /usr/bin/oc adm inspect --dest-dir must-gather --all-namespaces ${resource}
+done
+
+exit 0
+

--- a/must-gather/collection-scripts/namespace
+++ b/must-gather/collection-scripts/namespace
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+function namespace() {
+  # we control the subs, so this is the most reliable way to get the namespace
+  ns=$( oc get subs -A --field-selector metadata.name='performance-addon-operator-subscription' -o=jsonpath='{.items[0].metadata.namespace}{"\n"}' )
+  # trying again with the pods, which are _usually_ reliable - but users can change them
+  [ -z "${ns}" ] && ns=$( oc get pods -A -l name='performance-operator' -o=jsonpath='{.items[0].metadata.namespace}{"\n"}' )
+  # if namespace not found, fallback to the old default
+  [ -z "${ns}" ] && ns="openshift-performance-addon"
+  echo ${ns}
+}

--- a/must-gather/collection-scripts/version
+++ b/must-gather/collection-scripts/version
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+function version() {
+  # get version from image
+  version=$( \
+    oc status | grep '^pod' | \
+    sed -n -r -e 's/.*([[:digit:]]+\.[[:digit:]]+(:?\.[[:digit:]])?(:?-[^@]+)?).*/\1/p' \
+  )
+
+  # if version not found, fallback to imageID
+  [ -z "${version}" ] && version=$(oc status | grep '^pod.*runs' | sed -r -e 's/^pod.*runs //')
+
+  # if version still not found, use Unknown
+  [ -z "${version}" ] && version="Unknown"
+
+  echo ${version}
+}

--- a/openshift-ci/Dockerfile.must-gather
+++ b/openshift-ci/Dockerfile.must-gather
@@ -1,0 +1,4 @@
+FROM quay.io/openshift/origin-must-gather:4.6.0
+ARG COLLECTION_SCRIPTS_DIR=must-gather/collection-scripts
+COPY ${COLLECTION_SCRIPTS_DIR}/* /usr/bin/
+ENTRYPOINT /usr/bin/gather


### PR DESCRIPTION
This PR adds must-gather support for performance-addon-operator.

We intentionally collect everything which concerns the PAO operativity, ignoring any overlap or duplication with other layered images.
Worth noting this is especially true for the [sriov network operator](https://github.com/openshift/sriov-network-operator/tree/master/must-gather) which is very very likely to be installed on the same cluster on which PAO runs.

Signed-off-by: Francesco Romani <fromani@redhat.com>