### PR TITLE
index: fix building of the index images

### DIFF
--- a/hack/generate-manifests-index.sh
+++ b/hack/generate-manifests-index.sh
@@ -8,4 +8,4 @@ RUNTIME=${IMAGE_BUILD_CMD:-podman}
 VERSION=${OPERATOR_VERSION:-4.6.0}
 
 mkdir -p ${BASEPATH}/../build/_output/database || :
-${RUNTIME} run -v "${BASEPATH}/../build/_output":/sources:z quay.io/operator-framework/upstream-registry-builder /bin/initializer -m /sources/manifests/performance-addon-operator/"${VERSION}" -o /sources/database/index.db
+${RUNTIME} run -v "${BASEPATH}/../build/_output":/sources:z quay.io/operator-framework/upstream-registry-builder /bin/initializer -m /sources/manifests/performance-addon-operator/"${VERSION}"/manifests -o /sources/database/index.db


### PR DESCRIPTION
It seems that at least from version "18.02.0-ce"
the `initializer` found in the
`quay.io/operator-framework/upstream-registry-builder` image requires a
more precise path specification to read the manifests.

We fix our scripts to comply.
This issue was not triggered earlier on CI because we don't build *index*
images in CI, in turn caused by current CI limitations; we only build
bundle images in CI.

Signed-off-by: Francesco Romani <fromani@redhat.com>