### PR TITLE
Remove outdated tuned CR owned by a performance profile

### DIFF
--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -69,6 +69,19 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 			err = testclient.Client.Create(context.TODO(), outdatedTuned)
 			Expect(err).NotTo(HaveOccurred())
 
+			outdatedKey := types.NamespacedName{
+				Name:      outdatedTuned.Name,
+				Namespace: components.NamespaceNodeTuningOperator,
+			}
+			tuned = &tunedv1.Tuned{}
+			Eventually(func() bool {
+				if err := testclient.Client.Get(context.TODO(), outdatedKey, tuned); err != nil {
+					return false
+				}
+				return true
+			}, 120*time.Second, testPollInterval*time.Second).Should(BeTrue(),
+				"outdated tuned does not exist in the cluster")
+
 			Eventually(func() bool {
 				err := testclient.Client.List(context.TODO(), tunedList)
 				Expect(err).NotTo(HaveOccurred())

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -63,24 +63,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 			}
 			tuned := &tunedv1.Tuned{}
 			err = testclient.Client.Get(context.TODO(), key, tuned)
-			Expect(err).ToNot(HaveOccurred(), "cannot find the Cluster Node Tuning Operator object "+components.ProfileNamePerformance)
-			outdatedTuned := tuned.DeepCopy()
-			outdatedTuned.Name = "outdatedname"
-			err = testclient.Client.Create(context.TODO(), outdatedTuned)
-			Expect(err).NotTo(HaveOccurred())
-
-			outdatedKey := types.NamespacedName{
-				Name:      outdatedTuned.Name,
-				Namespace: components.NamespaceNodeTuningOperator,
-			}
-			tuned = &tunedv1.Tuned{}
-			Eventually(func() bool {
-				if err := testclient.Client.Get(context.TODO(), outdatedKey, tuned); err != nil {
-					return false
-				}
-				return true
-			}, 120*time.Second, testPollInterval*time.Second).Should(BeTrue(),
-				"outdated tuned does not exist in the cluster")
+			Expect(err).ToNot(HaveOccurred(), "cannot find the Cluster Node Tuning Operator object "+tuned.Name)
 
 			Eventually(func() bool {
 				err := testclient.Client.List(context.TODO(), tunedList)
@@ -97,14 +80,6 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				return true
 			}, 120*time.Second, testPollInterval*time.Second).Should(BeTrue(),
 				"tuned CR name owned by a performance profile CR should only be "+tunedExpectedName)
-
-			key = types.NamespacedName{
-				Name:      outdatedTuned.Name,
-				Namespace: components.NamespaceNodeTuningOperator,
-			}
-			tuned = &tunedv1.Tuned{}
-			err = testclient.Client.Get(context.TODO(), key, tuned)
-			Expect(err).To(HaveOccurred(), "tuned CR "+outdatedTuned.Name+" should have been delete by the controller")
 		})
 	})
 

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -51,7 +51,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 	})
 
 	Context("Tuned CRs generated from profile", func() {
-		It("[test_id:] Should have the expected name for tuned from the profile owner object", func() {
+		It("[test_id:31754] Should have the expected name for tuned from the profile owner object", func() {
 			tunedExpectedName := components.GetComponentName(testutils.PerformanceProfileName, components.ProfileNamePerformance)
 			tunedList := &tunedv1.TunedList{}
 			err := testclient.Client.List(context.TODO(), tunedList)
@@ -65,7 +65,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 			err = testclient.Client.Get(context.TODO(), key, tuned)
 			Expect(err).ToNot(HaveOccurred(), "cannot find the Cluster Node Tuning Operator object "+components.ProfileNamePerformance)
 			outdatedTuned := tuned.DeepCopy()
-			outdatedTuned.Name = "outdatedName"
+			outdatedTuned.Name = "outdatedname"
 			err = testclient.Client.Create(context.TODO(), outdatedTuned)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -51,18 +51,15 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 	})
 
 	Context("Tuned CRs generated from profile", func() {
-		It("[test_id:31754] Should have the expected name for tuned from the profile owner object", func() {
+		It("[test_id:31748] Should have the expected name for tuned from the profile owner object", func() {
 			tunedExpectedName := components.GetComponentName(testutils.PerformanceProfileName, components.ProfileNamePerformance)
 			tunedList := &tunedv1.TunedList{}
-			err := testclient.Client.List(context.TODO(), tunedList)
-			Expect(err).NotTo(HaveOccurred())
-
 			key := types.NamespacedName{
 				Name:      components.GetComponentName(testutils.PerformanceProfileName, components.ProfileNamePerformance),
 				Namespace: components.NamespaceNodeTuningOperator,
 			}
 			tuned := &tunedv1.Tuned{}
-			err = testclient.Client.Get(context.TODO(), key, tuned)
+			err := testclient.Client.Get(context.TODO(), key, tuned)
 			Expect(err).ToNot(HaveOccurred(), "cannot find the Cluster Node Tuning Operator object "+tuned.Name)
 
 			Eventually(func() bool {

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -70,6 +70,8 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func() bool {
+				err := testclient.Client.List(context.TODO(), tunedList)
+				Expect(err).NotTo(HaveOccurred())
 				for t := range tunedList.Items {
 					tunedItem := tunedList.Items[t]
 					ownerReferences := tunedItem.ObjectMeta.OwnerReferences

--- a/pkg/controller/performanceprofile/performanceprofile_controller.go
+++ b/pkg/controller/performanceprofile/performanceprofile_controller.go
@@ -385,7 +385,7 @@ func (r *ReconcilePerformanceProfile) applyComponents(profile *performancev1alph
 	}
 
 	if performanceTunedMutated != nil {
-		if err := r.createOrUpdateTuned(performanceTunedMutated); err != nil {
+		if err := r.createOrUpdateTuned(performanceTunedMutated, profile.Name); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/controller/performanceprofile/performanceprofile_controller_test.go
+++ b/pkg/controller/performanceprofile/performanceprofile_controller_test.go
@@ -170,6 +170,50 @@ var _ = Describe("Controller", func() {
 
 		})
 
+		It("should remove outdated tuned objects", func() {
+
+			tunedOutdatedA, err := tuned.NewNodePerformance(assetsDir, profile)
+			Expect(err).ToNot(HaveOccurred())
+			tunedOutdatedA.Name = "outdated-a"
+			tunedOutdatedA.OwnerReferences = []metav1.OwnerReference{
+				{Name: profile.Name},
+			}
+			tunedOutdatedB, err := tuned.NewNodePerformance(assetsDir, profile)
+			Expect(err).ToNot(HaveOccurred())
+			tunedOutdatedB.Name = "outdated-b"
+			tunedOutdatedB.OwnerReferences = []metav1.OwnerReference{
+				{Name: profile.Name},
+			}
+			r := newFakeReconciler(profile, tunedOutdatedA, tunedOutdatedB)
+
+			keyA := types.NamespacedName{
+				Name:      tunedOutdatedA.Name,
+				Namespace: tunedOutdatedA.Namespace,
+			}
+			ta := &tunedv1.Tuned{}
+			err = r.client.Get(context.TODO(), keyA, ta)
+			Expect(err).ToNot(HaveOccurred())
+
+			keyB := types.NamespacedName{
+				Name:      tunedOutdatedA.Name,
+				Namespace: tunedOutdatedA.Namespace,
+			}
+			tb := &tunedv1.Tuned{}
+			err = r.client.Get(context.TODO(), keyB, tb)
+			Expect(err).ToNot(HaveOccurred())
+
+			result, err := r.Reconcile(request)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+
+			tunedList := &tunedv1.TunedList{}
+			err = r.client.List(context.TODO(), tunedList)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(tunedList.Items)).To(Equal(1))
+			tunedName := components.GetComponentName(profile.Name, components.ProfileNamePerformance)
+			Expect(tunedList.Items[0].Name).To(Equal(tunedName))
+		})
+
 		It("should create nothing when pause annotation is set", func() {
 			profile.Annotations = map[string]string{performancev1alpha1.PerformanceProfilePauseAnnotation: "true"}
 			r := newFakeReconciler(profile)

--- a/pkg/controller/performanceprofile/resources.go
+++ b/pkg/controller/performanceprofile/resources.go
@@ -209,12 +209,11 @@ func (r *ReconcilePerformanceProfile) getMutatedTuned(tuned *tunedv1.Tuned) (*tu
 
 func (r *ReconcilePerformanceProfile) createOrUpdateTuned(tuned *tunedv1.Tuned, profileName string) error {
 
-	err := r.removeOutdateTuned(tuned, profileName)
-	if err != nil {
+	if err := r.removeOutdateTuned(tuned, profileName); err != nil {
 		return err
 	}
 
-	_, err = r.getTuned(tuned.Name, tuned.Namespace)
+	_, err := r.getTuned(tuned.Name, tuned.Namespace)
 	if errors.IsNotFound(err) {
 		klog.Infof("Create tuned %q under the namespace %q", tuned.Name, tuned.Namespace)
 		if err := r.client.Create(context.TODO(), tuned); err != nil {
@@ -243,8 +242,7 @@ func (r *ReconcilePerformanceProfile) removeOutdateTuned(tuned *tunedv1.Tuned, p
 		ownerReferences := tunedItem.ObjectMeta.OwnerReferences
 		for o := range ownerReferences {
 			if ownerReferences[o].Name == profileName && tunedItem.Name != tuned.Name {
-				err := r.deleteTuned(tunedItem.Name, tunedItem.Namespace)
-				if err != nil {
+				if err := r.deleteTuned(tunedItem.Name, tunedItem.Namespace); err != nil {
 					return err
 				}
 			}

--- a/pkg/controller/performanceprofile/resources.go
+++ b/pkg/controller/performanceprofile/resources.go
@@ -207,8 +207,14 @@ func (r *ReconcilePerformanceProfile) getMutatedTuned(tuned *tunedv1.Tuned) (*tu
 	return mutated, nil
 }
 
-func (r *ReconcilePerformanceProfile) createOrUpdateTuned(tuned *tunedv1.Tuned) error {
-	_, err := r.getTuned(tuned.Name, tuned.Namespace)
+func (r *ReconcilePerformanceProfile) createOrUpdateTuned(tuned *tunedv1.Tuned, profileName string) error {
+
+	err := r.removeOutdateTuned(tuned, profileName)
+	if err != nil {
+		return err
+	}
+
+	_, err = r.getTuned(tuned.Name, tuned.Namespace)
 	if errors.IsNotFound(err) {
 		klog.Infof("Create tuned %q under the namespace %q", tuned.Name, tuned.Namespace)
 		if err := r.client.Create(context.TODO(), tuned); err != nil {
@@ -223,6 +229,28 @@ func (r *ReconcilePerformanceProfile) createOrUpdateTuned(tuned *tunedv1.Tuned) 
 
 	klog.Infof("Update tuned %q under the namespace %q", tuned.Name, tuned.Namespace)
 	return r.client.Update(context.TODO(), tuned)
+}
+
+func (r *ReconcilePerformanceProfile) removeOutdateTuned(tuned *tunedv1.Tuned, profileName string) error {
+	tunedList := &tunedv1.TunedList{}
+	if err := r.client.List(context.TODO(), tunedList); err != nil {
+		klog.Errorf("Unable to list tuned objects for outdated removal procedure: %v", err)
+		return err
+	}
+
+	for t := range tunedList.Items {
+		tunedItem := tunedList.Items[t]
+		ownerReferences := tunedItem.ObjectMeta.OwnerReferences
+		for o := range ownerReferences {
+			if ownerReferences[o].Name == profileName && tunedItem.Name != tuned.Name {
+				err := r.deleteTuned(tunedItem.Name, tunedItem.Namespace)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (r *ReconcilePerformanceProfile) deleteTuned(name string, namespace string) error {


### PR DESCRIPTION
This PR comes to remove outdate tuned CR that do not match the expected name that is generated from their performance profile owner.
This arose from upgrade procedures where tuned generate name differs from the previous version and resulted in outdated tuned CR that were not removed from the cluster.