### PR TITLE
generate-manifests-index.sh: fix volume mount

### DIFF
--- a/hack/generate-manifests-index.sh
+++ b/hack/generate-manifests-index.sh
@@ -8,4 +8,4 @@ RUNTIME=${IMAGE_BUILD_CMD:-podman}
 VERSION=${OPERATOR_VERSION:-4.6.0}
 
 mkdir -p ${BASEPATH}/../build/_output/database || :
-${RUNTIME} run -v "${BASEPATH}/../build/_output":/sources quay.io/operator-framework/upstream-registry-builder /bin/initializer -m /sources/manifests/performance-addon-operator/"${VERSION}" -o /sources/database/index.db
+${RUNTIME} run -v "${BASEPATH}/../build/_output":/sources:z quay.io/operator-framework/upstream-registry-builder /bin/initializer -m /sources/manifests/performance-addon-operator/"${VERSION}" -o /sources/database/index.db


### PR DESCRIPTION
add missing flag to make the script work nicely with selinux.
Previously, without this flag, the script used to fail with

  panic: unable to open database file

selinux log revealed the culprit:

  avc:  denied  { write } for  pid=35664 comm="initializer" name="database" dev="dm-4" ino=393268 scontext=system_u:system_r:container_t:s0:c809,c992 tcontext=unconfined_u:object_r:user_tmp_t:s0 tclass=dir permissive=0

Signed-off-by: Francesco Romani <fromani@redhat.com>