### PR TITLE
must-gather: remove unneeded volume mount

### DIFF
--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -54,7 +54,7 @@ do
 
     oc exec $pod -n perf-node-gather -- lspci -nvv 2>/dev/null >> $NODE_PATH/lspci
     oc exec $pod -n perf-node-gather -- lscpu -e 2>/dev/null >> $NODE_PATH/lscpu
-    oc exec $pod -n perf-node-gather -- cat /host/proc/cmdline 2>/dev/null >> $NODE_PATH/proc_cmdline
+    oc exec $pod -n perf-node-gather -- cat /proc/cmdline 2>/dev/null >> $NODE_PATH/proc_cmdline
 done
 
 # Collect journal logs for specified units for all nodes

--- a/must-gather/node-gather/daemonset.yaml
+++ b/must-gather/node-gather/daemonset.yaml
@@ -37,32 +37,5 @@ spec:
               - /tmp/healthy
           initialDelaySeconds: 5
           periodSeconds: 5
-        volumeMounts:
-          - name: sys
-            mountPath: /sys
-          - name: proc
-            mountPath: /proc
-          - name: dev
-            mountPath: /host/dev
-          - name: etc
-            mountPath: /host/etc
         securityContext:
           privileged: true
-      volumes:
-      - name: sys
-        hostPath:
-          path: /sys
-          type: Directory
-      - name: proc
-        hostPath:
-          path: /proc
-          type: Directory
-      - name: dev
-        hostPath:
-          path: /dev
-          type: Directory
-      - name: etc
-        hostPath:
-          path: /etc
-          type: Directory
-


### PR DESCRIPTION
Further testing revealed we don't actually need the host mounts
in the current scenario (just run lspci and lscpu).
We already get /proc and /sys out of the box.

Also, remapping the host /proc inside the container was just wrong
and sometime lead to
```
container create failed: time="2020-06-17T09:06:26Z" level=error msg="container_linux.go:349: starting container process caused \"set process label: open /proc/self/task/1/attr/exec: no such file or directory\""
container_linux.go:349: starting container process caused "set process label: open /proc/self/task/1/attr/exec: no such file or directory"
```

It's just simpler and safer to avoid the mount until there is
a clear and obvious need for them.

Signed-off-by: Francesco Romani <fromani@redhat.com>