### PR TITLE
Fix test: "Verify rcu_nocbs kernel argument on the node"

### DIFF
--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -37,7 +37,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 	var balanceIsolated bool
 	var reservedCPU, isolatedCPU string
 	var listReservedCPU, listIsolatedCPU []int
-	var reservedCPUSet, isolatedCPUSet cpuset.CPUSet
+	var reservedCPUSet cpuset.CPUSet
 
 	BeforeEach(func() {
 		if discovery.Enabled() && testutils.ProfileNotFound {
@@ -63,7 +63,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 
 		Expect(profile.Spec.CPU.Isolated).NotTo(BeNil())
 		isolatedCPU = string(*profile.Spec.CPU.Isolated)
-		isolatedCPUSet, err = cpuset.Parse(isolatedCPU)
+		isolatedCPUSet, err := cpuset.Parse(isolatedCPU)
 		Expect(err).ToNot(HaveOccurred())
 		listIsolatedCPU = isolatedCPUSet.ToSlice()
 


### PR DESCRIPTION
A given process may end up being assigned in a cpu not belonging to the
reserved cpu set (i.e. if the host has more than reserved + isolated cpus). This
leads to flakes. Here we just check that cpu does not belong to the isolated
cpus because there is no guarantee for belonging to the reserved cpus.
