### PR TITLE
Bug 1872417: E2e tests - do not panic in discovery mode with no profile installed.

### DIFF
--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -18,6 +18,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
@@ -38,6 +39,10 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 	var reservedCPUSet cpuset.CPUSet
 
 	BeforeEach(func() {
+		if discovery.Enabled() && utils.ProfileNotFound {
+			Skip("Discovery mode enabled, performance profile not found")
+		}
+
 		workerRTNodes, err := nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)

--- a/functests/1_performance/hugepages.go
+++ b/functests/1_performance/hugepages.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
@@ -30,6 +31,10 @@ var _ = Describe("[performance]Hugepages", func() {
 	var profile *performancev1.PerformanceProfile
 
 	BeforeEach(func() {
+		if discovery.Enabled() && utils.ProfileNotFound {
+			Skip("Discovery mode enabled, performance profile not found")
+		}
+
 		var err error
 		workerRTNodes, err := nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -24,8 +24,10 @@ import (
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
+	"github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/mcps"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/pods"
@@ -46,6 +48,10 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 	var profile *performancev1.PerformanceProfile
 
 	BeforeEach(func() {
+		if discovery.Enabled() && utils.ProfileNotFound {
+			Skip("Discovery mode enabled, performance profile not found")
+		}
+
 		var err error
 		workerRTNodes, err = nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for node with role %q: %v", testutils.RoleWorkerCNF, err))

--- a/functests/1_performance/rt-kernel.go
+++ b/functests/1_performance/rt-kernel.go
@@ -18,7 +18,6 @@ var _ = Describe("[performance]RT Kernel", func() {
 	var err error
 
 	testutils.BeforeAll(func() {
-		discoveryFailed = true
 		profile, err = discovery.GetFilteredDiscoveryPerformanceProfile(
 			func(profile performancev1.PerformanceProfile) bool {
 				if profile.Spec.RealTimeKernel != nil && *profile.Spec.RealTimeKernel.Enabled == true {
@@ -26,10 +25,12 @@ var _ = Describe("[performance]RT Kernel", func() {
 				}
 				return false
 			})
-		Expect(err).ToNot(HaveOccurred(), "failed to get a a profile using a filter for RT kernel")
-		if profile != nil {
-			discoveryFailed = false
+
+		if err == discovery.ErrProfileNotFound {
+			discoveryFailed = true
+			return
 		}
+		Expect(err).ToNot(HaveOccurred(), "failed to get a a profile using a filter for RT kernel")
 	})
 
 	BeforeEach(func() {

--- a/functests/1_performance/topology_manager.go
+++ b/functests/1_performance/topology_manager.go
@@ -6,7 +6,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
 	performancev1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
@@ -20,6 +22,10 @@ var _ = Describe("[rfe_id:27350][performance]Topology Manager", func() {
 	var profile *performancev1.PerformanceProfile
 
 	BeforeEach(func() {
+		if discovery.Enabled() && utils.ProfileNotFound {
+			Skip("Discovery mode enabled, performance profile not found")
+		}
+
 		var err error
 		workerRTNodes, err = nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())

--- a/functests/2_performance_update/updating_profile.go
+++ b/functests/2_performance_update/updating_profile.go
@@ -17,8 +17,10 @@ import (
 
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
+	"github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/mcps"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
@@ -40,6 +42,10 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 	nodeLabel := testutils.NodeSelectorLabels
 
 	BeforeEach(func() {
+		if discovery.Enabled() && utils.ProfileNotFound {
+			Skip("Discovery mode enabled, performance profile not found")
+		}
+
 		workerRTNodes, err = nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)

--- a/functests/3_performance_status/status.go
+++ b/functests/3_performance_status/status.go
@@ -9,8 +9,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/mcps"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
@@ -30,6 +32,9 @@ var _ = Describe("Status testing of performance profile", func() {
 	var err error
 
 	BeforeEach(func() {
+		if discovery.Enabled() && utils.ProfileNotFound {
+			Skip("Discovery mode enabled, performance profile not found")
+		}
 		workerCNFNodes, err = nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 		workerCNFNodes, err = nodes.MatchingOptionalSelector(workerCNFNodes)

--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -11,8 +11,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/pods"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
@@ -74,6 +76,9 @@ var _ = Describe("[performance] Latency Test", func() {
 	BeforeEach(func() {
 		if !latencyTestRun {
 			Skip("Skip the oslat test, the LATENCY_TEST_RUN set to false")
+		}
+		if discovery.Enabled() && utils.ProfileNotFound {
+			Skip("Discovery mode enabled, performance profile not found")
 		}
 
 		var err error

--- a/functests/utils/discovery/discovery.go
+++ b/functests/utils/discovery/discovery.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 
@@ -12,6 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var ErrProfileNotFound = fmt.Errorf("Profile not found in discovery mode")
 
 // ConditionIterator is the function that accepts element of a PerformanceProfile and returns boolean
 type ConditionIterator func(performancev1.PerformanceProfile) bool
@@ -58,6 +61,10 @@ func getDiscoveryPerformanceProfile(performanceProfiles []performancev1.Performa
 			currentProfile = &profile
 			maxNodesNumber = len(profileNodes.Items)
 		}
+	}
+
+	if currentProfile == nil {
+		return nil, ErrProfileNotFound
 	}
 	return currentProfile, nil
 }


### PR DESCRIPTION
If discovery mode is enabled but no profile is installed the tests currently panic.
Here, we are forcing all the tests to skip if that happens, providing the reason.

