### PR TITLE
must-gather: fix the ds readiness check

### DIFF
--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 check_node_gather_pods_ready() {
     line=$(oc get ds perf-node-gather-daemonset -o=custom-columns=DESIRED:.status.desiredNumberScheduled,READY:.status.numberReady --no-headers -n perf-node-gather)
 
@@ -7,7 +9,7 @@ check_node_gather_pods_ready() {
     read desired ready <<< $line
     IFS=$'\n'
 
-    if [[ $ready -eq $desired ]]
+    if [[ "$desired" != "0" ]] && [[ "$ready" == "$desired" ]]
     then
        return 0
     else


### PR DESCRIPTION
Once the daemonset created, all initial values under the daemonset
status equal to 0, it can take some small amount of time until the
controller will update the status values.

Added additional check to see that the desired number of nodes does
not equal to 0.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>