### PR TITLE
Make the performance tests work in discovery mode

### DIFF
--- a/functests/0_config/config.go
+++ b/functests/0_config/config.go
@@ -44,11 +44,7 @@ var _ = Describe("[performance][config] Performance configuration", func() {
 
 		if discovery.Enabled() {
 			var err error
-			performanceProfile, err = profiles.GetByNodeLabels(
-				map[string]string{
-					fmt.Sprintf("%s/%s", testutils.LabelRole, testutils.RoleWorkerCNF): "",
-				},
-			)
+			performanceProfile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 			Expect(err).ToNot(HaveOccurred(), "Failed finding a performance profile in discovery mode")
 			profileAlreadyExists = true
 			klog.Info("Discovery mode: consuming a deployed performance profile from the cluster")
@@ -137,9 +133,6 @@ func testProfile() *performancev1alpha1.PerformanceProfile {
 	isolated := performancev1alpha1.CPUSet("1-3")
 	hugePagesSize := performancev1alpha1.HugePageSize("1G")
 
-	cnfRoleLabel := fmt.Sprintf("%s/%s", testutils.LabelRole, utils.RoleWorkerCNF)
-	nodeSelector := map[string]string{cnfRoleLabel: ""}
-
 	return &performancev1alpha1.PerformanceProfile{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PerformanceProfile",
@@ -163,7 +156,7 @@ func testProfile() *performancev1alpha1.PerformanceProfile {
 					},
 				},
 			},
-			NodeSelector: nodeSelector,
+			NodeSelector: testutils.NodeSelectorLabels,
 			RealTimeKernel: &performancev1alpha1.RealTimeKernel{
 				Enabled: pointer.BoolPtr(true),
 			},

--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -33,18 +33,14 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 	var reservedCPUSet cpuset.CPUSet
 
 	BeforeEach(func() {
-		workerRTNodes, err := nodes.GetByRole(testutils.RoleWorkerCNF)
+		workerRTNodes, err := nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
 		Expect(workerRTNodes).ToNot(BeEmpty())
 		workerRTNode = &workerRTNodes[0]
 
-		profile, err = profiles.GetByNodeLabels(
-			map[string]string{
-				fmt.Sprintf("%s/%s", testutils.LabelRole, testutils.RoleWorkerCNF): "",
-			},
-		)
+		profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(profile.Spec.HugePages).ToNot(BeNil())
 

--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/onsi/gomega"
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/images"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/pods"
@@ -100,6 +101,16 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 
 	Describe("[test_id:27492][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] Verification of cpu manager functionality", func() {
 		var testpod *corev1.Pod
+
+		testutils.BeforeAll(func() {
+			if discovery.Enabled() {
+				profile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
+				Expect(err).ToNot(HaveOccurred())
+				if len(*profile.Spec.CPU.Isolated) == 1 {
+					Skip("Skipping tests since there are insufficant isolated cores to create a stress pod")
+				}
+			}
+		})
 
 		AfterEach(func() {
 			err := testclient.Client.Delete(context.TODO(), testpod)

--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -101,14 +101,22 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 
 	Describe("[test_id:27492][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] Verification of cpu manager functionality", func() {
 		var testpod *corev1.Pod
+		var discoveryFailed bool
 
 		testutils.BeforeAll(func() {
+			discoveryFailed = false
 			if discovery.Enabled() {
 				profile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 				Expect(err).ToNot(HaveOccurred())
 				if len(*profile.Spec.CPU.Isolated) == 1 {
-					Skip("Skipping tests since there are insufficant isolated cores to create a stress pod")
+					discoveryFailed = true
 				}
+			}
+		})
+
+		BeforeEach(func() {
+			if discoveryFailed {
+				Skip("Skipping tests since there are insufficant isolated cores to create a stress pod")
 			}
 		})
 

--- a/functests/1_performance/hugepages.go
+++ b/functests/1_performance/hugepages.go
@@ -34,18 +34,14 @@ var _ = Describe("[performance]Hugepages", func() {
 
 	BeforeEach(func() {
 		var err error
-		workerRTNodes, err := nodes.GetByRole(testutils.RoleWorkerCNF)
+		workerRTNodes, err := nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
 		Expect(workerRTNodes).ToNot(BeEmpty())
 		workerRTNode = &workerRTNodes[0]
 
-		profile, err = profiles.GetByNodeLabels(
-			map[string]string{
-				fmt.Sprintf("%s/%s", testutils.LabelRole, testutils.RoleWorkerCNF): "",
-			},
-		)
+		profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(profile.Spec.HugePages).ToNot(BeNil())
 	})

--- a/functests/1_performance/hugepages.go
+++ b/functests/1_performance/hugepages.go
@@ -16,6 +16,7 @@ import (
 
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/images"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/pods"
@@ -59,6 +60,10 @@ var _ = Describe("[performance]Hugepages", func() {
 				availableHugepagesFile := fmt.Sprintf("/sys/devices/system/node/node%d/hugepages/hugepages-%skB/nr_hugepages", *page.Node, hugepagesSize)
 				nrHugepages := checkHugepagesStatus(availableHugepagesFile, workerRTNode)
 
+				if discovery.Enabled() && nrHugepages != 0 {
+					Skip("Skipping test since other guests might reside in the cluster affecting results")
+				}
+
 				freeHugepagesFile := fmt.Sprintf("/sys/devices/system/node/node%d/hugepages/hugepages-%skB/free_hugepages", *page.Node, hugepagesSize)
 				freeHugepages := checkHugepagesStatus(freeHugepagesFile, workerRTNode)
 
@@ -98,6 +103,9 @@ var _ = Describe("[performance]Hugepages", func() {
 			By("checking hugepages usage in bytes - should be 0 on idle system")
 			usageHugepagesFile := fmt.Sprintf("/rootfs/sys/fs/cgroup/hugetlb/hugetlb.%sB.usage_in_bytes", hpSize)
 			usageHugepages := checkHugepagesStatus(usageHugepagesFile, workerRTNode)
+			if discovery.Enabled() && usageHugepages != 0 {
+				Skip("Skipping test since other guests might reside in the cluster affecting results")
+			}
 			Expect(usageHugepages).To(Equal(0))
 
 			By("running the POD and waiting while it's installing testing tools")

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -45,16 +45,12 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 
 	BeforeEach(func() {
 		var err error
-		workerRTNodes, err = nodes.GetByRole(testutils.RoleWorkerCNF)
+		workerRTNodes, err = nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for node with role %q: %v", testutils.RoleWorkerCNF, err))
 		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
 		Expect(workerRTNodes).ToNot(BeEmpty(), fmt.Sprintf("no nodes with role %q found", testutils.RoleWorkerCNF))
-		profile, err = profiles.GetByNodeLabels(
-			map[string]string{
-				fmt.Sprintf("%s/%s", testutils.LabelRole, testutils.RoleWorkerCNF): "",
-			},
-		)
+		profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/functests/1_performance/rt-kernel.go
+++ b/functests/1_performance/rt-kernel.go
@@ -2,7 +2,6 @@ package __performance
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -48,9 +47,7 @@ var _ = Describe("[performance]RT Kernel", func() {
 				testpod.Namespace = testutils.NamespaceTesting
 				testpod.Spec.Containers[0].Command = []string{"uname", "-a"}
 				testpod.Spec.RestartPolicy = corev1.RestartPolicyNever
-				testpod.Spec.NodeSelector = map[string]string{
-					fmt.Sprintf("%s/%s", testutils.LabelRole, testutils.RoleWorkerCNF): "",
-				}
+				testpod.Spec.NodeSelector = testutils.NodeSelectorLabels
 
 				if err := testclient.Client.Create(context.TODO(), testpod); err != nil {
 					return ""

--- a/functests/1_performance/rt-kernel.go
+++ b/functests/1_performance/rt-kernel.go
@@ -21,9 +21,9 @@ import (
 
 var _ = Describe("[performance]RT Kernel", func() {
 	var testpod *corev1.Pod
-	var profile *performancev1alpha1.PerformanceProfile
 
 	testutils.BeforeAll(func() {
+		profile := &performancev1alpha1.PerformanceProfile{}
 		key := types.NamespacedName{
 			Name: testutils.PerformanceProfileName,
 		}

--- a/functests/1_performance/topology_manager.go
+++ b/functests/1_performance/topology_manager.go
@@ -1,8 +1,6 @@
 package __performance
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -21,16 +19,12 @@ var _ = Describe("[rfe_id:27350][performance]Topology Manager", func() {
 
 	BeforeEach(func() {
 		var err error
-		workerRTNodes, err = nodes.GetByRole(testutils.RoleWorkerCNF)
+		workerRTNodes, err = nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
 		Expect(workerRTNodes).ToNot(BeEmpty())
-		profile, err = profiles.GetByNodeLabels(
-			map[string]string{
-				fmt.Sprintf("%s/%s", testutils.LabelRole, testutils.RoleWorkerCNF): "",
-			},
-		)
+		profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/functests/1_performance/topology_manager.go
+++ b/functests/1_performance/topology_manager.go
@@ -1,6 +1,8 @@
 package __performance
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 

--- a/functests/2_performance_update/updating_profile.go
+++ b/functests/2_performance_update/updating_profile.go
@@ -201,10 +201,10 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		newNodeSelector := map[string]string{newLabel: ""}
 
 		testutils.BeforeAll(func() {
-			nonRTWorkerNodes, err := nodes.GetNonRTWorkers()
+			nonPerformancesWorkers, err := nodes.GetNonPerformancesWorkers()
 			Expect(err).ToNot(HaveOccurred())
-			if len(nonRTWorkerNodes) != 0 {
-				newCnfNode = &nonRTWorkerNodes[0]
+			if len(nonPerformancesWorkers) != 0 {
+				newCnfNode = &nonPerformancesWorkers[0]
 			}
 		})
 

--- a/functests/2_performance_update/updating_profile.go
+++ b/functests/2_performance_update/updating_profile.go
@@ -201,7 +201,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		newNodeSelector := map[string]string{newLabel: ""}
 
 		testutils.BeforeAll(func() {
-			nonPerformancesWorkers, err := nodes.GetNonPerformancesWorkers()
+			nonPerformancesWorkers, err := nodes.GetNonPerformancesWorkers(profile.Spec.NodeSelector)
 			Expect(err).ToNot(HaveOccurred())
 			if len(nonPerformancesWorkers) != 0 {
 				newCnfNode = &nonPerformancesWorkers[0]

--- a/functests/3_performance_status/status.go
+++ b/functests/3_performance_status/status.go
@@ -47,7 +47,7 @@ var _ = Describe("Status testing of performance profile", func() {
 			)
 			Expect(err).ToNot(HaveOccurred())
 			key := types.NamespacedName{
-				Name:      components.GetComponentName(testutils.PerformanceProfileName, components.ProfileNamePerformance),
+				Name:      components.GetComponentName(profile.Name, components.ProfileNamePerformance),
 				Namespace: components.NamespaceNodeTuningOperator,
 			}
 			tuned := &tunedv1.Tuned{}

--- a/functests/3_performance_status/status.go
+++ b/functests/3_performance_status/status.go
@@ -26,7 +26,7 @@ var _ = Describe("Status testing of performance profile", func() {
 	var err error
 
 	BeforeEach(func() {
-		workerCNFNodes, err = nodes.GetByRole(testutils.RoleWorkerCNF)
+		workerCNFNodes, err = nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 		workerCNFNodes, err = nodes.MatchingOptionalSelector(workerCNFNodes)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
@@ -37,14 +37,9 @@ var _ = Describe("Status testing of performance profile", func() {
 		var currentConfig string
 		nodeAnnotationCurrentConfig := "machineconfiguration.openshift.io/currentConfig"
 		nodeAnnotationDesiredConfig := "machineconfiguration.openshift.io/desiredConfig"
-		nodeLabel := map[string]string{fmt.Sprintf("%s/%s", testutils.LabelRole, testutils.RoleWorkerCNF): ""}
 
 		It("[test_id:30894] Tuned status field tied to Performance Profile", func() {
-			profile, err := profiles.GetByNodeLabels(
-				map[string]string{
-					fmt.Sprintf("%s/%s", testutils.LabelRole, testutils.RoleWorkerCNF): "",
-				},
-			)
+			profile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 			Expect(err).ToNot(HaveOccurred())
 			key := types.NamespacedName{
 				Name:      components.GetComponentName(profile.Name, components.ProfileNamePerformance),
@@ -92,9 +87,13 @@ var _ = Describe("Status testing of performance profile", func() {
 			)).ToNot(HaveOccurred())
 			// Wait until worker-cnf MCP is in degraded state and get condition reason
 			By("Wait for MCP condition to be Degraded")
-			mcps.WaitForCondition(testutils.RoleWorkerCNF, machineconfigv1.MachineConfigPoolDegraded, corev1.ConditionTrue)
-			mcpConditionReason := mcps.GetConditionReason(testutils.RoleWorkerCNF, machineconfigv1.MachineConfigPoolDegraded)
-			profileConditionMessage := profiles.GetConditionMessage(nodeLabel, v1.ConditionDegraded)
+			profile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
+			Expect(err).ToNot(HaveOccurred())
+			performanceMCP, err := mcps.GetByProfile(profile)
+			Expect(err).ToNot(HaveOccurred())
+			mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolDegraded, corev1.ConditionTrue)
+			mcpConditionReason := mcps.GetConditionReason(performanceMCP, machineconfigv1.MachineConfigPoolDegraded)
+			profileConditionMessage := profiles.GetConditionMessage(testutils.NodeSelectorLabels, v1.ConditionDegraded)
 			// Verify the status reason of performance profile
 			Expect(profileConditionMessage).To(ContainSubstring(mcpConditionReason))
 			// Revert back the currentConfig
@@ -107,7 +106,7 @@ var _ = Describe("Status testing of performance profile", func() {
 					[]byte(fmt.Sprintf(`[{ "op": "replace", "path": "/metadata/annotations", "value": %s }]`, revertAnnotate)),
 				),
 			)).ToNot(HaveOccurred())
-			mcps.WaitForCondition(testutils.RoleWorkerCNF, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
+			mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
 		})
 	})
 })

--- a/functests/utils/consts.go
+++ b/functests/utils/consts.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
 )
@@ -43,6 +44,10 @@ func init() {
 			PerformanceProfileName = profile.Name
 		}
 		NodeSelectorLabels = profile.Spec.NodeSelector
+		if NodesSelector != "" {
+			keyValue := strings.Split(NodesSelector, "=")
+			NodeSelectorLabels[keyValue[0]] = keyValue[1]
+		}
 	}
 }
 

--- a/functests/utils/consts.go
+++ b/functests/utils/consts.go
@@ -5,12 +5,13 @@ import (
 	"os"
 
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
-	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
-	"k8s.io/klog"
 )
 
 // RoleWorkerCNF contains role name of cnf worker nodes
 var RoleWorkerCNF string
+
+// NodeSelectorLabels contains the node labels the perfomance profile should match
+var NodeSelectorLabels map[string]string
 
 // PerformanceProfileName contains the name of the PerformanceProfile created for tests
 // or an existing profile when discover mode is enabled
@@ -30,25 +31,19 @@ func init() {
 		PerformanceProfileName = "performance"
 	}
 
-<<<<<<< HEAD
 	NodesSelector = os.Getenv("NODES_SELECTOR")
-=======
-	if discovery.Enabled() {
-		performanceProfile, err := profiles.GetByNodeLabels(
-			map[string]string{
-				fmt.Sprintf("%s/%s", LabelRole, RoleWorkerCNF): "",
-			},
-		)
-		if err != nil {
-			klog.Error("Failed finding an existing performance profile in discovery mode", err)
-		} else {
-			if performanceProfile != nil {
-				PerformanceProfileName = performanceProfile.Name
-				klog.Info("Discovery mode: consuming a deployed performance profile from the cluster")
-			}
-		}
+
+	NodeSelectorLabels = map[string]string{
+		fmt.Sprintf("%s/%s", LabelRole, RoleWorkerCNF): "",
 	}
->>>>>>> Make the performance tests work in discovery mode
+
+	if discovery.Enabled() {
+		profile, err := discovery.GetDiscoveryPerformanceProfile()
+		if err != nil {
+			PerformanceProfileName = profile.Name
+		}
+		NodeSelectorLabels = profile.Spec.NodeSelector
+	}
 }
 
 const (

--- a/functests/utils/consts.go
+++ b/functests/utils/consts.go
@@ -1,13 +1,19 @@
 package utils
 
 import (
+	"fmt"
 	"os"
+
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
+	"k8s.io/klog"
 )
 
 // RoleWorkerCNF contains role name of cnf worker nodes
 var RoleWorkerCNF string
 
 // PerformanceProfileName contains the name of the PerformanceProfile created for tests
+// or an existing profile when discover mode is enabled
 var PerformanceProfileName string
 
 // NodesSelector represents the label selector used to filter impacted nodes.
@@ -24,7 +30,25 @@ func init() {
 		PerformanceProfileName = "performance"
 	}
 
+<<<<<<< HEAD
 	NodesSelector = os.Getenv("NODES_SELECTOR")
+=======
+	if discovery.Enabled() {
+		performanceProfile, err := profiles.GetByNodeLabels(
+			map[string]string{
+				fmt.Sprintf("%s/%s", LabelRole, RoleWorkerCNF): "",
+			},
+		)
+		if err != nil {
+			klog.Error("Failed finding an existing performance profile in discovery mode", err)
+		} else {
+			if performanceProfile != nil {
+				PerformanceProfileName = performanceProfile.Name
+				klog.Info("Discovery mode: consuming a deployed performance profile from the cluster")
+			}
+		}
+	}
+>>>>>>> Make the performance tests work in discovery mode
 }
 
 const (

--- a/functests/utils/consts.go
+++ b/functests/utils/consts.go
@@ -39,7 +39,7 @@ func init() {
 
 	if discovery.Enabled() {
 		profile, err := discovery.GetDiscoveryPerformanceProfile()
-		if err != nil {
+		if err == nil {
 			PerformanceProfileName = profile.Name
 		}
 		NodeSelectorLabels = profile.Spec.NodeSelector

--- a/functests/utils/discovery/discovery.go
+++ b/functests/utils/discovery/discovery.go
@@ -1,0 +1,12 @@
+package discovery
+
+import (
+	"os"
+	"strconv"
+)
+
+// Enabled indicates whether test discovery mode is enabled.
+func Enabled() bool {
+	discoveryMode, _ := strconv.ParseBool(os.Getenv("DISCOVERY_MODE"))
+	return discoveryMode
+}

--- a/functests/utils/discovery/discovery.go
+++ b/functests/utils/discovery/discovery.go
@@ -1,12 +1,58 @@
 package discovery
 
 import (
+	"context"
 	"os"
 	"strconv"
+
+	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
+	performancev1alpha1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Enabled indicates whether test discovery mode is enabled.
 func Enabled() bool {
 	discoveryMode, _ := strconv.ParseBool(os.Getenv("DISCOVERY_MODE"))
 	return discoveryMode
+}
+
+// GetDiscoveryPerformanceProfile returns an existing profile in the cluster with the most nodes using it.
+// In case no profile exists - return nil
+func GetDiscoveryPerformanceProfile(exclude ...string) (*performancev1alpha1.PerformanceProfile, error) {
+	performanceProfiles, err := profiles.GetAllProfiles()
+	if err != nil {
+		return nil, err
+	}
+
+	var currentProfile *performancev1alpha1.PerformanceProfile = nil
+	maxNodesNumber := 0
+	for _, profile := range performanceProfiles.Items {
+		if isExcluded(profile.GetName(), exclude) {
+			continue
+		}
+		selector := labels.SelectorFromSet(profile.Spec.NodeSelector)
+
+		profileNodes := &corev1.NodeList{}
+		if err := testclient.Client.List(context.TODO(), profileNodes, &client.ListOptions{LabelSelector: selector}); err != nil {
+			return nil, err
+		}
+
+		if len(profileNodes.Items) > maxNodesNumber {
+			currentProfile = &profile
+			maxNodesNumber = len(profileNodes.Items)
+		}
+	}
+	return currentProfile, nil
+}
+
+func isExcluded(item string, exclude []string) bool {
+	for _, excluded := range exclude {
+		if item == excluded {
+			return true
+		}
+	}
+	return false
 }

--- a/functests/utils/mcps/mcps.go
+++ b/functests/utils/mcps/mcps.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/klog"
-
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
@@ -14,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	performancev1alpha1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1alpha1"

--- a/functests/utils/mcps/mcps.go
+++ b/functests/utils/mcps/mcps.go
@@ -3,8 +3,9 @@ package mcps
 import (
 	"context"
 	"fmt"
-	"k8s.io/klog"
 	"time"
+
+	"k8s.io/klog"
 
 	. "github.com/onsi/gomega"
 
@@ -15,11 +16,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	performancev1alpha1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1alpha1"
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/profile"
 )
 
 const (
@@ -50,6 +53,18 @@ func GetByName(name string) (*machineconfigv1.MachineConfigPool, error) {
 	}
 	err := testclient.GetWithRetry(context.TODO(), key, mcp)
 	return mcp, err
+}
+
+// GetByProfile returns the MCP by a given performance profile
+func GetByProfile(performanceProfile *performancev1alpha1.PerformanceProfile) (string, error) {
+	mcpLabel := profile.GetMachineConfigLabel(performanceProfile)
+	key, value := components.GetFirstKeyAndValue(mcpLabel)
+	mcpsByLabel, err := GetByLabel(key, value)
+	if err != nil {
+		return "", err
+	}
+	performanceMCP := &mcpsByLabel[0]
+	return performanceMCP.Name, nil
 }
 
 // New creates a new MCP with the given name and node selector

--- a/functests/utils/nodes/nodes.go
+++ b/functests/utils/nodes/nodes.go
@@ -44,19 +44,18 @@ func GetByLabels(nodeLabels map[string]string) ([]corev1.Node, error) {
 }
 
 // GetNonPerformancesWorkers returns list of nodes with non matching perfomance profile labels
-func GetNonPerformancesWorkers(nodeSelectorLabels ...string) ([]corev1.Node, error) {
-	nonRTWorkerNodes := []corev1.Node{}
-
+func GetNonPerformancesWorkers(nodeSelectorLabels map[string]string) ([]corev1.Node, error) {
+	nonPerformanceWorkerNodes := []corev1.Node{}
 	workerNodes, err := GetByRole(testutils.RoleWorker)
 	for _, node := range workerNodes {
-		for label := range testutils.NodeSelectorLabels {
+		for label := range nodeSelectorLabels {
 			if _, ok := node.Labels[label]; !ok {
-				nonRTWorkerNodes = append(nonRTWorkerNodes, node)
+				nonPerformanceWorkerNodes = append(nonPerformanceWorkerNodes, node)
 				break
 			}
 		}
 	}
-	return nonRTWorkerNodes, err
+	return nonPerformanceWorkerNodes, err
 }
 
 // GetMachineConfigDaemonByNode returns the machine-config-daemon pod that runs on the specified node

--- a/functests/utils/nodes/nodes.go
+++ b/functests/utils/nodes/nodes.go
@@ -43,8 +43,8 @@ func GetByLabels(nodeLabels map[string]string) ([]corev1.Node, error) {
 	return GetBySelector(selector)
 }
 
-// GetNonRTWorkers returns list of nodes with non matching perfomance profile labels
-func GetNonRTWorkers() ([]corev1.Node, error) {
+// GetNonPerformancesWorkers returns list of nodes with non matching perfomance profile labels
+func GetNonPerformancesWorkers(nodeSelectorLabels ...string) ([]corev1.Node, error) {
 	nonRTWorkerNodes := []corev1.Node{}
 
 	workerNodes, err := GetByRole(testutils.RoleWorker)

--- a/functests/utils/nodes/nodes.go
+++ b/functests/utils/nodes/nodes.go
@@ -37,16 +37,24 @@ func GetBySelector(selector labels.Selector) ([]corev1.Node, error) {
 	return nodes.Items, nil
 }
 
-// GetNonRTWorkers returns list of nodes with no worker-cnf label
+// GetByLabels returns all nodes with the specified labels
+func GetByLabels(nodeLabels map[string]string) ([]corev1.Node, error) {
+	selector := labels.SelectorFromSet(nodeLabels)
+	return GetBySelector(selector)
+}
+
+// GetNonRTWorkers returns list of nodes with non matching perfomance profile labels
 func GetNonRTWorkers() ([]corev1.Node, error) {
 	nonRTWorkerNodes := []corev1.Node{}
 
 	workerNodes, err := GetByRole(testutils.RoleWorker)
 	for _, node := range workerNodes {
-		if _, ok := node.Labels[fmt.Sprintf("%s/%s", testutils.LabelRole, testutils.RoleWorkerCNF)]; ok {
-			continue
+		for label := range testutils.NodeSelectorLabels {
+			if _, ok := node.Labels[label]; !ok {
+				nonRTWorkerNodes = append(nonRTWorkerNodes, node)
+				break
+			}
 		}
-		nonRTWorkerNodes = append(nonRTWorkerNodes, node)
 	}
 	return nonRTWorkerNodes, err
 }

--- a/functests/utils/profiles/profiles.go
+++ b/functests/utils/profiles/profiles.go
@@ -56,3 +56,12 @@ func GetAllProfiles() (*performancev1alpha1.PerformanceProfileList, error) {
 	}
 	return profiles, nil
 }
+
+// GetProfilesCount returns the total number of existing perfomance profiles
+func GetProfilesCount() (int, error) {
+	profiles, err := GetAllProfiles()
+	if err != nil {
+		return 0, err
+	}
+	return len(profiles.Items), nil
+}

--- a/functests/utils/profiles/profiles.go
+++ b/functests/utils/profiles/profiles.go
@@ -14,8 +14,8 @@ import (
 
 // GetByNodeLabels gets the performance profile that must have node selector equals to passed node labels
 func GetByNodeLabels(nodeLabels map[string]string) (*performancev1alpha1.PerformanceProfile, error) {
-	profiles := &performancev1alpha1.PerformanceProfileList{}
-	if err := testclient.Client.List(context.TODO(), profiles); err != nil {
+	profiles, err := GetAllProfiles()
+	if err != nil {
 		return nil, err
 	}
 
@@ -46,4 +46,13 @@ func GetConditionMessage(nodeLabels map[string]string, conditionType v1.Conditio
 		}
 	}
 	return ""
+}
+
+// GetAllProfiles gets all the exiting profiles in the cluster
+func GetAllProfiles() (*performancev1alpha1.PerformanceProfileList, error) {
+	profiles := &performancev1alpha1.PerformanceProfileList{}
+	if err := testclient.Client.List(context.TODO(), profiles); err != nil {
+		return nil, err
+	}
+	return profiles, nil
 }

--- a/functests/utils/profiles/profiles.go
+++ b/functests/utils/profiles/profiles.go
@@ -14,7 +14,7 @@ import (
 
 // GetByNodeLabels gets the performance profile that must have node selector equals to passed node labels
 func GetByNodeLabels(nodeLabels map[string]string) (*performancev1alpha1.PerformanceProfile, error) {
-	profiles, err := GetAllProfiles()
+	profiles, err := All()
 	if err != nil {
 		return nil, err
 	}
@@ -48,20 +48,11 @@ func GetConditionMessage(nodeLabels map[string]string, conditionType v1.Conditio
 	return ""
 }
 
-// GetAllProfiles gets all the exiting profiles in the cluster
-func GetAllProfiles() (*performancev1alpha1.PerformanceProfileList, error) {
+// All gets all the exiting profiles in the cluster
+func All() (*performancev1alpha1.PerformanceProfileList, error) {
 	profiles := &performancev1alpha1.PerformanceProfileList{}
 	if err := testclient.Client.List(context.TODO(), profiles); err != nil {
 		return nil, err
 	}
 	return profiles, nil
-}
-
-// GetProfilesCount returns the total number of existing perfomance profiles
-func GetProfilesCount() (int, error) {
-	profiles, err := GetAllProfiles()
-	if err != nil {
-		return 0, err
-	}
-	return len(profiles.Items), nil
 }


### PR DESCRIPTION
The performance tests should be able to work in "discovery mode", meaning that they rely on the feature they want to test to be configured on the cluster use use the default test profile the performance tests create. 
Discovery mode is be enabled the environment parameter DISCOVERY_MODE=1/ t / T / TRUE / true /True