### PR TITLE
[release-4.4] backport must-gather integration

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,0 +1,2 @@
+# Dummy file for the project structure
+# Please use openshift-ci/Dockerfile.must-gather

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# generate /must-gather/version file
+. version
+echo "performance-addon-operator/must-gather" > /must-gather/version
+version >> /must-gather/version
+
+. namespace
+PAO_NAMESPACE=$( namespace )
+
+# resource list
+resources=()
+
+# performance operator namespace
+resources+=(ns/${PAO_NAMESPACE})
+
+# performance operator profiles
+resources+=(performanceprofile)
+
+# machine/node resources
+resources+=(nodes machineconfigs machineconfigpools featuregates kubeletconfigs tuneds)
+
+# run the collection of resources using must-gather
+for resource in ${resources[@]}; do
+  /usr/bin/oc adm inspect --dest-dir must-gather --all-namespaces ${resource}
+done
+
+# Collect nodes details
+/usr/bin/gather_nodes
+
+exit 0
+

--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+check_node_gather_pods_ready() {
+    line=$(oc get ds perf-node-gather-daemonset -o=custom-columns=DESIRED:.status.desiredNumberScheduled,READY:.status.numberReady --no-headers -n perf-node-gather)
+
+    IFS=$' '
+    read desired ready <<< $line
+    IFS=$'\n'
+
+    if [[ $ready -eq $desired ]]
+    then
+       return 0
+    else
+       return 1
+    fi
+}
+
+IFS=$'\n'
+
+BASE_COLLECTION_PATH="/must-gather"
+NODES_PATH=${BASE_COLLECTION_PATH}/nodes
+mkdir -p ${NODES_PATH}
+NAMESPACE_MANIFEST="/etc/node-gather/namespace.yaml"
+SERVICEACCOUNT_MANIFEST="/etc/node-gather/serviceaccount.yaml"
+DAEMONSET_MANIFEST="/etc/node-gather/daemonset.yaml"
+NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+POD_NAME=$(oc get pods --field-selector=status.podIP=$(hostname -I) -n $NAMESPACE -o'custom-columns=name:metadata.name' --no-headers)
+MUST_GATHER_IMAGE=$(oc get pod -n $NAMESPACE $POD_NAME -o jsonpath="{.spec.initContainers[0].image}")
+
+sed -i -e "s#MUST_GATHER_IMAGE#$MUST_GATHER_IMAGE#" $DAEMONSET_MANIFEST
+
+oc create -f $NAMESPACE_MANIFEST
+oc create -f $SERVICEACCOUNT_MANIFEST
+oc adm policy add-scc-to-user privileged -n perf-node-gather -z perf-node-gather
+oc create -f $DAEMONSET_MANIFEST
+
+COUNTER=0
+until check_node_gather_pods_ready || [ $COUNTER -eq 300 ]; do
+   (( COUNTER++ ))
+   sleep 1
+done
+
+for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName --no-headers --field-selector=status.phase!=Running -n perf-node-gather)
+do
+    echo "Failed to collect perf-node-gather data from node ${line} due to pod scheduling failure." >> ${NODES_PATH}/skipped_nodes.txt
+done
+
+for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name --no-headers --field-selector=status.phase=Running -n perf-node-gather)
+do
+    node=$(echo $line | awk -F ' ' '{print $1}')
+    pod=$(echo $line | awk -F ' ' '{print $2}')
+    NODE_PATH=${NODES_PATH}/$node
+    mkdir -p ${NODE_PATH}
+
+    oc exec $pod -n perf-node-gather -- lspci -nvv 2>/dev/null >> $NODE_PATH/lspci
+    oc exec $pod -n perf-node-gather -- lscpu -e 2>/dev/null >> $NODE_PATH/lscpu
+    oc exec $pod -n perf-node-gather -- cat /proc/cmdline 2>/dev/null >> $NODE_PATH/proc_cmdline
+done
+
+# Collect journal logs for specified units for all nodes
+NODE_UNITS=(kubelet)
+for NODE in $(oc get nodes --no-headers -o custom-columns=':metadata.name'); do
+    NODE_PATH=${NODES_PATH}/$NODE
+    mkdir -p ${NODE_PATH}
+    for UNIT in ${NODE_UNITS[@]}; do
+        oc adm node-logs $NODE -u $UNIT > ${NODE_PATH}/${NODE}_logs_$UNIT &
+    done
+done
+
+oc delete -f $DAEMONSET_MANIFEST
+oc delete -f $SERVICEACCOUNT_MANIFEST
+oc delete -f $NAMESPACE_MANIFEST

--- a/must-gather/collection-scripts/namespace
+++ b/must-gather/collection-scripts/namespace
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+function namespace() {
+  # we control the subs, so this is the most reliable way to get the namespace
+  ns=$( oc get subs -A --field-selector metadata.name='performance-addon-operator-subscription' -o=jsonpath='{.items[0].metadata.namespace}{"\n"}' )
+  # trying again with the pods, which are _usually_ reliable - but users can change them
+  [ -z "${ns}" ] && ns=$( oc get pods -A -l name='performance-operator' -o=jsonpath='{.items[0].metadata.namespace}{"\n"}' )
+  # if namespace not found, fallback to the old default
+  [ -z "${ns}" ] && ns="openshift-performance-addon"
+  echo ${ns}
+}

--- a/must-gather/collection-scripts/version
+++ b/must-gather/collection-scripts/version
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+function version() {
+  # get version from image
+  version=$( \
+    oc status | grep '^pod' | \
+    sed -n -r -e 's/.*([[:digit:]]+\.[[:digit:]]+(:?\.[[:digit:]])?(:?-[^@]+)?).*/\1/p' \
+  )
+
+  # if version not found, fallback to imageID
+  [ -z "${version}" ] && version=$(oc status | grep '^pod.*runs' | sed -r -e 's/^pod.*runs //')
+
+  # if version still not found, use Unknown
+  [ -z "${version}" ] && version="Unknown"
+
+  echo ${version}
+}

--- a/must-gather/node-gather/daemonset.yaml
+++ b/must-gather/node-gather/daemonset.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: perf-node-gather-daemonset
+  namespace: perf-node-gather
+  labels:
+spec:
+  selector:
+    matchLabels:
+      name: perf-node-gather-daemonset
+  template:
+    metadata:
+      labels:
+        name: perf-node-gather-daemonset
+    spec:
+      serviceaccount: perf-node-gather
+      serviceAccountName: perf-node-gather
+      terminationGracePeriodSeconds: 0
+      hostNetwork: true
+      containers:
+      - name: node-probe
+        image: MUST_GATHER_IMAGE
+        command: ["/bin/bash", "-c", "echo ok > /tmp/healthy && sleep INF"]
+        imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        readinessProbe:
+          exec:
+            command:
+              - cat
+              - /tmp/healthy
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        securityContext:
+          privileged: true

--- a/must-gather/node-gather/namespace.yaml
+++ b/must-gather/node-gather/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: perf-node-gather

--- a/must-gather/node-gather/serviceaccount.yaml
+++ b/must-gather/node-gather/serviceaccount.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: perf-node-gather
+  namespace: perf-node-gather
+

--- a/openshift-ci/Dockerfile.must-gather
+++ b/openshift-ci/Dockerfile.must-gather
@@ -1,0 +1,18 @@
+FROM quay.io/openshift/origin-must-gather:4.6.0 AS builder
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+RUN microdnf install -y pciutils util-linux hostname rsync
+
+# Copy must-gather required binaries
+COPY --from=builder /usr/bin/openshift-must-gather /usr/bin/openshift-must-gather
+COPY --from=builder /usr/bin/oc /usr/bin/oc
+
+# Save original gather script
+COPY --from=builder /usr/bin/gather* /usr/bin/
+RUN mv /usr/bin/gather /usr/bin/gather_original
+
+ARG COLLECTION_SCRIPTS_DIR=must-gather/collection-scripts
+ARG NODE_GATHER_MANIFESTS_DIR=must-gather/node-gather
+COPY ${COLLECTION_SCRIPTS_DIR}/* /usr/bin/
+COPY ${NODE_GATHER_MANIFESTS_DIR} /etc/node-gather
+ENTRYPOINT /usr/bin/gather


### PR DESCRIPTION
The performance-operator can be deployed in a namespace
different from the one we recommend, hence the `gather`
logic could be a bit smarter and try to figure out.

must-gather collects basic information about
the HW topology of the nodes. We use standard system utilities like
`lspci -nvv` and `lscpu -e`.
We use the same approach pioneered in cnv-must-gather to collect
data from worker nodes.

When we reach the `gather_node` stage, we create a daemonset which
will run on each worker nodes. Thanks to this daemonset, we create
hollow empty privileged pods. Privileged pods are needed to be able
to access the worker node `/proc` and `/sys` pseudofs.

Once the daemonset is ready, we iterate over all the worker nodes
and we run our collection programs (lscpu, lspci...) in the privileged
pods.
When we collected all the information we need, we clean up after
ourselves removing the daemonset with all the dependencies.

This approach is complex but minimizes the time on which privileged
pods run in the cluster.

Further testing revealed we don't actually need the host mounts
in the current scenario (just run lspci and lscpu).
We already get /proc and /sys out of the box.

Also, remapping the host /proc inside the container was just wrong
and sometime lead to
```
container create failed: time="2020-06-17T09:06:26Z" level=error msg="container_linux.go:349: starting container process caused \"set process label: open /proc/self/task/1/attr/exec: no such file or directory\""
container_linux.go:349: starting container process caused "set process label: open /proc/self/task/1/attr/exec: no such file or directory"
```

It's just simpler and safer to avoid the mount until there is
a clear and obvious need for them.

Signed-off-by: Francesco Romani <fromani@redhat.com>