### PR TITLE
Dockerfiles: remove useless argument

### DIFF
--- a/openshift-ci/Dockerfile.bundle.ci
+++ b/openshift-ci/Dockerfile.bundle.ci
@@ -2,7 +2,6 @@
 FROM scratch
 
 ARG CHANNEL=4.6
-ARG FULL_OPERATOR_IMAGE=quay.io/openshift-kni/performance-addon-operator-metadata:4.6-snapshot
 ARG OLM_SOURCE=manifests
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1

--- a/openshift-ci/Dockerfile.bundle.upstream.dev
+++ b/openshift-ci/Dockerfile.bundle.upstream.dev
@@ -2,7 +2,6 @@
 FROM scratch
 
 ARG CHANNEL=4.6
-ARG FULL_OPERATOR_IMAGE=quay.io/openshift-kni/performance-addon-operator-metadata:4.6-snapshot
 ARG OLM_SOURCE=build/_output/manifests
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1


### PR DESCRIPTION
We don't really need the "FULL_OPERATOR_IMAGE" in the bundle
Dockerfiles: it is only needed in the build step, when we update the
manifests. IOW, when we build the containers, the replacement must have
been done already.

Clean up for clarity; the variable was left over because of a copypaste
artifact.

Signed-off-by: Francesco Romani <fromani@redhat.com>