### PR TITLE
Improvement for operator upgrade test:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ cluster-wait-for-mcp:
     # NOTE: for CI this is done in the config suite of the functests!
     # Use this when deploying manifests manually with CLUSTER=manual
 	@echo "Waiting for MCP to be updated"
-	hack/wait-for-mcp.sh
+	CLUSTER=$(CLUSTER) hack/wait-for-mcp.sh
 
 .PHONY: cluster-clean
 cluster-clean:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This will label 1 worker node with the `worker-cnf` role, and OCP's `Machine Con
 In order to wait until MCO is ready, you can watch the `MachineConfigPool` until it is marked as updated with 
 
 ```
-make cluster-wait-for-mcp
+CLUSTER=manual make cluster-wait-for-mcp
 ```
 
 > Note: Be aware this can take quite a while (many minutes)

--- a/cluster-setup/upgrade-test-cluster/performance/performance_profile.yaml
+++ b/cluster-setup/upgrade-test-cluster/performance/performance_profile.yaml
@@ -1,7 +1,7 @@
 apiVersion: performance.openshift.io/v1alpha1
 kind: PerformanceProfile
 metadata:
-  name: manual
+  name: upgrade-test
 spec:
   additionalKernelArgs:
     - "nmi_watchdog=0"
@@ -21,5 +21,7 @@ spec:
         node: 0
   realTimeKernel:
     enabled: true
+  numa:
+    topologyPolicy: "single-numa-node"
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""

--- a/functests/utils/consts.go
+++ b/functests/utils/consts.go
@@ -35,6 +35,8 @@ const (
 )
 
 const (
+	// PerformanceOperatorNamespace contains the name of the performance operator namespace
+	PerformanceOperatorNamespace = "openshift-performance-addon"
 	// NamespaceMachineConfigOperator contains the namespace of the machine-config-opereator
 	NamespaceMachineConfigOperator = "openshift-machine-config-operator"
 	// NamespaceTesting contains the name of the testing namespace

--- a/hack/run-upgrade-tests.sh
+++ b/hack/run-upgrade-tests.sh
@@ -1,7 +1,28 @@
 #!/bin/bash
 
-IMAGE_TAG="4.6-snapshot" CLUSTER="upgrade-test" make cluster-deploy
-make cluster-wait-for-mcp
+FROM_VERSION="${FROM_VERSION:-4.5.0}"
+TO_VERSION="${TO_VERSION:-4.6.0}"
+
+OC_TOOL="${OC_TOOL:-oc}"
+
+# By default we are running full scope of tests after operator upgrade (time consuming)
+RUN_TESTS_AFTER_UPGRADE="${RUN_TESTS_AFTER_UPGRADE:-true}"
+PERF_TEST_PROFILE="${PERF_TEST_PROFILE:-upgrade-test}"
+
+# check if operator is already installed with right version
+subs=$(${OC_TOOL} get subscriptions -o name -n openshift-performance-addon)
+if [ -n "$subs" ]; then
+  echo "Operator exists, verifying the version"
+  channel=$(oc get $subs -n openshift-performance-addon -o jsonpath={.spec.channel})
+  if [[ "$channel" != "$FROM_VERSION" ]]; then
+    echo "Channel $channel is not equal to $FROM_VERSION, exit"
+    exit 1
+  fi
+else
+  IMAGE_TAG="${TO_VERSION:0:3}-snapshot" CLUSTER="upgrade-test" make cluster-deploy
+  make cluster-label-worker-cnf
+  CLUSTER="upgrade-test" make cluster-wait-for-mcp
+fi
 
 which ginkgo
 if [ $? -ne 0 ]; then
@@ -24,9 +45,21 @@ trap 'err=1' ERR
 # --keepGoing: don't stop on failing suite
 # -requireSuite: fail if tests are not executed because of missing suite
 # HEADS UP: fromVersion needs to match the channel in cluster-setup/upgrade-test-cluster/performance/operator_subscription.patch.yaml
-GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --keepGoing -requireSuite functests-extended -- -junitDir /tmp/artifacts -fromVersion 4.5.0 -toVersion 4.6.0
+GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --keepGoing -requireSuite functests-extended -- -junitDir /tmp/artifacts -fromVersion $FROM_VERSION -toVersion $TO_VERSION
 
-make cluster-clean
+echo "[INFO] Waiting a bit until MCO starts updating nodes"
+sleep 60
+
+# run all tests after upgrade operator
+if [ "$RUN_TESTS_AFTER_UPGRADE" == true ] && [ $err = 0 ]; then
+  echo "[INFO] Running tests after operator upgrade"
+  ${OC_TOOL} get performanceprofile "$PERF_TEST_PROFILE"
+  if [ $? -ne 0 ]; then
+	  echo "[ERROR] Performance profile $PERF_TEST_PROFILE not exists, exit"
+	  exit 1
+  fi
+  PERF_TEST_PROFILE=$PERF_TEST_PROFILE make functests-only
+fi
 
 # fail if any of the above failed
 test $err = 0

--- a/hack/wait-for-mcp.sh
+++ b/hack/wait-for-mcp.sh
@@ -28,7 +28,7 @@ do
 
   echo "[INFO] Checking if MCP picked up the performance MC"
   # No output means that the new machine config wasn't picked by MCO yet
-  if [ -z "$(${OC_TOOL} get mcp worker-cnf -o jsonpath='{.spec.configuration.source[?(@.name=="performance-manual")].name}')" ]
+  if [ -z "$(${OC_TOOL} get mcp worker-cnf -o jsonpath='{.spec.configuration.source[?(@.name=="performance-'$CLUSTER'")].name}')" ]
   then
     iterations=$((iterations + 1))
     iterations_left=$((max_iterations - iterations))


### PR DESCRIPTION
- it runs all other tests after upgrade
- option to run on a cluster with pre-installed profile
- option to run it on d/s