### PR TITLE
Remove hugepages multiple sizes validation

### DIFF
--- a/functests/0_config/config.go
+++ b/functests/0_config/config.go
@@ -151,6 +151,10 @@ func testProfile() *performancev1.PerformanceProfile {
 						Count: 1,
 						Node:  pointer.Int32Ptr(0),
 					},
+					{
+						Size:  "2M",
+						Count: 128,
+					},
 				},
 			},
 			NodeSelector: testutils.NodeSelectorLabels,

--- a/functests/1_performance/hugepages.go
+++ b/functests/1_performance/hugepages.go
@@ -47,6 +47,8 @@ var _ = Describe("[performance]Hugepages", func() {
 		Expect(profile.Spec.HugePages).ToNot(BeNil())
 	})
 
+	// We have multiple hugepages e2e tests under the upstream, so the only thing that we should check, if the PAO configure
+	// correctly number of hugepages that will be available on the node
 	Context("[rfe_id:27369]when NUMA node specified", func() {
 		It("[test_id:27752][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] should be allocated on the specifed NUMA node ", func() {
 			for _, page := range profile.Spec.HugePages.Pages {
@@ -57,14 +59,10 @@ var _ = Describe("[performance]Hugepages", func() {
 				hugepagesSize, err := machineconfig.GetHugepagesSizeKilobytes(page.Size)
 				Expect(err).ToNot(HaveOccurred())
 
-				availableHugepagesFile := fmt.Sprintf("/sys/devices/system/node/node%d/hugepages/hugepages-%skB/nr_hugepages", *page.Node, hugepagesSize)
+				availableHugepagesFile := fmt.Sprintf("/sys/kernel/mm/hugepages/hugepages-%skB/nr_hugepages", hugepagesSize)
 				nrHugepages := checkHugepagesStatus(availableHugepagesFile, workerRTNode)
 
-				if discovery.Enabled() && nrHugepages != 0 {
-					Skip("Skipping test since other guests might reside in the cluster affecting results")
-				}
-
-				freeHugepagesFile := fmt.Sprintf("/sys/devices/system/node/node%d/hugepages/hugepages-%skB/free_hugepages", *page.Node, hugepagesSize)
+				freeHugepagesFile := fmt.Sprintf("/sys/kernel/mm/hugepages/hugepages-%skB/nr_hugepages", hugepagesSize)
 				freeHugepages := checkHugepagesStatus(freeHugepagesFile, workerRTNode)
 
 				Expect(int32(nrHugepages)).To(Equal(page.Count), "The number of available hugepages should be equal to the number in performance profile")
@@ -73,16 +71,34 @@ var _ = Describe("[performance]Hugepages", func() {
 		})
 	})
 
-	// TODO: enable it once https://github.com/kubernetes/kubernetes/pull/84051
-	// is available under the openshift
-	// Context("when NUMA node unspecified", func() {
-	// 	It("should be allocated equally among NUMA nodes", func() {
-	// 		command := []string{"cat", pathHugepages2048kB}
-	// 		nrHugepages, err := nodes.ExecCommandOnMachineConfigDaemon(testclient.Client, workerRTNode, command)
-	// 		Expect(err).ToNot(HaveOccurred())
-	// 		Expect(string(nrHugepages)).To(Equal("128"))
-	// 	})
-	// })
+	Context("with multiple sizes", func() {
+		It("should be supported and available for the container usage", func() {
+			for _, page := range profile.Spec.HugePages.Pages {
+				hugepagesSize, err := machineconfig.GetHugepagesSizeKilobytes(page.Size)
+				Expect(err).ToNot(HaveOccurred())
+
+				availableHugepagesFile := fmt.Sprintf("/sys/kernel/mm/hugepages/hugepages-%skB/nr_hugepages", hugepagesSize)
+				if page.Node != nil {
+					availableHugepagesFile = fmt.Sprintf("/sys/devices/system/node/node%d/hugepages/hugepages-%skB/nr_hugepages", *page.Node, hugepagesSize)
+				}
+				nrHugepages := checkHugepagesStatus(availableHugepagesFile, workerRTNode)
+
+				if discovery.Enabled() && nrHugepages != 0 {
+					Skip("Skipping test since other guests might reside in the cluster affecting results")
+				}
+
+				freeHugepagesFile := fmt.Sprintf("/sys/kernel/mm/hugepages/hugepages-%skB/free_hugepages", hugepagesSize)
+				if page.Node != nil {
+					freeHugepagesFile = fmt.Sprintf("/sys/devices/system/node/node%d/hugepages/hugepages-%skB/free_hugepages", *page.Node, hugepagesSize)
+				}
+
+				freeHugepages := checkHugepagesStatus(freeHugepagesFile, workerRTNode)
+
+				Expect(int32(nrHugepages)).To(Equal(page.Count), "The number of available hugepages should be equal to the number in performance profile")
+				Expect(nrHugepages).To(Equal(freeHugepages), "On idle system the number of available hugepages should be equal to free hugepages")
+			}
+		})
+	})
 
 	Context("[rfe_id:27354]Huge pages support for container workloads", func() {
 		var testpod *corev1.Pod

--- a/pkg/controller/performanceprofile/components/profile/profile.go
+++ b/pkg/controller/performanceprofile/components/profile/profile.go
@@ -3,7 +3,7 @@ package profile
 import (
 	"fmt"
 
-	"github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
+	v1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 )
@@ -120,16 +120,11 @@ func validateHugepages(hugepages *v1.HugePages) error {
 			return validationError(fmt.Sprintf("hugepages default size should be equal to %q or %q", hugepagesSize1G, hugepagesSize2M))
 		}
 	}
-	hugepagesSizes := map[v1.HugePageSize]string{}
-	for _, page := range hugepages.Pages {
-		hugepagesSizes[page.Size] = ""
-	}
 
-	// TODO: this validation should be removed, once https://github.com/kubernetes/kubernetes/pull/84051
-	// is available under the openshift
-	// validate that we do not have allocations of hugepages of different sizes
-	if len(hugepagesSizes) > 1 {
-		return validationError("allocation of hugepages with different sizes not supported")
+	for _, page := range hugepages.Pages {
+		if page.Size != hugepagesSize1G && page.Size != hugepagesSize2M {
+			return validationError(fmt.Sprintf("the page size should be equal to %q or %q", hugepagesSize1G, hugepagesSize2M))
+		}
 	}
 
 	return nil

--- a/pkg/controller/performanceprofile/components/profile/profile_test.go
+++ b/pkg/controller/performanceprofile/components/profile/profile_test.go
@@ -1,7 +1,9 @@
 package profile
 
 import (
-	"github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
+	"fmt"
+
+	v1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
 	"k8s.io/utils/pointer"
 
@@ -75,15 +77,15 @@ var _ = Describe("PerformanceProfile", func() {
 			Expect(err.Error()).To(ContainSubstring("hugepages default size should be equal"))
 		})
 
-		It("should reject hugepages allocation with different sizes", func() {
+		It("should reject hugepages allocation with unexpected page size", func() {
 			profile.Spec.HugePages.Pages = append(profile.Spec.HugePages.Pages, v1.HugePage{
 				Count: 128,
 				Node:  pointer.Int32Ptr(0),
-				Size:  v1.HugePageSize("2M"),
+				Size:  v1.HugePageSize("14M"),
 			})
 			err := ValidateParameters(profile)
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("allocation of hugepages with different sizes not supported"))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("the page size should be equal to %q or %q", hugepagesSize1G, hugepagesSize2M)))
 		})
 	})
 
@@ -132,9 +134,7 @@ var _ = Describe("PerformanceProfile", func() {
 			Expect(v).To(Equal(NodeSelectorRole))
 
 		})
-
 	})
-
 })
 
 func setValidNodeSelector(profile *v1.PerformanceProfile) {


### PR DESCRIPTION
Multiple hugepages sizes support feature was promoted to beta under
the Kubernetes 1.19, it gives us possibility to support multiple
hugepages sizes under the PAO, without need to enable additional
feature gate.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>