### PR TITLE
functest/nodes: allow nodes matching by an optional selector

### DIFF
--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -35,6 +35,8 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 	BeforeEach(func() {
 		workerRTNodes, err := nodes.GetByRole(testutils.RoleWorkerCNF)
 		Expect(err).ToNot(HaveOccurred())
+		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
 		Expect(workerRTNodes).ToNot(BeEmpty())
 		workerRTNode = &workerRTNodes[0]
 

--- a/functests/1_performance/hugepages.go
+++ b/functests/1_performance/hugepages.go
@@ -36,6 +36,8 @@ var _ = Describe("[performance]Hugepages", func() {
 		var err error
 		workerRTNodes, err := nodes.GetByRole(testutils.RoleWorkerCNF)
 		Expect(err).ToNot(HaveOccurred())
+		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
 		Expect(workerRTNodes).ToNot(BeEmpty())
 		workerRTNode = &workerRTNodes[0]
 

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -41,6 +41,8 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 		var err error
 		workerRTNodes, err = nodes.GetByRole(testutils.RoleWorkerCNF)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for node with role %q: %v", testutils.RoleWorkerCNF, err))
+		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
 		Expect(workerRTNodes).ToNot(BeEmpty(), fmt.Sprintf("no nodes with role %q found", testutils.RoleWorkerCNF))
 		profile, err = profiles.GetByNodeLabels(
 			map[string]string{

--- a/functests/1_performance/topology_manager.go
+++ b/functests/1_performance/topology_manager.go
@@ -23,6 +23,8 @@ var _ = Describe("[rfe_id:27350][performance]Topology Manager", func() {
 		var err error
 		workerRTNodes, err = nodes.GetByRole(testutils.RoleWorkerCNF)
 		Expect(err).ToNot(HaveOccurred())
+		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
 		Expect(workerRTNodes).ToNot(BeEmpty())
 		profile, err = profiles.GetByNodeLabels(
 			map[string]string{

--- a/functests/2_performance_update/updating_profile.go
+++ b/functests/2_performance_update/updating_profile.go
@@ -36,6 +36,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 	BeforeEach(func() {
 		workerRTNodes, err = nodes.GetByRole(testutils.RoleWorkerCNF)
 		Expect(err).ToNot(HaveOccurred())
+		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
 		Expect(workerRTNodes).ToNot(BeEmpty())
 		profile, err = profiles.GetByNodeLabels(nodeLabel)
 		Expect(err).ToNot(HaveOccurred())

--- a/functests/3_performance_status/status.go
+++ b/functests/3_performance_status/status.go
@@ -28,6 +28,8 @@ var _ = Describe("Status testing of performance profile", func() {
 	BeforeEach(func() {
 		workerCNFNodes, err = nodes.GetByRole(testutils.RoleWorkerCNF)
 		Expect(err).ToNot(HaveOccurred())
+		workerCNFNodes, err = nodes.MatchingOptionalSelector(workerCNFNodes)
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
 		Expect(workerCNFNodes).ToNot(BeEmpty())
 	})
 

--- a/functests/utils/consts.go
+++ b/functests/utils/consts.go
@@ -10,6 +10,9 @@ var RoleWorkerCNF string
 // PerformanceProfileName contains the name of the PerformanceProfile created for tests
 var PerformanceProfileName string
 
+// NodesSelector represents the label selector used to filter impacted nodes.
+var NodesSelector string
+
 func init() {
 	RoleWorkerCNF = os.Getenv("ROLE_WORKER_CNF")
 	if RoleWorkerCNF == "" {
@@ -20,6 +23,8 @@ func init() {
 	if PerformanceProfileName == "" {
 		PerformanceProfileName = "performance"
 	}
+
+	NodesSelector = os.Getenv("NODES_SELECTOR")
 }
 
 const (


### PR DESCRIPTION
Currently the nodes for e2e tests are selected by a 'role' label.
Sometimes the granularity is not enough and there is a need to filter
the 'role' nodes using a standard label.

Allow the filtering based on a "NODES_SELECTOR" environment variable.

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>