### PR TITLE
functests/cpu_management: fix test when balanceIsolated=false

### DIFF
--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -51,6 +51,9 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 			balanceIsolated = *profile.Spec.CPU.BalanceIsolated
 		}
 
+		Expect(profile.Spec.CPU.Isolated).NotTo(BeNil())
+		isolatedCPU = string(*profile.Spec.CPU.Isolated)
+
 		Expect(profile.Spec.CPU.Reserved).NotTo(BeNil())
 		reservedCPU = string(*profile.Spec.CPU.Reserved)
 		reservedCPUSet, err := cpuset.Parse(reservedCPU)


### PR DESCRIPTION
Commit f5667ceafe88a (fix guaranteed pod cpu test) removed
the initialization of isolatedCPU package variable, however
the tests (e.g. test_id:28026 )need it for profiles with
balanceIsolated parameter set to false.

Init the value from the profile.

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>