### PR TITLE
[release-4.5] Remove outdated tuned CR owned by a performance profile

### DIFF
--- a/pkg/controller/performanceprofile/performanceprofile_controller.go
+++ b/pkg/controller/performanceprofile/performanceprofile_controller.go
@@ -408,7 +408,7 @@ func (r *ReconcilePerformanceProfile) applyComponents(profile *performancev1alph
 	}
 
 	if performanceTunedMutated != nil {
-		if err := r.createOrUpdateTuned(performanceTunedMutated); err != nil {
+		if err := r.createOrUpdateTuned(performanceTunedMutated, profile.Name); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/controller/performanceprofile/resources.go
+++ b/pkg/controller/performanceprofile/resources.go
@@ -274,7 +274,12 @@ func (r *ReconcilePerformanceProfile) getMutatedTuned(tuned *tunedv1.Tuned) (*tu
 	return mutated, nil
 }
 
-func (r *ReconcilePerformanceProfile) createOrUpdateTuned(tuned *tunedv1.Tuned) error {
+func (r *ReconcilePerformanceProfile) createOrUpdateTuned(tuned *tunedv1.Tuned, profileName string) error {
+
+	if err := r.removeOutdateTuned(tuned, profileName); err != nil {
+		return err
+	}
+
 	_, err := r.getTuned(tuned.Name, tuned.Namespace)
 	if errors.IsNotFound(err) {
 		klog.Infof("Create tuned %q under the namespace %q", tuned.Name, tuned.Namespace)
@@ -290,6 +295,27 @@ func (r *ReconcilePerformanceProfile) createOrUpdateTuned(tuned *tunedv1.Tuned) 
 
 	klog.Infof("Update tuned %q under the namespace %q", tuned.Name, tuned.Namespace)
 	return r.client.Update(context.TODO(), tuned)
+}
+
+func (r *ReconcilePerformanceProfile) removeOutdateTuned(tuned *tunedv1.Tuned, profileName string) error {
+	tunedList := &tunedv1.TunedList{}
+	if err := r.client.List(context.TODO(), tunedList); err != nil {
+		klog.Errorf("Unable to list tuned objects for outdated removal procedure: %v", err)
+		return err
+	}
+
+	for t := range tunedList.Items {
+		tunedItem := tunedList.Items[t]
+		ownerReferences := tunedItem.ObjectMeta.OwnerReferences
+		for o := range ownerReferences {
+			if ownerReferences[o].Name == profileName && tunedItem.Name != tuned.Name {
+				if err := r.deleteTuned(tunedItem.Name, tunedItem.Namespace); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (r *ReconcilePerformanceProfile) deleteTuned(name string, namespace string) error {


### PR DESCRIPTION
This is a cherry-pick of #268

This PR comes to remove outdated tuned CR that do not match the expected name that is generated from their performance profile owner.
This arose from upgrade procedures where tuned generate name differs from the previous version and resulted in outdated tuned CR that were not removed from the cluster.
