### PR TITLE
Add dummy 2M huge pages kernel arguments

### DIFF
--- a/pkg/controller/performanceprofile/components/consts.go
+++ b/pkg/controller/performanceprofile/components/consts.go
@@ -20,3 +20,10 @@ const (
 	// ProfileNamePerformance defines the performance tuned profile name
 	ProfileNamePerformance = "openshift-node-performance"
 )
+
+const (
+	// HugepagesSize2M contains the size of 2M hugepages
+	HugepagesSize2M = "2M"
+	// HugepagesSize1G contains the size of 1G hugepages
+	HugepagesSize1G = "1G"
+)

--- a/pkg/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/controller/performanceprofile/components/tuned/tuned_test.go
@@ -8,7 +8,11 @@ import (
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	v1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
 	testutils "github.com/openshift-kni/performance-addon-operators/pkg/utils/testing"
+
+	"k8s.io/utils/pointer"
 )
 
 const testAssetsDir = "../../../../../build/assets"
@@ -17,23 +21,37 @@ const expectedMatchSelector = `
       mcKey: mcValue
 `
 
-var cmdlineCPUsPartitioning = regexp.MustCompile(`\s*cmdline_cpu_part=\+\s*nohz=on\s+rcu_nocbs=\${isolated_cores}\s+tuned.non_isolcpus=\${not_isolated_cpumask}\s+intel_pstate=disable\s+nosoftlockup\s*`)
-var cmdlineRealtimeWithCPUBalancing = regexp.MustCompile(`\s*cmdline_realtime=\+\s*tsc=nowatchdog\s+intel_iommu=on\s+iommu=pt\s+isolcpus=managed_irq,\${isolated_cores}\s+systemd.cpu_affinity=\${not_isolated_cores_expanded}\s*`)
-var cmdlineRealtimeWithoutCPUBalancing = regexp.MustCompile(`\s*cmdline_realtime=\+\s*tsc=nowatchdog\s+intel_iommu=on\s+iommu=pt\s+isolcpus=domain,managed_irq,\${isolated_cores}\s+systemd.cpu_affinity=\${not_isolated_cores_expanded}\s*`)
-var cmdlineHugepages = regexp.MustCompile(`\s*cmdline_hugepages=\+\s*default_hugepagesz=1G\s+hugepagesz=1G\s+hugepages=4\s*`)
-var cmdlineAdditionalArg = regexp.MustCompile(`\s*cmdline_additionalArg=\+\s*test1=val1\s+test2=val2\s*`)
+var (
+	cmdlineCPUsPartitioning            = regexp.MustCompile(`\s*cmdline_cpu_part=\+\s*nohz=on\s+rcu_nocbs=\${isolated_cores}\s+tuned.non_isolcpus=\${not_isolated_cpumask}\s+intel_pstate=disable\s+nosoftlockup\s*`)
+	cmdlineRealtimeWithCPUBalancing    = regexp.MustCompile(`\s*cmdline_realtime=\+\s*tsc=nowatchdog\s+intel_iommu=on\s+iommu=pt\s+isolcpus=managed_irq,\${isolated_cores}\s+systemd.cpu_affinity=\${not_isolated_cores_expanded}\s*`)
+	cmdlineRealtimeWithoutCPUBalancing = regexp.MustCompile(`\s*cmdline_realtime=\+\s*tsc=nowatchdog\s+intel_iommu=on\s+iommu=pt\s+isolcpus=domain,managed_irq,\${isolated_cores}\s+systemd.cpu_affinity=\${not_isolated_cores_expanded}\s*`)
+	cmdlineHugepages                   = regexp.MustCompile(`\s*cmdline_hugepages=\+\s*default_hugepagesz=1G\s+hugepagesz=1G\s+hugepages=4\s*`)
+	cmdlineAdditionalArg               = regexp.MustCompile(`\s*cmdline_additionalArg=\+\s*test1=val1\s+test2=val2\s*`)
+	cmdlineDummy2MHugePages            = regexp.MustCompile(`\s*cmdline_hugepages=\+\s*default_hugepagesz=1G\s+hugepagesz=1G\s+hugepages=4\s+hugepagesz=2M\s+hugepages=0\s*`)
+	cmdlineMultipleHugePages           = regexp.MustCompile(`\s*cmdline_hugepages=\+\s*default_hugepagesz=1G\s+hugepagesz=1G\s+hugepages=4\s+hugepagesz=2M\s+hugepages=128\s*`)
+)
+
 var additionalArgs = []string{"test1=val1", "test2=val2"}
 
 var _ = Describe("Tuned", func() {
+	var profile *v1.PerformanceProfile
+
+	BeforeEach(func() {
+		profile = testutils.NewPerformanceProfile("test")
+	})
+
+	getTunedManifest := func(profile *v1.PerformanceProfile) string {
+		tuned, err := NewNodePerformance(testAssetsDir, profile)
+		Expect(err).ToNot(HaveOccurred())
+		y, err := yaml.Marshal(tuned)
+		Expect(err).ToNot(HaveOccurred())
+		return string(y)
+	}
+
 	Context("with worker performance profile", func() {
 		It("should generate yaml with expected parameters", func() {
-			profile := testutils.NewPerformanceProfile("test")
-			tuned, err := NewNodePerformance(testAssetsDir, profile)
-			Expect(err).ToNot(HaveOccurred())
-			y, err := yaml.Marshal(tuned)
-			Expect(err).ToNot(HaveOccurred())
+			manifest := getTunedManifest(profile)
 
-			manifest := string(y)
 			Expect(manifest).To(ContainSubstring(expectedMatchSelector))
 			Expect(manifest).To(ContainSubstring(fmt.Sprintf("isolated_cores=4-7")))
 			By("Populating CPU partitioning cmdline")
@@ -48,47 +66,99 @@ var _ = Describe("Tuned", func() {
 		})
 
 		It("should generate yaml with expected parameters for Isolated balancing disabled", func() {
-			profile := testutils.NewPerformanceProfile("test")
-			f := false
-			profile.Spec.CPU.BalanceIsolated = &f
-			tuned, err := NewNodePerformance(testAssetsDir, profile)
-			Expect(err).ToNot(HaveOccurred())
-			y, err := yaml.Marshal(tuned)
-			Expect(err).ToNot(HaveOccurred())
-			manifest := string(y)
+			profile.Spec.CPU.BalanceIsolated = pointer.BoolPtr(false)
+			manifest := getTunedManifest(profile)
+
 			Expect(cmdlineRealtimeWithoutCPUBalancing.MatchString(manifest)).To(BeTrue())
 		})
 
 		It("should generate yaml with expected parameters for additional kernel arguments", func() {
-			profile := testutils.NewPerformanceProfile("test")
 			profile.Spec.AdditionalKernelArgs = additionalArgs
-			tuned, err := NewNodePerformance(testAssetsDir, profile)
-			Expect(err).ToNot(HaveOccurred())
-			y, err := yaml.Marshal(tuned)
-			Expect(err).ToNot(HaveOccurred())
-			manifest := string(y)
+			manifest := getTunedManifest(profile)
+
 			Expect(cmdlineAdditionalArg.MatchString(manifest)).To(BeTrue())
 		})
 
 		It("should not allocate hugepages on the specific NUMA node via kernel arguments", func() {
-			profile := testutils.NewPerformanceProfile("test")
-			dummyNode := int32(1)
-			tuned, err := NewNodePerformance(testAssetsDir, profile)
-			Expect(err).ToNot(HaveOccurred())
-			y, err := yaml.Marshal(tuned)
-			Expect(err).ToNot(HaveOccurred())
-			manifest := string(y)
+			manifest := getTunedManifest(profile)
 			Expect(strings.Count(manifest, "hugepagesz=")).Should(BeNumerically("==", 2))
 			Expect(strings.Count(manifest, "hugepages=")).Should(BeNumerically("==", 3))
-			profile.Spec.HugePages.Pages[0].Node = &dummyNode
-			tuned, err = NewNodePerformance(testAssetsDir, profile)
-			Expect(err).ToNot(HaveOccurred())
-			y, err = yaml.Marshal(tuned)
-			Expect(err).ToNot(HaveOccurred())
-			manifest = string(y)
+
+			profile.Spec.HugePages.Pages[0].Node = pointer.Int32Ptr(1)
+			manifest = getTunedManifest(profile)
 			Expect(strings.Count(manifest, "hugepagesz=")).Should(BeNumerically("==", 1))
 			Expect(strings.Count(manifest, "hugepages=")).Should(BeNumerically("==", 2))
 		})
 
+		Context("with 1G default huge pages", func() {
+			Context("with requested 2M huge pages allocation on the specified node", func() {
+				It("should append the dummy 2M huge pages kernel arguments", func() {
+					profile.Spec.HugePages.Pages = append(profile.Spec.HugePages.Pages, v1.HugePage{
+						Size:  components.HugepagesSize2M,
+						Count: 128,
+						Node:  pointer.Int32Ptr(0),
+					})
+
+					manifest := getTunedManifest(profile)
+					Expect(cmdlineDummy2MHugePages.MatchString(manifest)).To(BeTrue())
+				})
+			})
+
+			Context("with requested 2M huge pages allocation via kernel arguments", func() {
+				It("should not append the dummy 2M kernel arguments", func() {
+					profile.Spec.HugePages.Pages = append(profile.Spec.HugePages.Pages, v1.HugePage{
+						Size:  components.HugepagesSize2M,
+						Count: 128,
+					})
+
+					manifest := getTunedManifest(profile)
+					Expect(cmdlineDummy2MHugePages.MatchString(manifest)).To(BeFalse())
+					Expect(cmdlineMultipleHugePages.MatchString(manifest)).To(BeTrue())
+				})
+			})
+
+			Context("without requested 2M hugepages", func() {
+				It("should not append dummy 2M huge pages kernel arguments", func() {
+					manifest := getTunedManifest(profile)
+					Expect(cmdlineDummy2MHugePages.MatchString(manifest)).To(BeFalse())
+				})
+			})
+
+			Context("with requested 2M huge pages allocation on the specified node and via kernel arguments", func() {
+				It("should not append the dummy 2M kernel arguments", func() {
+					profile.Spec.HugePages.Pages = append(profile.Spec.HugePages.Pages, v1.HugePage{
+						Size:  components.HugepagesSize2M,
+						Count: 128,
+						Node:  pointer.Int32Ptr(0),
+					})
+					profile.Spec.HugePages.Pages = append(profile.Spec.HugePages.Pages, v1.HugePage{
+						Size:  components.HugepagesSize2M,
+						Count: 128,
+					})
+
+					manifest := getTunedManifest(profile)
+					Expect(cmdlineDummy2MHugePages.MatchString(manifest)).To(BeFalse())
+					Expect(cmdlineMultipleHugePages.MatchString(manifest)).To(BeTrue())
+				})
+			})
+		})
+
+		Context("with 2M default huge pages", func() {
+			Context("with requested 2M huge pages allocation on the specified node", func() {
+				It("should not append the dummy 2M huge pages kernel arguments", func() {
+					defaultSize := v1.HugePageSize(components.HugepagesSize2M)
+					profile.Spec.HugePages.DefaultHugePagesSize = &defaultSize
+					profile.Spec.HugePages.Pages = append(profile.Spec.HugePages.Pages, v1.HugePage{
+						Size:  components.HugepagesSize2M,
+						Count: 128,
+						Node:  pointer.Int32Ptr(0),
+					})
+
+					manifest := getTunedManifest(profile)
+					Expect(cmdlineDummy2MHugePages.MatchString(manifest)).To(BeFalse())
+					Expect(cmdlineMultipleHugePages.MatchString(manifest)).To(BeFalse())
+				})
+			})
+		})
 	})
 })


### PR DESCRIPTION
Some architectures such as arm, powerpc, and sparc set up hstates for all supported sizes.
Other architectures such as riscv, s390, and x86 only set up hstates for those requested on the command line with hugepagesz=.
Depending on config options, x86 and riscv may or may not set up PUD_SIZE hstates.
So once you specify the `default_hugepagesz` equal to 1G,
the kernel will remove all 2M huge pages related files and directories from the filesystem.
You can find more details under the kernel email thread - https://lkml.org/lkml/2020/3/5/1113.

And it will prevent to allocate 2M huge pages on the specific NUMA node because the expected file does not exist.

To W/A the problem, once a user will request 2M huge pages allocation on the
specific NUMA node and the `default_hugepagesz` equal to 1G, the controller
will add dummy 2M huge pages kernel arguments `hugepagesz=2M hugepages=0`.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>