### PR TITLE
Fix registry images

### DIFF
--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -1,4 +1,8 @@
-FROM quay.io/openshift/origin-operator-registry:4.5
+FROM quay.io/openshift/origin-operator-registry:4.6 as builder
+
+FROM quay.io/openshift/origin-operator-registry:4.6
+
+COPY --from=builder /usr/bin/sh /bin/sh
 
 ARG OPENSHIFT_BUILD_NAMESPACE
 
@@ -11,8 +15,13 @@ ENV REG_URL=registry.svc.ci.openshift.org
 
 # replaces performance-addon-operator image with the one built by openshift ci
 RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|${REG_URL}/${OPENSHIFT_BUILD_NAMESPACE}/stable:performance-addon-operator|g" {} \; || :
+
 # Initialize the database
+USER root
 RUN initializer --manifests /registry/performance-addon-operator-catalog --output bundles.db
+RUN chown 1001 bundles.db
+
+USER 1001
 
 # There are multiple binaries in the origin-operator-registry
 # We want the registry-server

--- a/openshift-ci/Dockerfile.registry.intermediate
+++ b/openshift-ci/Dockerfile.registry.intermediate
@@ -1,1 +1,5 @@
-FROM quay.io/openshift/origin-operator-registry:4.5
+FROM quay.io/openshift/origin-operator-registry:4.6 as builder
+
+FROM quay.io/openshift/origin-operator-registry:4.6
+
+COPY --from=builder /usr/bin/sh /bin/sh

--- a/openshift-ci/Dockerfile.registry.upstream.dev
+++ b/openshift-ci/Dockerfile.registry.upstream.dev
@@ -1,4 +1,8 @@
-FROM quay.io/openshift/origin-operator-registry:4.5
+FROM quay.io/openshift/origin-operator-registry:4.6 as builder
+
+FROM quay.io/openshift/origin-operator-registry:4.6
+
+COPY --from=builder /usr/bin/sh /bin/sh
 
 ARG FULL_OPERATOR_IMAGE=quay.io/openshift-kni/performance-addon-operator:4.6-snapshot
 ARG OLM_SOURCE=deploy/olm-catalog
@@ -9,7 +13,11 @@ COPY ${OLM_SOURCE} /registry/performance-addon-operator-catalog
 RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|${FULL_OPERATOR_IMAGE}|g" {} \; || :
 
 # Initialize the database
+USER root
 RUN initializer --manifests /registry/performance-addon-operator-catalog --output bundles.db
+RUN chown 1001 bundles.db
+
+USER 1001
 
 # There are multiple binaries in the origin-operator-registry
 # We want the registry-server


### PR DESCRIPTION
The latest changes under the base registry images broke our build because
the base image does not have any binaries except ones that related to
the registry under the `/bin` directories. Also, the default user
of the registry base image changed from the root to 1001, that will prevent
to save `bundles.db` database under the root directory.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>