### PR TITLE
enhance must-gather to get the basic node HW topology

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,3 +1,2 @@
-FROM quay.io/openshift/origin-must-gather:4.6.0
-COPY collection-scripts/* /usr/bin/
-ENTRYPOINT /usr/bin/gather
+# Dummy file for the project structure
+# Please use openshift-ci/Dockerfile.must-gather

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -25,5 +25,8 @@ for resource in ${resources[@]}; do
   /usr/bin/oc adm inspect --dest-dir must-gather --all-namespaces ${resource}
 done
 
+# Collect nodes details
+/usr/bin/gather_nodes
+
 exit 0
 

--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+check_node_gather_pods_ready() {
+    line=$(oc get ds perf-node-gather-daemonset -o=custom-columns=DESIRED:.status.desiredNumberScheduled,READY:.status.numberReady --no-headers -n perf-node-gather)
+
+    IFS=$' '
+    read desired ready <<< $line
+    IFS=$'\n'
+
+    if [[ $ready -eq $desired ]]
+    then
+       return 0
+    else
+       return 1
+    fi
+}
+
+IFS=$'\n'
+
+BASE_COLLECTION_PATH="/must-gather"
+NODES_PATH=${BASE_COLLECTION_PATH}/nodes
+mkdir -p ${NODES_PATH}
+NAMESPACE_MANIFEST="/etc/node-gather/namespace.yaml"
+SERVICEACCOUNT_MANIFEST="/etc/node-gather/serviceaccount.yaml"
+DAEMONSET_MANIFEST="/etc/node-gather/daemonset.yaml"
+NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+POD_NAME=$(oc get pods --field-selector=status.podIP=$(hostname -I) -n $NAMESPACE -o'custom-columns=name:metadata.name' --no-headers)
+MUST_GATHER_IMAGE=$(oc get pod -n $NAMESPACE $POD_NAME -o jsonpath="{.spec.initContainers[0].image}")
+
+sed -i -e "s#MUST_GATHER_IMAGE#$MUST_GATHER_IMAGE#" $DAEMONSET_MANIFEST
+
+oc create -f $NAMESPACE_MANIFEST
+oc create -f $SERVICEACCOUNT_MANIFEST
+oc adm policy add-scc-to-user privileged -n perf-node-gather -z perf-node-gather
+oc create -f $DAEMONSET_MANIFEST
+
+COUNTER=0
+until check_node_gather_pods_ready || [ $COUNTER -eq 300 ]; do
+   (( COUNTER++ ))
+   sleep 1
+done
+
+for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName --no-headers --field-selector=status.phase!=Running -n perf-node-gather)
+do
+    echo "Failed to collect perf-node-gather data from node ${line} due to pod scheduling failure." >> ${NODES_PATH}/skipped_nodes.txt
+done
+
+for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name --no-headers --field-selector=status.phase=Running -n perf-node-gather)
+do
+    node=$(echo $line | awk -F ' ' '{print $1}')
+    pod=$(echo $line | awk -F ' ' '{print $2}')
+    NODE_PATH=${NODES_PATH}/$node
+    mkdir -p ${NODE_PATH}
+
+    oc exec $pod -n perf-node-gather -- lspci -nvv 2>/dev/null >> $NODE_PATH/lspci
+    oc exec $pod -n perf-node-gather -- lscpu -e 2>/dev/null >> $NODE_PATH/lscpu
+    oc exec $pod -n perf-node-gather -- cat /host/proc/cmdline 2>/dev/null >> $NODE_PATH/proc_cmdline
+done
+
+# Collect journal logs for specified units for all nodes
+NODE_UNITS=(kubelet)
+for NODE in $(oc get nodes --no-headers -o custom-columns=':metadata.name'); do
+    NODE_PATH=${NODES_PATH}/$NODE
+    mkdir -p ${NODE_PATH}
+    for UNIT in ${NODE_UNITS[@]}; do
+        oc adm node-logs $NODE -u $UNIT > ${NODE_PATH}/${NODE}_logs_$UNIT &
+    done
+done
+
+oc delete -f $DAEMONSET_MANIFEST
+oc delete -f $SERVICEACCOUNT_MANIFEST
+oc delete -f $NAMESPACE_MANIFEST

--- a/must-gather/node-gather/daemonset.yaml
+++ b/must-gather/node-gather/daemonset.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: perf-node-gather-daemonset
+  namespace: perf-node-gather
+  labels:
+spec:
+  selector:
+    matchLabels:
+      name: perf-node-gather-daemonset
+  template:
+    metadata:
+      labels:
+        name: perf-node-gather-daemonset
+    spec:
+      serviceaccount: perf-node-gather
+      serviceAccountName: perf-node-gather
+      terminationGracePeriodSeconds: 0
+      hostNetwork: true
+      containers:
+      - name: node-probe
+        image: MUST_GATHER_IMAGE
+        command: ["/bin/bash", "-c", "echo ok > /tmp/healthy && sleep INF"]
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        readinessProbe:
+          exec:
+            command:
+              - cat
+              - /tmp/healthy
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        volumeMounts:
+          - name: sys
+            mountPath: /sys
+          - name: proc
+            mountPath: /proc
+          - name: dev
+            mountPath: /host/dev
+          - name: etc
+            mountPath: /host/etc
+        securityContext:
+          privileged: true
+      volumes:
+      - name: sys
+        hostPath:
+          path: /sys
+          type: Directory
+      - name: proc
+        hostPath:
+          path: /proc
+          type: Directory
+      - name: dev
+        hostPath:
+          path: /dev
+          type: Directory
+      - name: etc
+        hostPath:
+          path: /etc
+          type: Directory
+

--- a/must-gather/node-gather/namespace.yaml
+++ b/must-gather/node-gather/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: perf-node-gather

--- a/must-gather/node-gather/serviceaccount.yaml
+++ b/must-gather/node-gather/serviceaccount.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: perf-node-gather
+  namespace: perf-node-gather
+

--- a/openshift-ci/Dockerfile.must-gather
+++ b/openshift-ci/Dockerfile.must-gather
@@ -1,4 +1,18 @@
-FROM quay.io/openshift/origin-must-gather:4.6.0
+FROM quay.io/openshift/origin-must-gather:4.6.0 AS builder
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+RUN microdnf install -y pciutils util-linux hostname rsync
+
+# Copy must-gather required binaries
+COPY --from=builder /usr/bin/openshift-must-gather /usr/bin/openshift-must-gather
+COPY --from=builder /usr/bin/oc /usr/bin/oc
+
+# Save original gather script
+COPY --from=builder /usr/bin/gather* /usr/bin/
+RUN mv /usr/bin/gather /usr/bin/gather_original
+
 ARG COLLECTION_SCRIPTS_DIR=must-gather/collection-scripts
+ARG NODE_GATHER_MANIFESTS_DIR=must-gather/node-gather
 COPY ${COLLECTION_SCRIPTS_DIR}/* /usr/bin/
+COPY ${NODE_GATHER_MANIFESTS_DIR} /etc/node-gather
 ENTRYPOINT /usr/bin/gather


### PR DESCRIPTION
must-gather: collect basic HW node topology
  
This patch enhance must-gather to collect basic information about
the HW topology of the nodes. We use standard system utilities like
`lspci -nvv` and `lscpu -e`.
We use the same approach pioneered in cnv-must-gather to collect
data from worker nodes.

When we reach the `gather_node` stage, we create a daemonset which
will run on each worker nodes. Thanks to this daemonset, we create
hollow empty privileged pods. Privileged pods are needed to be able
to access the worker node `/proc` and `/sys` pseudofs.

Once the daemonset is ready, we iterate over all the worker nodes
and we run our collection programs (lscpu, lspci...) in the privileged
pods.
When we collected all the information we need, we clean up after
ourselves removing the daemonset with all the dependencies.

This approach is complex but minimizes the time on which privileged
pods run in the cluster.
