### PR TITLE
must-gather: add basic doc in README

### DIFF
--- a/must-gather/README.md
+++ b/must-gather/README.md
@@ -1,0 +1,19 @@
+About collecting container-native performance-related data
+==========================================================
+
+You can use the `oc adm must-gather` CLI command to collect information about your cluster, including features and objects associated with the areas managed by performance-addon-operator.
+
+In addition to the performance-operator logs and manifests, the command will collect basic information about the hardware topology of the worker nodes.
+This information is useful to understand and verify resource allocation to pods, whose proper alignment is critical for low-latency workloads.
+
+To collect the container-native performance-related data with must-gather, you must specify the extra image using the `--image` option.
+Example command line:
+```bash
+oc adm must-gather --image=quay.io/openshift-kni/performance-addon-operator-must-gather:latest
+```
+
+To collect the cluster-related data and *additionally* the performance-related data, you can use multiple `--image` options like in this example:
+```bash
+oc adm must-gather --image=quay.io/openshift/origin-must-gather --image=quay.io/openshift-kni/performance-addon-operator-must-gather:latest
+```
+


### PR DESCRIPTION
The documentation is minimal because the content is well covered by the OCP docs.

Signed-off-by: Francesco Romani <fromani@redhat.com>