### PR TITLE
[release-4.4] Fix for cpu affinity test

### DIFF
--- a/functests/performance/cpu_management.go
+++ b/functests/performance/cpu_management.go
@@ -57,7 +57,7 @@ var _ = Describe("[performance] CPU Management", func() {
 
 		Expect(profile.Spec.CPU.Reserved).NotTo(BeNil())
 		reservedCPU = string(*profile.Spec.CPU.Reserved)
-		reservedCPUSet, err := cpuset.Parse(reservedCPU)
+		reservedCPUSet, err = cpuset.Parse(reservedCPU)
 		Expect(err).ToNot(HaveOccurred())
 		listReservedCPU = reservedCPUSet.ToSlice()
 	})
@@ -86,12 +86,12 @@ var _ = Describe("[performance] CPU Management", func() {
 			Expect(execCommandOnWorker(cmd, workerRTNode)).To(MatchRegexp(fmt.Sprintf(`"reservedSystemCPUs": ?"%s"`, reservedCPU)))
 
 			By("checking CPU affinity mask for kernel scheduler")
-			cmd = []string{"/bin/bash", "-c", "taskset -pc $(pgrep rcu_sched)"}
+			cmd = []string{"/bin/bash", "-c", "taskset -pc 1"}
 			mask := strings.SplitAfter(execCommandOnWorker(cmd, workerRTNode), " ")
 			maskSet, err := cpuset.Parse(mask[len(mask)-1])
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(reservedCPUSet.IsSubsetOf(maskSet)).To(Equal(true))
+			Expect(reservedCPUSet.IsSubsetOf(maskSet)).To(Equal(true), fmt.Sprintf("The init process (pid 1) should have cpu affinity: %s", reservedCPU))
 		})
 
 	})

--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -6,7 +6,8 @@ COPY deploy/olm-catalog /registry/performance-addon-operator-catalog
 
 # easier switching between CI clusters...
 #ENV REG_URL=default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com
-ENV REG_URL=registry.svc.ci.openshift.org
+#ENV REG_URL=registry.svc.ci.openshift.org
+ENV REG_URL=registry.build02.ci.openshift.org
 
 # replaces performance-addon-operator image with the one built by openshift ci
 RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|${REG_URL}/${OPENSHIFT_BUILD_NAMESPACE}/stable:performance-addon-operator|g" {} \; || :


### PR DESCRIPTION
Changed the pid that verifies cpu affinity mask (now using pid 1) for having more generic approach
Removed colon for reservedCPUSet variable in BeforeEach() (otherwise this variable is Null in tests)

(technically, same changes as we had in commit: https://github.com/openshift-kni/performance-addon-operators/pull/331/commits/5f545eb31f1e18c5163851c0211b455d44ea3d1d, can't do cherry pick because of different functest folder structure)