### PR TITLE
docs: Update the docs to reflect the API is now v1

### DIFF
--- a/docs/configuration_hotfixes.md
+++ b/docs/configuration_hotfixes.md
@@ -19,7 +19,7 @@ When creating a [performance profile CR](../deploy/crds/performance.openshift.io
 Additional kernel arguments could be added in the performance profile CR using the `additionalKernelArgs` field:
 
 ```yaml
-apiVersion: performance.openshift.io/v1alpha1
+apiVersion: performance.openshift.io/v1
 kind: PerformanceProfile
 metadata:
   name: example-performanceprofile
@@ -91,7 +91,7 @@ spec:
 
 ```yaml
 performance_profile.yaml
-apiVersion: performance.openshift.io/v1alpha1
+apiVersion: performance.openshift.io/v1
 kind: PerformanceProfile
 metadata:
   name: manual


### PR DESCRIPTION
Update the API references to v1.
Leave the README's reference to the way the operator
was created to v1alpha1.

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>