### PR TITLE
e2e tests: fix the RT kernel check

### DIFF
--- a/functests/utils/nodes/nodes.go
+++ b/functests/utils/nodes/nodes.go
@@ -172,9 +172,14 @@ func HasPreemptRTKernel(node *corev1.Node) error {
 		return err
 	}
 
-	cmd = []string{"/bin/bash", "-c", "grep -Ee '^CONFIG_PREEMPT_RT=y' /rootfs/usr/lib/modules/$(uname -r)/config"}
-	if _, err := ExecCommandOnNode(cmd, node); err != nil {
+	cmd = []string{"/bin/bash", "-c", "cat /rootfs/sys/kernel/realtime"}
+	out, err := ExecCommandOnNode(cmd, node)
+	if err != nil {
 		return err
+	}
+
+	if out != "1" {
+		return fmt.Errorf("RT kernel disabled")
 	}
 
 	return nil


### PR DESCRIPTION
Flags for the RT kernel configuration are different under
`rhel-rt-8.2` and `rhel-rt-8.3`, `CONFIG_PREEMPT_RT_FULL` vs
`CONFIG_PREEMPT_RT`. To avoid need to change the flag check
we have better check if the RT kernel is enabled via
`/sys/kernel/realtime` file.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>