### PR TITLE
Revert the CI registry URL back to registry.svc.ci.openshift.org

### DIFF
--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -6,8 +6,8 @@ COPY deploy/olm-catalog /registry/performance-addon-operator-catalog
 
 # easier switching between CI clusters...
 # ENV REG_URL=default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com
-# ENV REG_URL=registry.svc.ci.openshift.org
-ENV REG_URL=registry.build02.ci.openshift.org
+ENV REG_URL=registry.svc.ci.openshift.org
+#ENV REG_URL=registry.build02.ci.openshift.org
 
 # replaces performance-addon-operator image with the one built by openshift ci
 RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|${REG_URL}/${OPENSHIFT_BUILD_NAMESPACE}/stable:performance-addon-operator|g" {} \; || :


### PR DESCRIPTION
Looks like CI was moved to another cluster again, let's switch it and check if tests passed