### PR TITLE
metadata: add metadata image, to be used with OPM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,8 @@ operator-container: build
 .PHONY: metadata-container
 metadata-container: generate-latest-dev-csv
 	@echo "Building the performance-addon-operator metadata image"
-	$(IMAGE_BUILD_CMD) build --no-cache -f openshift-ci/Dockerfile.metadata -t "$(FULL_METADATA_IMAGE)" --build-arg FULL_OPERATOR_IMAGE="$(FULL_OPERATOR_IMAGE)"  .
+	@find build/_output/olm-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|${FULL_OPERATOR_IMAGE}|g" {} \; || :
+	$(IMAGE_BUILD_CMD) build --no-cache -f openshift-ci/Dockerfile.metadata -t "$(FULL_METADATA_IMAGE)" .
 
 .PHONY: registry-container
 registry-container: generate-latest-dev-csv

--- a/deploy/metadata/performance-addon-operator/4.6.0/annotations.yaml
+++ b/deploy/metadata/performance-addon-operator/4.6.0/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+        operators.operatorframework.io.bundle.mediatype.v1: "registry+v1"
+        operators.operatorframework.io.bundle.manifests.v1: "manifests/"
+        operators.operatorframework.io.bundle.metadata.v1: "metadata/"
+        operators.operatorframework.io.bundle.package.v1: "performance-addon-operator"
+        operators.operatorframework.io.bundle.channels.v1: "4.6.0"
+        operators.operatorframework.io.bundle.channel.default.v1: "4.6.0"

--- a/openshift-ci/Dockerfile.metadata
+++ b/openshift-ci/Dockerfile.metadata
@@ -1,0 +1,17 @@
+# see: https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md
+FROM scratch
+
+ARG CHANNEL=4.6
+ARG FULL_OPERATOR_IMAGE=quay.io/openshift-kni/performance-addon-operator-metadata:4.6-snapshot
+ARG OLM_SOURCE=deploy/olm-catalog
+ARG OLM_METADATA=deploy/metadata
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=performance-addon-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=4.6.0
+LABEL operators.operatorframework.io.bundle.channel.default.v1=4.6.0
+
+COPY ${OLM_SOURCE}/performance-addon-operator/${CHANNEL}.0 /manifests/
+COPY ${OLM_METADATA}/performance-addon-operator/${CHANNEL}.0 /metadata/

--- a/openshift-ci/Dockerfile.metadata
+++ b/openshift-ci/Dockerfile.metadata
@@ -3,7 +3,7 @@ FROM scratch
 
 ARG CHANNEL=4.6
 ARG FULL_OPERATOR_IMAGE=quay.io/openshift-kni/performance-addon-operator-metadata:4.6-snapshot
-ARG OLM_SOURCE=deploy/olm-catalog
+ARG OLM_SOURCE=build/_output/olm-catalog
 ARG OLM_METADATA=deploy/metadata
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1


### PR DESCRIPTION
Not long ago the OLM gained support for the OPM tooling, which changes
the way we pack and deliver the metadata to be consumed by the OLM
itself. The new, recommended flow, makes use of the so-called "operator
bundles" and of the "index images".

See: https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md

For our intents and purposes, the main benefit here is that we don't
need to maintain anymore binary registry images, but rather only
much simpler and less challenging metadata images.

Signed-off-by: Francesco Romani <fromani@redhat.com>