### PR TITLE
Set Tuned created CR to higher priority

### DIFF
--- a/pkg/controller/performanceprofile/components/tuned/tuned.go
+++ b/pkg/controller/performanceprofile/components/tuned/tuned.go
@@ -118,7 +118,7 @@ func NewNodePerformance(assetsDir string, profile *performancev1.PerformanceProf
 		},
 	}
 
-	priority := uint64(30)
+	priority := uint64(20)
 	recommends := []tunedv1.TunedRecommend{
 		{
 			Profile:             &name,


### PR DESCRIPTION
Set Tuned CR to a higher priority (20) in order to avoid collisions with NTO profiles with the same priority (with emphasis on deploying profiles on mater nodes ) 