### PR TITLE
functests: ensure deleted objects are really gone

### DIFF
--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -50,8 +50,9 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
 		Expect(workerRTNodes).ToNot(BeEmpty())
 		workerRTNode = &workerRTNodes[0]
-
 		profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
+		By(fmt.Sprintf("Checking the profile %s with cpus %#v", profile.Name, profile.Spec.CPU))
+
 		Expect(err).ToNot(HaveOccurred())
 		Expect(profile.Spec.HugePages).ToNot(BeNil())
 

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -318,6 +318,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 
 			By("Remove second profile and verify that KubeletConfig and MachineConfig were removed")
 			Expect(testclient.Client.Delete(context.TODO(), secondProfile)).ToNot(HaveOccurred())
+			Expect(profiles.WaitForDeletion(secondProfile, 60*time.Second)).ToNot(HaveOccurred())
 
 			Consistently(func() corev1.ConditionStatus {
 				return mcps.GetConditionStatus(testutils.RoleWorkerCNF, machineconfigv1.MachineConfigPoolUpdating)

--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -108,7 +108,13 @@ var _ = Describe("[performance] Latency Test", func() {
 	})
 
 	AfterEach(func() {
-		if err := testclient.Client.Delete(context.TODO(), oslatPod); err != nil {
+		var err error
+		err = testclient.Client.Delete(context.TODO(), oslatPod)
+		if err != nil {
+			klog.Error(err)
+		}
+		err = pods.WaitForDeletion(oslatPod, 60*time.Second)
+		if err != nil {
 			klog.Error(err)
 		}
 	})

--- a/functests/utils/clean/clean.go
+++ b/functests/utils/clean/clean.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/profile"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/mcps"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
 	performancev1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
 	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
@@ -45,6 +47,8 @@ func All() {
 	Expect(err).ToNot(HaveOccurred(), "Failed to find perf profile")
 	err = testclient.Client.Delete(context.TODO(), &perfProfile)
 	Expect(err).ToNot(HaveOccurred(), "Failed to delete perf profile")
+	err = profiles.WaitForDeletion(&perfProfile, 60*time.Second)
+	Expect(err).ToNot(HaveOccurred(), "Failed to wait for perf profile deletion")
 
 	mcpLabel := profile.GetMachineConfigLabel(&perfProfile)
 	key, value := components.GetFirstKeyAndValue(mcpLabel)


### PR DESCRIPTION
In our test suite we must ensure deleted objects are really gone.
Add WaitForDeletion helper for profiles, and use it in the test which previously just used other means to check a profile was gone.
Make sure we consistently wait for pod deletion once we delete a pod.