### PR TITLE
Makefile: hack: let repeated `make` calls works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ export GO111MODULE=on
 .PHONY: build
 build: gofmt golint govet dist generate-manifests-tree
 
+.PHONY: clean
+clean:
+	rm -rf build/_output
+
 .PHONY: dist
 dist: build-output-dir
 	@echo "Building operator binary"

--- a/hack/generate-manifests-tree.sh
+++ b/hack/generate-manifests-tree.sh
@@ -13,10 +13,11 @@ OUT_DIR="build/_output/manifests"
 OLM_DIR="build/_output/olm-catalog"
 
 if [ ! -d "${OLM_DIR}" ]; then
-	echo "missing output directory ${OUT_DIR} run 'make generate-latest-dev-csv' before" 1>&2
+	echo "missing directory ${OLM_DIR} run 'make generate-latest-dev-csv' before" 1>&2
 	exit 1
 fi
 
+rm -rf "${OUT_DIR}"
 mv "${OLM_DIR}" "${OUT_DIR}"
 find "${OUT_DIR}" -type f -exec sed -i "s|REPLACE_IMAGE|${OPERATOR_IMAGE}|g" {} \; || :
 for entry in ${OUT_DIR}/performance-addon-operator/*; do


### PR DESCRIPTION
Fix `generate-manifests-tree.sh` to clean up the output directory before
to run. This makes sense in general because the scripts can't deal with
dirty output directory: it expects implicitely a clean slate, so let's
enforce this constraints.

As side effect, we enable repeated `make` calls to work cleanly now.

Resolves: https://github.com/openshift-kni/performance-addon-operators/issues/342
Signed-off-by: Francesco Romani <fromani@redhat.com>