### PR TITLE
Deploy the custom runtime via the operator

### DIFF
--- a/build/assets/configs/99-runtimes.conf
+++ b/build/assets/configs/99-runtimes.conf
@@ -1,0 +1,14 @@
+# We should copy paste the default runtime because this snippet will override the whole runtimes section
+[crio.runtime.runtimes.runc]
+runtime_path = ""
+runtime_type = "oci"
+runtime_root = "/run/runc"
+
+# The CRI-O will check the runtime handler name under the code and will activate high-performance features,
+# like CPU load balancing.
+# We should provide the runtime_path because we need to inform that we want to re-use runc binary and we
+# do not have high-performance binary under the $PATH that will point to it.
+[crio.runtime.runtimes.high-performance]
+runtime_path = "/bin/runc"
+runtime_type = "oci"
+runtime_root = "/run/runc"

--- a/deploy/olm-catalog/performance-addon-operator/4.6.0/performance-addon-operator.v4.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.6.0/performance-addon-operator.v4.6.0.clusterserviceversion.yaml
@@ -97,6 +97,12 @@ spec:
           - tuneds
           verbs:
           - '*'
+        - apiGroups:
+          - node.k8s.io
+          resources:
+          - runtimeclasses
+          verbs:
+          - '*'
         serviceAccountName: performance-operator
       deployments:
       - name: performance-operator

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -32,6 +32,12 @@ rules:
   - tuneds
   verbs:
   - '*'
+- apiGroups:
+  - node.k8s.io
+  resources:
+  - runtimeclasses
+  verbs:
+  - '*'
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -3,13 +3,16 @@ package __performance
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	. "github.com/onsi/ginkgo"
@@ -23,6 +26,7 @@ import (
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/pods"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
 	performancev1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
 )
 
 var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
@@ -172,6 +176,133 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 			table.Entry("Non-guaranteed POD can work on any CPU", false),
 			table.Entry("Guaranteed POD should work on isolated cpu", true),
 		)
+	})
+
+	When("pod runs with the CPU load balancing runtime class", func() {
+		var testpod *corev1.Pod
+		var defaultFlags []int
+
+		getCPUSchedulingDomainFlags := func(cpu int) ([]int, error) {
+			cmd := []string{"/bin/bash", "-c", fmt.Sprintf("cat /proc/sys/kernel/sched_domain/cpu%d/domain*/flags", cpu)}
+			out, err := nodes.ExecCommandOnNode(cmd, workerRTNode)
+			if err != nil {
+				return nil, err
+			}
+
+			var domainsFlags []int
+			for _, domainFlags := range strings.Split(out, "\n") {
+				flags, err := strconv.Atoi(domainFlags)
+				if err != nil {
+					return nil, err
+				}
+				domainsFlags = append(domainsFlags, flags)
+			}
+
+			sort.Ints(domainsFlags)
+			return domainsFlags, nil
+		}
+
+		BeforeEach(func() {
+			// get the default value for sched_domain flags, we will check the flags only for the CPU 0, because on the
+			// clean system it should be the same for all CPUs
+			var err error
+			defaultFlags, err = getCPUSchedulingDomainFlags(0)
+			Expect(err).ToNot(HaveOccurred())
+
+			testpod = pods.GetTestPod()
+			testpod.Annotations = map[string]string{
+				"cpu-load-balancing.crio.io": "true",
+			}
+			testpod.Namespace = testutils.NamespaceTesting
+
+			cpus := resource.MustParse("1")
+			memory := resource.MustParse("256Mi")
+
+			// change pod resource requirements, to change the pod QoS class to guaranteed
+			testpod.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    cpus,
+					corev1.ResourceMemory: memory,
+				},
+			}
+
+			// use the CPU load balancing runtime class
+			runtimeClassName := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
+			testpod.Spec.RuntimeClassName = &runtimeClassName
+		})
+
+		AfterEach(func() {
+			// it possible that the pod already was deleted as part of the test, in this case we want to skip teardown
+			key := types.NamespacedName{
+				Name:      testpod.Name,
+				Namespace: testpod.Namespace,
+			}
+			err := testclient.Client.Get(context.TODO(), key, testpod)
+			if errors.IsNotFound(err) {
+				return
+			}
+
+			err = testclient.Client.Delete(context.TODO(), testpod)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = pods.WaitForDeletion(testpod, 60*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("[test_id:32646] should disable CPU load balancing for CPU's used by the pod", func() {
+			By("Starting the pod")
+			err := testclient.Client.Create(context.TODO(), testpod)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = pods.WaitForCondition(testpod, corev1.PodReady, corev1.ConditionTrue, 10*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Getting the container ID")
+			containerID, err := pods.GetContainerIDByName(testpod, "test")
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Getting the container cpuset.cpus cgroup")
+			cmd := []string{"/bin/bash", "-c", fmt.Sprintf("find /rootfs/sys/fs/cgroup/cpuset/ -name *%s*", containerID)}
+			containerCgroup, err := nodes.ExecCommandOnNode(cmd, workerRTNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Checking what CPU the pod is using")
+			cmd = []string{"/bin/bash", "-c", fmt.Sprintf("cat %s/cpuset.cpus", containerCgroup)}
+			output, err := nodes.ExecCommandOnNode(cmd, workerRTNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			cpu, err := strconv.Atoi(output)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Getting the CPU scheduling flags")
+			flags, err := getCPUSchedulingDomainFlags(cpu)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verifying that the CPU load balancing was disabled")
+			Expect(len(flags)).To(Equal(len(defaultFlags)))
+			// the CPU flags should be almost the same except the LSB that should be disabled
+			for i := range flags {
+				Expect(flags[i]).To(Equal(defaultFlags[i] - 1))
+			}
+
+			By("Deleting the pod")
+			err = testclient.Client.Delete(context.TODO(), testpod)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = pods.WaitForDeletion(testpod, 60*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Getting the CPU scheduling flags")
+			flags, err = getCPUSchedulingDomainFlags(cpu)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verifying that the CPU load balancing was enabled back")
+			Expect(len(flags)).To(Equal(len(defaultFlags)))
+			// the CPU scheduling flags should be restored to the default values
+			for i := range flags {
+				Expect(flags[i]).To(Equal(defaultFlags[i]))
+			}
+		})
 	})
 })
 

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -5,19 +5,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-
-	"k8s.io/apimachinery/pkg/runtime"
+	"path/filepath"
 
 	"github.com/coreos/go-systemd/unit"
 	igntypes "github.com/coreos/ignition/config/v2_2/types"
-
 	performancev1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
 	profile2 "github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/profile"
-
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 )
 
@@ -32,9 +30,13 @@ const (
 	MCKernelRT = "realtime"
 	// MCKernelDefault is the value of the kernel setting in MachineConfig for the default kernel
 	MCKernelDefault = "default"
+	// HighPerformanceRuntime contains the name of the CPU load balancing runtime
+	HighPerformanceRuntime = "high-performance"
 
 	hugepagesAllocation = "hugepages-allocation"
 	bashScriptsDir      = "/usr/local/bin"
+	crioConfd           = "/etc/crio/crio.conf.d"
+	crioRuntimesConfig  = "99-runtimes"
 )
 
 const (
@@ -51,11 +53,10 @@ const (
 )
 
 const (
-	systemdServiceKubelet      = "kubelet.service"
-	systemdServiceTypeOneshot  = "oneshot"
-	systemdTargetMultiUser     = "multi-user.target"
-	systemdTargetNetworkOnline = "network-online.target"
-	systemdTrue                = "true"
+	systemdServiceKubelet     = "kubelet.service"
+	systemdServiceTypeOneshot = "oneshot"
+	systemdTargetMultiUser    = "multi-user.target"
+	systemdTrue               = "true"
 )
 
 const (
@@ -104,8 +105,6 @@ func New(assetsDir string, profile *performancev1.PerformanceProfile) (*machinec
 }
 
 func getIgnitionConfig(assetsDir string, profile *performancev1.PerformanceProfile) (*igntypes.Config, error) {
-
-	mode := 0700
 	ignitionConfig := &igntypes.Config{
 		Ignition: igntypes.Ignition{
 			Version: defaultIgnitionVersion,
@@ -115,24 +114,25 @@ func getIgnitionConfig(assetsDir string, profile *performancev1.PerformanceProfi
 		},
 	}
 
+	// add script files under the node /usr/local/bin directory
+	mode := 0700
 	for _, script := range []string{hugepagesAllocation} {
-		content, err := ioutil.ReadFile(fmt.Sprintf("%s/scripts/%s.sh", assetsDir, script))
-		if err != nil {
+		src := filepath.Join(assetsDir, "scripts", fmt.Sprintf("%s.sh", script))
+		if err := addFile(ignitionConfig, src, getBashScriptPath(script), &mode); err != nil {
 			return nil, err
 		}
-		contentBase64 := base64.StdEncoding.EncodeToString(content)
-		ignitionConfig.Storage.Files = append(ignitionConfig.Storage.Files, igntypes.File{
-			Node: igntypes.Node{
-				Filesystem: defaultFileSystem,
-				Path:       getBashScriptPath(script),
-			},
-			FileEmbedded1: igntypes.FileEmbedded1{
-				Contents: igntypes.FileContents{
-					Source: fmt.Sprintf("%s,%s", defaultIgnitionContentSource, contentBase64),
-				},
-				Mode: &mode,
-			},
-		})
+	}
+
+	// add crio config snippet under the node /etc/crio/crio.conf.d/ directory
+	crioConfdRuntimesMode := 0644
+	config := fmt.Sprintf("%s.conf", crioRuntimesConfig)
+	if err := addFile(
+		ignitionConfig,
+		filepath.Join(assetsDir, "configs", config),
+		filepath.Join(crioConfd, config),
+		&crioConfdRuntimesMode,
+	); err != nil {
+		return nil, err
 	}
 
 	if profile.Spec.HugePages != nil {
@@ -222,4 +222,25 @@ func getHugepagesAllocationUnitOptions(hugepagesSize string, hugepagesCount int3
 		// WantedBy
 		unit.NewUnitOption(systemdSectionInstall, systemdWantedBy, systemdTargetMultiUser),
 	}
+}
+
+func addFile(ignitionConfig *igntypes.Config, src string, dst string, mode *int) error {
+	content, err := ioutil.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	contentBase64 := base64.StdEncoding.EncodeToString(content)
+	ignitionConfig.Storage.Files = append(ignitionConfig.Storage.Files, igntypes.File{
+		Node: igntypes.Node{
+			Filesystem: defaultFileSystem,
+			Path:       dst,
+		},
+		FileEmbedded1: igntypes.FileEmbedded1{
+			Contents: igntypes.FileContents{
+				Source: fmt.Sprintf("%s,%s", defaultIgnitionContentSource, contentBase64),
+			},
+			Mode: mode,
+		},
+	})
+	return nil
 }

--- a/pkg/controller/performanceprofile/components/runtimeclass/runtimeclass.go
+++ b/pkg/controller/performanceprofile/components/runtimeclass/runtimeclass.go
@@ -1,0 +1,27 @@
+package runtimeclass
+
+import (
+	performancev1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
+
+	nodev1beta1 "k8s.io/api/node/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// New returns a new RuntimeClass object
+func New(profile *performancev1.PerformanceProfile, handler string) *nodev1beta1.RuntimeClass {
+	name := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
+	return &nodev1beta1.RuntimeClass{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "RuntimeClass",
+			APIVersion: "node.k8s.io/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Handler: handler,
+		Scheduling: &nodev1beta1.Scheduling{
+			NodeSelector: profile.Spec.NodeSelector,
+		},
+	}
+}


### PR DESCRIPTION
Functionality to disable/enable the CPU load balancing will be implemented on the CRI-O level, the code under the CRI-O will disable/enable CPU load balancing only when:

- the pod uses `performance-<profile_name>` runtime class
- the pod has `cpu-load-balancing.crio.io: true` annotation

The performance-addon-operator will be responsible for the creation of the high-performance runtime handler config snippet, it will have the same content as default runtime handler, under relevant nodes, and for creation of the high-performance runtime class under the cluster.

A user will be responsible for specifying the relevant runtime class and annotation under the pod.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>