### PR TITLE
fix for PAO cleaning script

### DIFF
--- a/hack/clean-deploy.sh
+++ b/hack/clean-deploy.sh
@@ -6,7 +6,7 @@ OC_TOOL="${OC_TOOL:-oc}"
 profiles=$(${OC_TOOL} get performanceprofile -o name)
 for profileName in $profiles
 do
-  nodeSelector="$(${OC_TOOL} get $profileName -o=jsonpath='{.spec.nodeSelector}'  | awk -F'[/:]' '{print $2}')"
+  nodeSelector="$(${OC_TOOL} get $profileName -o=jsonpath='{.spec.nodeSelector}'  | awk -F'[/"]' '{print $3}')"
 
   if [[ $nodeSelector != "worker" ]]; then
     mcps+=($(${OC_TOOL} get mcp -l machineconfiguration.openshift.io/role=$nodeSelector -o name | awk -F "/" '{print $2}'))


### PR DESCRIPTION
this is a fix for nodeSelector parser that gets incorrect data:
```
$ oc get performanceprofile.performance.openshift.io/manual -o=jsonpath='{.spec.nodeSelector}' | awk -F'[/:]' '{print $2}'
worker-cnf"
```
as result node label and mcp were not removed.