### PR TITLE
Fix CPU managment test to check for right numbers of isolated CPUs

### DIFF
--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -152,7 +152,10 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 			if discovery.Enabled() {
 				profile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 				Expect(err).ToNot(HaveOccurred())
-				if len(*profile.Spec.CPU.Isolated) == 1 {
+				isolatedCPU = string(*profile.Spec.CPU.Isolated)
+				isolatedCPUSet, err := cpuset.Parse(isolatedCPU)
+				Expect(err).ToNot(HaveOccurred())
+				if isolatedCPUSet.Size() <= 1 {
 					discoveryFailed = true
 				}
 			}


### PR DESCRIPTION
Test fixed to check a cpuset of isolated cpus :  if the amount of isolated cups is 1 or 0 then tests in discovery mode will be skipped with : "Skipping tests since there are insufficient isolated cores to create a stress pod" 