### PR TITLE
controller: validation: check for cpu cores split

### DIFF
--- a/functests/utils/profiles/profiles.go
+++ b/functests/utils/profiles/profiles.go
@@ -15,6 +15,7 @@ import (
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	performancev1 "github.com/openshift-kni/performance-addon-operators/pkg/apis/performance/v1"
 	v1 "github.com/openshift/custom-resource-status/conditions/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // GetByNodeLabels gets the performance profile that must have node selector equals to passed node labels
@@ -56,16 +57,37 @@ func WaitForDeletion(prof *performancev1.PerformanceProfile, timeout time.Durati
 	})
 }
 
-// GetConditionMessage gets the performance profile message for the given type
-func GetConditionMessage(nodeLabels map[string]string, conditionType v1.ConditionType) string {
+// GetCondition the performance profile condition for the given type
+func GetCondition(nodeLabels map[string]string, conditionType v1.ConditionType) *v1.Condition {
 	profile, err := GetByNodeLabels(nodeLabels)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "Failed getting profile by nodelabel")
 	for _, condition := range profile.Status.Conditions {
 		if condition.Type == conditionType {
-			return condition.Message
+			return &condition
 		}
 	}
+	return nil
+}
+
+// GetConditionMessage gets the performance profile message for the given type
+func GetConditionMessage(nodeLabels map[string]string, conditionType v1.ConditionType) string {
+	cond := GetCondition(nodeLabels, conditionType)
+	if cond != nil {
+		return cond.Message
+	}
 	return ""
+}
+
+func GetConditionWithStatus(nodeLabels map[string]string, conditionType v1.ConditionType) *v1.Condition {
+	var cond *v1.Condition
+	EventuallyWithOffset(1, func() bool {
+		cond = GetCondition(nodeLabels, conditionType)
+		if cond == nil {
+			return false
+		}
+		return cond.Status == corev1.ConditionTrue
+	}, 30, 5).Should(BeTrue(), "condition %q not matched: %#v", conditionType, cond)
+	return cond
 }
 
 // All gets all the exiting profiles in the cluster

--- a/pkg/controller/performanceprofile/components/utils.go
+++ b/pkg/controller/performanceprofile/components/utils.go
@@ -108,3 +108,18 @@ func CPUListToMaskList(cpulist string) (hexMask string, err error) {
 	trimmedCPUMaskList := b.String()
 	return trimmedCPUMaskList, nil
 }
+
+// CPUListIntersect returns cpu ids found in both the provided cpuLists, if any
+func CPUListIntersect(cpuListA, cpuListB string) ([]int, error) {
+	var err error
+	cpusA, err := cpuset.Parse(cpuListA)
+	if err != nil {
+		return nil, err
+	}
+	cpusB, err := cpuset.Parse(cpuListB)
+	if err != nil {
+		return nil, err
+	}
+	commonSet := cpusA.Intersection(cpusB)
+	return commonSet.ToSlice(), nil
+}

--- a/pkg/controller/performanceprofile/components/utils_test.go
+++ b/pkg/controller/performanceprofile/components/utils_test.go
@@ -39,4 +39,49 @@ var _ = Describe("Components utils", func() {
 			}
 		})
 	})
+
+	Context("Check intersections between CPU sets", func() {
+		It("should detect invalid cpulists", func() {
+			var cpuListInvalid = []string{
+				"0-", "-", "-3", ",,", ",2", "-,", "0-1,", "0,1,3,,4",
+			}
+
+			for _, entry := range cpuListInvalid {
+				_, err := CPUListIntersect(entry, entry)
+				Expect(err).To(HaveOccurred())
+
+				_, err = CPUListIntersect(entry, "0-3")
+				Expect(err).To(HaveOccurred())
+
+				_, err = CPUListIntersect("0-3", entry)
+				Expect(err).To(HaveOccurred())
+			}
+		})
+
+		It("should detect cpulist intersections", func() {
+			type cpuListIntersect struct {
+				cpuListA string
+				cpuListB string
+				result   []int
+			}
+
+			var cpuListIntersectTestcases = []cpuListIntersect{
+				{"0-3", "4-15", []int{}},
+				{"0-3", "8-15", []int{}},
+				{"0-3", "0-15", []int{0, 1, 2, 3}},
+				{"0-3", "3-15", []int{3}},
+				{"3-7", "6-15", []int{6, 7}},
+			}
+
+			for _, entry := range cpuListIntersectTestcases {
+				res, err := CPUListIntersect(entry.cpuListA, entry.cpuListB)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(len(res)).To(Equal(len(entry.result)))
+				for idx, cpuid := range res {
+					Expect(cpuid).To(Equal(entry.result[idx]))
+				}
+			}
+		})
+	})
 })


### PR DESCRIPTION
We always assume, and document, that the reserved and
isolated cpus set must not overlap.
Add some validation code to enforce this constraint.

Signed-off-by: Francesco Romani <fromani@redhat.com>