### PR TITLE
Fix generate scripts to support generation of z-stream manifests

### DIFF
--- a/deploy/olm-catalog/performance-addon-operator/4.6.0/performance.openshift.io_performanceprofiles_crd.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.6.0/performance.openshift.io_performanceprofiles_crd.yaml
@@ -72,9 +72,9 @@ spec:
                   It is possible to set huge pages with multiple size values at the
                   same time. For example, hugepages can be set with 1G and 2M, both
                   values will be set on the node by the performance-addon-operator.
-                  It is important to notice that setting hugepages default size to 1G
-                  will remove all 2M related folders from the node and it will be impossible
-                  to configure 2M hugepages under the node.
+                  It is important to notice that setting hugepages default size to
+                  1G will remove all 2M related folders from the node and it will
+                  be impossible to configure 2M hugepages under the node.
                 properties:
                   defaultHugepagesSize:
                     description: DefaultHugePagesSize defines huge pages default size
@@ -251,6 +251,12 @@ spec:
                 type: object
               hugepages:
                 description: HugePages defines a set of huge pages related parameters.
+                  It is possible to set huge pages with multiple size values at the
+                  same time. For example, hugepages can be set with 1G and 2M, both
+                  values will be set on the node by the performance-addon-operator.
+                  It is important to notice that setting hugepages default size to
+                  1G will remove all 2M related folders from the node and it will
+                  be impossible to configure 2M hugepages under the node.
                 properties:
                   defaultHugepagesSize:
                     description: DefaultHugePagesSize defines huge pages default size

--- a/hack/csv-generate.sh
+++ b/hack/csv-generate.sh
@@ -2,53 +2,66 @@
 
 set -e
 
-export GOROOT=$(go env GOROOT)
+GOROOT=$(go env GOROOT)
+export GOROOT
 
 OLD="4.4.0"
 PREV="4.5.0"
 LATEST="4.6.0"
 
-IS_DEV=$( [[ $1 = "-dev" ]] && echo true || echo false )
+IS_DEV=$([[ $1 == "-dev" ]] && echo true || echo false)
 
-if [[ $IS_DEV = true ]] || [[ -z "$CSV_VERSION" ]]; then
+if [[ -z "$CSV_VERSION" ]]; then
   CSV_VERSION=$LATEST
+fi
+
+if [[ -z "$REPLACES_CSV_VERSION" ]]; then
   REPLACES_CSV_VERSION=$PREV
 fi
 
+if [[ -z "$CSV_CHANNEL" ]]; then
+  CSV_CHANNEL=$LATEST
+fi
+
+if [[ -z "$CSV_FROM_VERSION" ]]; then
+  CSV_FROM_VERSION=$PREV
+fi
 
 PACKAGE_NAME="performance-addon-operator"
-
 PACKAGE_DIR="deploy/olm-catalog/${PACKAGE_NAME}"
+
 CSV_DIR="${PACKAGE_DIR}/${CSV_VERSION}"
-CSV_FILE="$CSV_DIR/${PACKAGE_NAME}.v${CSV_VERSION}.clusterserviceversion.yaml"
 
 OUT_ROOT="build/_output"
 OUT_DIR="${OUT_ROOT}/olm-catalog"
 OUT_CSV_DIR="${OUT_DIR}/${PACKAGE_NAME}/${CSV_VERSION}"
 OUT_CSV_FILE="${OUT_CSV_DIR}/${PACKAGE_NAME}.v${CSV_VERSION}.clusterserviceversion.yaml"
 
+TEMPLATES_DIR="${OUT_ROOT}/templates"
+CSV_TEMPLATE_FILE="${TEMPLATES_DIR}/${PACKAGE_NAME}.v${CSV_VERSION}.clusterserviceversion.yaml"
+
 EXTRA_ANNOTATIONS=""
 MAINTAINERS=""
 
-if [ -n "$DESCRIPTION_FILE" ]; then
-	DESCRIPTION="-description-from=$DESCRIPTION_FILE"
-fi
 if [ -n "$MAINTAINERS_FILE" ]; then
-	MAINTAINERS="-maintainers-from=$MAINTAINERS_FILE"
+  MAINTAINERS="-maintainers-from=$MAINTAINERS_FILE"
 fi
 if [ -n "$ANNOTATIONS_FILE" ]; then
-	EXTRA_ANNOTATIONS="-annotations-from=$ANNOTATIONS_FILE"
+  EXTRA_ANNOTATIONS="-annotations-from=$ANNOTATIONS_FILE"
 fi
 
 clean_package() {
-	mkdir -p "$CSV_DIR"
-	rm -rf "$OUT_DIR"
-	mkdir -p "$OUT_CSV_DIR"
+  mkdir -p "$CSV_DIR"
+  rm -rf "$OUT_DIR"
+  mkdir -p "$OUT_CSV_DIR"
+
+  rm -rf "${TEMPLATES_DIR}"
+  mkdir -p "${TEMPLATES_DIR}"
 }
 
 if ! [[ "$CSV_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-	echo "CSV_VERSION not provided or does not match semver format"
-	exit 1
+  echo "CSV_VERSION not provided or does not match semver format"
+  exit 1
 fi
 
 # clean up all old data first
@@ -62,20 +75,24 @@ if [[ "$CSV_VERSION" != "$PREV" ]] && [[ "$CSV_VERSION" != "$OLD" ]]; then
   $OPERATOR_SDK generate csv \
     --operator-name="${PACKAGE_NAME}" \
     --csv-version="${CSV_VERSION}" \
-    --csv-channel="${CSV_VERSION}" \
+    --csv-channel="${CSV_CHANNEL}" \
     --default-channel=true \
     --update-crds \
     --make-manifests=false \
+    --from-version="${CSV_FROM_VERSION}" \
     --output-dir="${OUT_ROOT}"
+
+  # copy template CSV file to preserve it for our csv-generator
+  mv "${OUT_CSV_FILE}" "${CSV_TEMPLATE_FILE}"
 
   # using the generated CSV, create the real CSV by injecting all the right data into it
   build/_output/bin/csv-generator \
     --csv-version "${CSV_VERSION}" \
-    --operator-csv-template-file "${CSV_FILE}" \
+    --operator-csv-template-file "${CSV_TEMPLATE_FILE}" \
     --operator-image "${FULL_OPERATOR_IMAGE}" \
-    --olm-bundle-directory "$OUT_CSV_DIR" \
-    --replaces-csv-version "$REPLACES_CSV_VERSION" \
-    --skip-range "$CSV_SKIP_RANGE" \
+    --olm-bundle-directory "${OUT_CSV_DIR}" \
+    --replaces-csv-version "${REPLACES_CSV_VERSION}" \
+    --skip-range "${CSV_SKIP_RANGE}" \
     "${MAINTAINERS}" \
     "${EXTRA_ANNOTATIONS}"
 
@@ -83,12 +100,12 @@ if [[ "$CSV_VERSION" != "$PREV" ]] && [[ "$CSV_VERSION" != "$OLD" ]]; then
   cp -a deploy/crds/performance.openshift.io_performanceprofiles_crd.yaml "${OUT_CSV_DIR}"
 fi
 
-# copy remaining manifests to final location
-cp -a --no-clobber $PACKAGE_DIR/ $OUT_DIR/
+if [[ "$IS_DEV" == true ]]; then
+  # copy generated CSV and CRD back to repository dir
+  cp "${OUT_CSV_DIR}"/* "${CSV_DIR}/"
 
-# copy dev CSV back to repository dir
-if [[ "$IS_DEV" = true ]]; then
-  cp "$OUT_CSV_FILE" "$CSV_FILE"
+  # copy generated package yaml
+  cp "${OUT_DIR}/${PACKAGE_NAME}/${PACKAGE_NAME}.package.yaml" ${PACKAGE_DIR}/
 fi
 
-echo "New OLM manifests created at $OUT_DIR"
+echo "New OLM manifests created at ${OUT_DIR}"

--- a/hack/generate-manifests-index.sh
+++ b/hack/generate-manifests-index.sh
@@ -7,5 +7,6 @@ BASEPATH=$( dirname $SELF )
 RUNTIME=${IMAGE_BUILD_CMD:-podman}
 VERSION=${OPERATOR_VERSION:-4.6.0}
 
-mkdir -p ${BASEPATH}/../build/_output/database || :
+rm -rf ${BASEPATH}/../build/_output/database && \
+mkdir -p ${BASEPATH}/../build/_output/database && \
 ${RUNTIME} run -v "${BASEPATH}/../build/_output":/sources:z quay.io/operator-framework/upstream-registry-builder /bin/initializer -m /sources/manifests/performance-addon-operator/"${VERSION}"/manifests -o /sources/database/index.db

--- a/hack/generate-manifests-tree.sh
+++ b/hack/generate-manifests-tree.sh
@@ -17,13 +17,14 @@ if [ ! -d "${OLM_DIR}" ]; then
 	exit 1
 fi
 
-mv "${OLM_DIR}" "${OUT_DIR}"
+rm -rf ${OUT_DIR} && mkdir -p ${OUT_DIR} && mv "${OLM_DIR}/performance-addon-operator" "${OUT_DIR}"
 find "${OUT_DIR}" -type f -exec sed -i "s|REPLACE_IMAGE|${OPERATOR_IMAGE}|g" {} \; || :
 for entry in ${OUT_DIR}/performance-addon-operator/*; do
 	version=$( basename $entry )
 	if [ ! -d deploy/metadata/performance-addon-operator/$version ]; then
 		continue
 	fi
+
 	mkdir -p $entry/manifests && mv $entry/*.yaml $entry/manifests
 	mkdir -p $entry/metadata && cp deploy/metadata/performance-addon-operator/$version/* $entry/metadata
 done


### PR DESCRIPTION
1. csv-generate: pass `--from-version` parameter to prevent errors
from the `operator-sdk generate csv` and create the separate ENV
variable for the CSV channel. Also, copy CRD and package yamls to the
repository directory after the generation to have updated files.

2. generate-manifest-index: remove the database folder before generating
the new bundle database.

3. generate-manifests-tree: fix the path for generated files.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>