### PR TITLE
Provide the latency e2e test and container image

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,29 @@ Unit tests can be executed with `make unittests`.
 The functional tests are located in `/functests`. They can be executed with `make functests-only` on a cluster with a
 deployed Performance Operator and configured MCP and nodes. It will create its own Performance profile!
 
+### Latency test
+
+The latency-test container image gives the possibility to run the latency 
+test without need to install go, ginkgo or other go related modules.
+
+The test himself is running the `oslat` binary and verifies if the maximal latency returned by the `oslat`
+less than specified value under the `OSLAT_MAXIMUM_LATENCY`.
+
+To run the latency test inside of the container:
+
+```
+docker run --rm -v /kubeconfig:/kubeconfig -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=60 -e OSLAT_MAXIMUM_LATENCY=700 alukiano/latency-test:4.6-snapshot /usr/bin/run-tests.sh
+```
+
+You can run the container with different ENV variables, but the bare minimum is to pass
+`KUBECONFIG` mount and ENV variable, to give to the test access to the cluster and
+`LATENCY_TEST_RUN=true` to run the latency test.
+
+- `LATENCY_TEST_RUN` indicates if the latency test should run.
+- `LATENCY_TEST_RUNTIME` the amount of time in seconds that the latency test should run.
+- `LATENCY_TEST_IMAGE` the image that used under the latency test.
+- `OSLAT_MAXIMUM_LATENCY` the expected maximum latency for all buckets in us.
+
 # Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for some guidelines.

--- a/functests/4_latency/Dockerfile
+++ b/functests/4_latency/Dockerfile
@@ -1,0 +1,17 @@
+# This Dockerfile is the temporary solution until we will integrate oslat binary and test into cnf-tests
+FROM golang:1.14 AS builder
+WORKDIR /go/src/github.com/openshift-kni/performance-addon-operator
+COPY . .
+RUN make dist-functests
+RUN git rev-list -1 HEAD > ./latency-test-sha.txt
+
+FROM quay.io/openshift/origin-oc-rpms:4.6 AS oc
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+COPY --from=oc /go/src/github.com/openshift/oc/oc /usr/bin/oc
+
+COPY --from=builder /go/src/github.com/openshift-kni/performance-addon-operator/functests/0_config/0_config.test /0_config.test
+COPY --from=builder /go/src/github.com/openshift-kni/performance-addon-operator/functests/4_latency/4_latency.test /4_latency.test
+COPY --from=builder /go/src/github.com/openshift-kni/performance-addon-operator/latency-test-sha.txt /latency-test-sha.txt
+COPY --from=builder /go/src/github.com/openshift-kni/performance-addon-operator/functests/4_latency/run-tests.sh /usr/bin/run-tests.sh

--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -1,0 +1,236 @@
+package __latency
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
+	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/pods"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
+	v1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+	"k8s.io/utils/pointer"
+)
+
+var (
+	latencyTestRun     = false
+	latencyTestRuntime = "300"
+	latencyTestImage   = "quay.io/openshift-kni/oslat:latest"
+	maximumLatency     = -1
+)
+
+// LATENCY_TEST_RUN: indicates if the latency test should run
+// LATENCY_TEST_RUNTIME: the amount of time in seconds that the latency test should run
+// LATENCY_TEST_IMAGE: the image use under the latency test
+// OSLAT_MAXIMUM_LATENCY: the expected maximum latency for all buckets in us
+func init() {
+	latencyTestRunEnv := os.Getenv("LATENCY_TEST_RUN")
+	if latencyTestRunEnv != "" {
+		if latencyTestRunEnv == "true" {
+			latencyTestRun = true
+		}
+	}
+
+	latencyTestRuntimeEnv := os.Getenv("LATENCY_TEST_RUNTIME")
+	if latencyTestRuntimeEnv != "" {
+		latencyTestRuntime = latencyTestRuntimeEnv
+	}
+
+	latencyTestImageEnv := os.Getenv("LATENCY_TEST_IMAGE")
+	if latencyTestImageEnv != "" {
+		latencyTestImage = latencyTestImageEnv
+	}
+
+	maximumLatencyEnv := os.Getenv("OSLAT_MAXIMUM_LATENCY")
+	if maximumLatencyEnv != "" {
+		var err error
+		if maximumLatency, err = strconv.Atoi(maximumLatencyEnv); err != nil {
+			klog.Errorf("the environment variable OSLAT_MAXIMUM_LATENCY has incorrect value %q", maximumLatencyEnv)
+			panic(err)
+		}
+	}
+}
+
+var _ = Describe("[performance] Latency Test", func() {
+	var workerRTNode *corev1.Node
+	var profile *v1.PerformanceProfile
+	var oslatPod *corev1.Pod
+
+	BeforeEach(func() {
+		if !latencyTestRun {
+			Skip("Skip the oslat test, the LATENCY_TEST_RUN set to false")
+		}
+
+		var err error
+		profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
+		Expect(err).ToNot(HaveOccurred())
+
+		if profile.Spec.CPU.Isolated == nil {
+			Skip(fmt.Sprintf("Skip the oslat test, the profile %q does not have isolated CPUs", profile.Name))
+		}
+
+		isolatedCpus := cpuset.MustParse(string(*profile.Spec.CPU.Isolated))
+		// we require at least two CPUs to run oslat test, because one CPU should be used to run the main oslat thread
+		// we can not use all isolated CPUs, because if reserved and isolated include all node CPUs, and reserved CPUs
+		// do not calculated into the Allocated, at least part of time of one of isolated CPUs will be used to run
+		// other node containers
+		// at least two isolated CPUs to run oslat + one isolated CPU used by other containers on the node = at least 3 isolated CPUs
+		if isolatedCpus.Size() < 3 {
+			Skip(fmt.Sprintf("Skip the oslat test, the profile %q has less than two isolated CPUs", profile.Name))
+		}
+
+		workerRTNodes, err := nodes.GetByLabels(testutils.NodeSelectorLabels)
+		Expect(err).ToNot(HaveOccurred())
+		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
+		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
+		Expect(workerRTNodes).ToNot(BeEmpty())
+		workerRTNode = &workerRTNodes[0]
+	})
+
+	AfterEach(func() {
+		if err := testclient.Client.Delete(context.TODO(), oslatPod); err != nil {
+			klog.Error(err)
+		}
+	})
+
+	Context("with the oslat image", func() {
+		It("should succeed", func() {
+			oslatPod = getOslatPod(profile, workerRTNode)
+			err := testclient.Client.Create(context.TODO(), oslatPod)
+			Expect(err).ToNot(HaveOccurred())
+
+			timeout, err := strconv.Atoi(latencyTestRuntime)
+			Expect(err).ToNot(HaveOccurred())
+
+			// give two minutes to download the oslat image
+			err = pods.WaitForPhase(oslatPod, corev1.PodRunning, 2*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			// add additional 2 minutes to give enough time to the cluster to move the pod to Succeeded phase
+			podTimeout := time.Duration(timeout + 120)
+			err = pods.WaitForPhase(oslatPod, corev1.PodSucceeded, podTimeout*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+
+			cmd := []string{"cat", "/rootfs/var/log/oslat.log"}
+			out, err := nodes.ExecCommandOnNode(cmd, workerRTNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			// verify the maximum latency only when it requested, because this value can be very different
+			// on different systems
+			if maximumLatency == -1 {
+				return
+			}
+
+			maximumRegex, err := regexp.Compile(`Maximum:\t*\s*(.*)\s*\(us\)`)
+			Expect(err).ToNot(HaveOccurred())
+
+			latencies := maximumRegex.FindSubmatch([]byte(out))
+			Expect(maximumLatency).ToNot(BeNil())
+
+			// under the output of the oslat very often we have one anomaly high value, for example
+			// Maximum:    16543 15 15 14 13 12 12 13 12 12 12 12 12 12 12 12 12 (us)
+			// it still unclear if it oslat bug or the kernel one, but we definitely do not want to
+			// fail our test on it
+			var anomaly bool
+			for _, lat := range strings.Split(string(latencies[1]), " ") {
+				if lat == "" {
+					continue
+				}
+
+				curr, err := strconv.Atoi(lat)
+				Expect(err).ToNot(HaveOccurred())
+
+				// skip the anomaly value
+				if curr > maximumLatency && !anomaly {
+					anomaly = true
+					continue
+				}
+
+				Expect(curr < maximumLatency).To(BeTrue(), fmt.Sprintf("The current latency %d is bigger than the expected one %d", curr, maximumLatency))
+			}
+		})
+	})
+})
+
+func getOslatPod(profile *v1.PerformanceProfile, node *corev1.Node) *corev1.Pod {
+	cpus := cpuset.MustParse(string(*profile.Spec.CPU.Isolated))
+	runtimeClass := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
+	volumeTypeDirectory := corev1.HostPathDirectory
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "oslat-",
+			Annotations: map[string]string{
+				"cpu-load-balancing.crio.io": "true",
+			},
+			Namespace: testutils.NamespaceTesting,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy:    corev1.RestartPolicyNever,
+			RuntimeClassName: &runtimeClass,
+			Containers: []corev1.Container{
+				{
+					Name:  "oslat",
+					Image: latencyTestImage,
+					Env: []corev1.EnvVar{
+						{
+							// we mount the host directory under the pod and write all logs to oslat.log under it
+							Name:  "LOG_DIR",
+							Value: "/host",
+						},
+						{
+							Name:  "RUNTIME_SECONDS",
+							Value: latencyTestRuntime,
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							// we can not use all isolated CPUs, because if reserved and isolated include all node CPUs, and reserved CPUs
+							// do not calculated into the Allocated, at least part of time of one of isolated CPUs will be used to run
+							// other node containers
+							corev1.ResourceCPU:    resource.MustParse(strconv.Itoa(cpus.Size() - 1)),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: pointer.BoolPtr(true),
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "logs",
+							MountPath: "/host",
+						},
+					},
+				},
+			},
+			NodeSelector: map[string]string{
+				"kubernetes.io/hostname": node.Labels["kubernetes.io/hostname"],
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "logs",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/var/log",
+							Type: &volumeTypeDirectory,
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/functests/4_latency/run-tests.sh
+++ b/functests/4_latency/run-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+# Setting -e is fine as we want both config to succeed
+# before running the "real" tests.
+
+suites=(0_config 4_latency)
+
+for suite in "${suites[@]}"; do
+    echo running "/${suite}.test" "$@"
+    "./${suite}.test" "$@"
+done

--- a/functests/4_latency/test_suite_latency_test.go
+++ b/functests/4_latency/test_suite_latency_test.go
@@ -1,0 +1,49 @@
+// +build !unittests
+
+package __latency_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
+	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/junit"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/namespaces"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog"
+
+	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
+)
+
+var _ = BeforeSuite(func() {
+	Expect(testclient.ClientsEnabled).To(BeTrue())
+	// create test namespace
+	err := testclient.Client.Create(context.TODO(), namespaces.TestingNamespace)
+	if errors.IsAlreadyExists(err) {
+		klog.Warning("test namespace already exists, that is unexpected")
+		return
+	}
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	err := testclient.Client.Delete(context.TODO(), namespaces.TestingNamespace)
+	Expect(err).ToNot(HaveOccurred())
+	err = namespaces.WaitForDeletion(testutils.NamespaceTesting, 5*time.Minute)
+})
+
+func TestLatency(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	rr := []Reporter{}
+	if ginkgo_reporters.Polarion.Run {
+		rr = append(rr, &ginkgo_reporters.Polarion)
+	}
+	rr = append(rr, junit.NewJUnitReporter("latency"))
+	RunSpecsWithDefaultAndCustomReporters(t, "Performance Addon Operator latency e2e tests", rr)
+}

--- a/hack/build-test-bin.sh
+++ b/hack/build-test-bin.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+if ! which go; then
+  echo "No go command available"
+  exit 1
+fi
+
+GOPATH="${GOPATH:-~/go}"
+export PATH=$PATH:$GOPATH/bin
+
+if ! which gingko; then
+	echo "Downloading ginkgo tool"
+	go install github.com/onsi/ginkgo/ginkgo
+fi
+
+ginkgo build ./functests/*

--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+GINKGO_SUITS=${GINKGO_SUITS:-functests}
+LATENCY_TEST_RUN=${LATENCY_TEST_RUN:-"false"}
+
 which ginkgo
 if [ $? -ne 0 ]; then
 	echo "Downloading ginkgo tool"
@@ -12,8 +15,15 @@ if ! which tput &> /dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
   NO_COLOR="-noColor"
 fi
 
+# run the latency tests under the OpenShift CI, just to verify that the image works
+if [ -n "${IMAGE_FORMAT}" ]; then
+  LATENCY_TEST_RUN="true"
+fi
+
+
+echo "Running Functional Tests: ${GINKGO_SUITS}"
 # -v: print out the text and location for each spec before running it and flush output to stdout in realtime
 # -r: run suites recursively
 # --keepGoing: don't stop on failing suite
 # -requireSuite: fail if tests are not executed because of missing suite
-GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --keepGoing -requireSuite functests -- -junitDir /tmp/artifacts
+GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --keepGoing -requireSuite ${GINKGO_SUITS} -- -junitDir /tmp/artifacts


### PR DESCRIPTION
As first step we should only to test that the oslat image
works correctly, the next step will be to define uppper and
lower bounds and to verify that the latency has value between
bounds.

The latency-test container image gives possibilty to run the latency
tests without need to install go, ginkgo or other go related modules.

To run the latency test inside of container:

```
docker run --rm -v /home/alukiano/Downloads/cluster/auth/kubeconfig:/kubeconfig -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=60 -e OSLAT_MAXIMUM_LATENCY=700 alukiano/latency-test:4.6-snapshot /usr/bin/run-tests.sh
```

You can run the container with different ENV variable, but the bare minimum is to pass
`KUBECONFIG` mount and ENV variable, to give to the test access to the cluster and
`LATENCY_TEST_RUN=true` to run the latency test.

- `LATENCY_TEST_RUN`: indicates if the latency test should run
- `LATENCY_TEST_RUNTIME`: the amount of time in seconds that the latency test should run
- `LATENCY_TEST_IMAGE`: the image use under the latency test
- `OSLAT_MAXIMUM_LATENCY`: the expected maximum latency for all buckets in us


Signed-off-by: Artyom Lukianov <alukiano@redhat.com>