### PR TITLE
Enable support for stall daemon in base profile

### DIFF
--- a/build/assets/tuned/openshift-node-performance
+++ b/build/assets/tuned/openshift-node-performance
@@ -25,6 +25,9 @@ governor=performance                          #  latency-performance
 energy_perf_bias=performance                  #  latency-performance 
 min_perf_pct=100                              #  latency-performance 
 
+[service]
+service.stalld=start,enable
+
 [vm]
 transparent_hugepages=never                   #  network-latency
 

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -151,6 +151,15 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				Expect(string(initrd)).ShouldNot(ContainSubstring("'/etc/systemd/system.conf /etc/systemd/system.conf.d/setAffinity.conf'"))
 			}
 		})
+
+		It("[test_id:][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] stalld daemon is running on the host", func() {
+			for _, node := range workerRTNodes {
+				tuned := tunedForNode(&node)
+				_, err := pods.ExecCommandOnPod(tuned, []string{"pidof", "stalld"})
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
 	})
 
 	Context("Additional kernel arguments added from perfomance profile", func() {

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -152,7 +152,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 			}
 		})
 
-		It("[test_id:][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] stalld daemon is running on the host", func() {
+		It("[test_id:35363][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] stalld daemon is running on the host", func() {
 			for _, node := range workerRTNodes {
 				tuned := tunedForNode(&node)
 				_, err := pods.ExecCommandOnPod(tuned, []string{"pidof", "stalld"})


### PR DESCRIPTION
Enable by default the stall daemon in the base profile.
Stall daemon is supported by NTO : https://github.com/openshift/cluster-node-tuning-operator/pull/152  
and tuned service plugin: https://github.com/redhat-performance/tuned/pull/293