### PR TITLE
Do not run 2_performance_update test suit

### DIFF
--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-GINKGO_SUITS=${GINKGO_SUITS:-functests}
+# All test suits should be enabled once the bug https://bugzilla.redhat.com/show_bug.cgi?id=1865839 fixed
+# GINKGO_SUITS=${GINKGO_SUITS:-functests}
+GINKGO_SUITS=${GINKGO_SUITS:-"functests/0_config functests/1_performance functests/3_performance_status"}
 LATENCY_TEST_RUN=${LATENCY_TEST_RUN:-"false"}
 
 which ginkgo


### PR DESCRIPTION
Under our CI very high percentage of failures happens
under the 2_performance_update test suit because of the bug
https://bugzilla.redhat.com/show_bug.cgi?id=1865839.

Disable temporary the 2_performance_update test suit until
the bug will be fixed.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>