### PR TITLE
Pao run master nodes

### DIFF
--- a/deploy/olm-catalog/performance-addon-operator/4.6.0/performance-addon-operator.v4.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.6.0/performance-addon-operator.v4.6.0.clusterserviceversion.yaml
@@ -118,6 +118,13 @@ spec:
               labels:
                 name: performance-operator
             spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
               containers:
               - command:
                 - performance-operator
@@ -137,6 +144,9 @@ spec:
                 name: performance-operator
                 resources: {}
               serviceAccountName: performance-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
       permissions:
       - rules:
         - apiGroups:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -13,6 +13,16 @@ spec:
         name: performance-operator
     spec:
       serviceAccountName: performance-operator
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
         - name: performance-operator
           # Replace this with the built image name

--- a/functests/0_config/config.go
+++ b/functests/0_config/config.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -29,8 +27,6 @@ import (
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/mcps"
-	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
-	"github.com/openshift-kni/performance-addon-operators/functests/utils/pods"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
 	"github.com/openshift-kni/performance-addon-operators/pkg/apis"
 	performancev1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
@@ -40,25 +36,6 @@ import (
 )
 
 var _ = Describe("[performance][config] Performance configuration", func() {
-
-	It("Should run performance profile pod on a master node", func() {
-		pod, err := pods.GetPerformanceOperatorPod()
-		Expect(err).ToNot(HaveOccurred(), "Failed to find the Performance Addon Operator pod")
-
-		Expect(strings.HasPrefix(pod.Name, "performance-operator")).To(BeTrue(),
-			"Performance Addon Operator pod name should start with performance-operator prefix")
-
-		masterNodes, err := nodes.GetByRole(testutils.RoleMaster)
-		Expect(err).ToNot(HaveOccurred(), "Failed to query the master nodes")
-		for _, node := range masterNodes {
-			if node.Name == pod.Spec.NodeName {
-				return
-			}
-		}
-
-		// Fail
-		Expect(true).To(Reject(), "Performance Addon Operator is not running in a master node")
-	})
 
 	It("Should successfully deploy the performance profile", func() {
 

--- a/functests/0_config/config.go
+++ b/functests/0_config/config.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -27,6 +29,8 @@ import (
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/mcps"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/pods"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
 	"github.com/openshift-kni/performance-addon-operators/pkg/apis"
 	performancev1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
@@ -36,6 +40,25 @@ import (
 )
 
 var _ = Describe("[performance][config] Performance configuration", func() {
+
+	It("Should run performance profile pod on a master node", func() {
+		pod, err := pods.GetPerformanceOperatorPod()
+		Expect(err).ToNot(HaveOccurred(), "Failed to find the Performance Addon Operator pod")
+
+		Expect(strings.HasPrefix(pod.Name, "performance-operator")).To(BeTrue(),
+			"Performance Addon Operator pod name should start with performance-operator prefix")
+
+		masterNodes, err := nodes.GetByRole(testutils.RoleMaster)
+		Expect(err).ToNot(HaveOccurred(), "Failed to query the master nodes")
+		for _, node := range masterNodes {
+			if node.Name == pod.Spec.NodeName {
+				return
+			}
+		}
+
+		// Fail
+		Expect(true).To(Reject(), "Performance Addon Operator is not running in a master node")
+	})
 
 	It("Should successfully deploy the performance profile", func() {
 

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/node/v1beta1"
@@ -59,6 +60,29 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 		Expect(workerRTNodes).ToNot(BeEmpty(), fmt.Sprintf("no nodes with role %q found", testutils.RoleWorkerCNF))
 		profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// self-tests; these are only vaguely related to performance becase these are enablement conditions, not actual settings.
+	// For example, running on control plane means we leave more resources for the workload.
+	Context("Performance Operator", func() {
+		It("Should run on the control plane nodes", func() {
+			pod, err := pods.GetPerformanceOperatorPod()
+			Expect(err).ToNot(HaveOccurred(), "Failed to find the Performance Addon Operator pod")
+
+			Expect(strings.HasPrefix(pod.Name, "performance-operator")).To(BeTrue(),
+				"Performance Addon Operator pod name should start with performance-operator prefix")
+
+			masterNodes, err := nodes.GetByRole(testutils.RoleMaster)
+			Expect(err).ToNot(HaveOccurred(), "Failed to query the master nodes")
+			for _, node := range masterNodes {
+				if node.Name == pod.Spec.NodeName {
+					return
+				}
+			}
+
+			// Fail
+			Expect(true).To(Reject(), "Performance Addon Operator is not running in a master node")
+		})
 	})
 
 	Context("Tuned CRs generated from profile", func() {

--- a/functests/utils/consts.go
+++ b/functests/utils/consts.go
@@ -67,6 +67,8 @@ func init() {
 const (
 	// RoleWorker contains the worker role
 	RoleWorker = "worker"
+	// RoleMaster contains the master role
+	RoleMaster = "master"
 )
 
 const (

--- a/functests/utils/pods/pods.go
+++ b/functests/utils/pods/pods.go
@@ -11,9 +11,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
@@ -142,4 +144,24 @@ func GetContainerIDByName(pod *corev1.Pod, containerName string) (string, error)
 		}
 	}
 	return "", fmt.Errorf("failed to find the container ID for the container %q under the pod %q", containerName, pod.Name)
+}
+
+// GetPerformanceOperatorPod returns the pod running the Performance Profile Operator
+func GetPerformanceOperatorPod() (*corev1.Pod, error) {
+	selector, err := labels.Parse(fmt.Sprintf("%s=%s", "name", "performance-operator"))
+	if err != nil {
+		return nil, err
+	}
+
+	pods := &corev1.PodList{}
+
+	opts := &client.ListOptions{LabelSelector: selector, Namespace: testutils.PerformanceOperatorNamespace}
+	if err := testclient.Client.List(context.TODO(), pods, opts); err != nil {
+		return nil, err
+	}
+	if len(pods.Items) != 1 {
+		return nil, fmt.Errorf("incorrect performance operator pods count: %d", len(pods.Items))
+	}
+
+	return &pods.Items[0], nil
 }


### PR DESCRIPTION
Followup of https://github.com/openshift-kni/performance-addon-operators/pull/351 with the functest moved out from the `0_config` suite.