### PR TITLE
Adaptation to build operators under the OpenShift CI

### DIFF
--- a/cluster-setup/mcp-only-cluster/performance/kustomization.yaml
+++ b/cluster-setup/mcp-only-cluster/performance/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - machine_config_pool.yaml

--- a/cluster-setup/mcp-only-cluster/performance/machine_config_pool.yaml
+++ b/cluster-setup/mcp-only-cluster/performance/machine_config_pool.yaml
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker-cnf
+  namespace: openshift-machine-config-operator
+  labels:
+    machineconfiguration.openshift.io/role: worker-cnf
+spec:
+  paused: true
+  machineConfigSelector:
+    matchExpressions:
+      - key: machineconfiguration.openshift.io/role
+        operator: In
+        values: [worker,worker-cnf]
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker-cnf: ""

--- a/deploy/metadata/performance-addon-operator/4.5.1/annotations.yaml
+++ b/deploy/metadata/performance-addon-operator/4.5.1/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: "registry+v1"
+  operators.operatorframework.io.bundle.manifests.v1: "manifests/"
+  operators.operatorframework.io.bundle.metadata.v1: "metadata/"
+  operators.operatorframework.io.bundle.package.v1: "performance-addon-operator"
+  operators.operatorframework.io.bundle.channels.v1: "4.5"
+  operators.operatorframework.io.bundle.channel.default.v1: "4.5"

--- a/deploy/olm-catalog/performance-addon-operator/4.5.1/performance-addon-operator.v4.5.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.5.1/performance-addon-operator.v4.5.1.clusterserviceversion.yaml
@@ -1,0 +1,206 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "performance.openshift.io/v1",
+          "kind": "PerformanceProfile",
+          "metadata": {
+            "name": "example-performanceprofile"
+          },
+          "spec": {
+            "additionalKernelArgs": [
+              "nmi_watchdog=0",
+              "audit=0",
+              "mce=off",
+              "processor.max_cstate=1",
+              "idle=poll",
+              "intel_idle.max_cstate=0"
+            ],
+            "cpu": {
+              "isolated": "2-3",
+              "reserved": "0-1"
+            },
+            "hugepages": {
+              "defaultHugepagesSize": "1G",
+              "pages": [
+                {
+                  "count": 2,
+                  "node": 0,
+                  "size": "1G"
+                }
+              ]
+            },
+            "nodeSelector": {
+              "node-role.kubernetes.io/performance": ""
+            },
+            "realTimeKernel": {
+              "enabled": true
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    containerImage: REPLACE_IMAGE
+    olm.skipRange: '>=4.4.0 <4.5.1'
+  name: performance-addon-operator.v4.5.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: PerformanceProfile is the Schema for the performanceprofiles API.
+      displayName: Performance Profile
+      kind: PerformanceProfile
+      name: performanceprofiles.performance.openshift.io
+      version: v1
+    - description: PerformanceProfile is the Schema for the performanceprofiles API.
+      displayName: Performance Profile
+      kind: PerformanceProfile
+      name: performanceprofiles.performance.openshift.io
+      version: v1alpha1
+  description: |2-
+
+    Performance Addon Operator provides the ability to enable advanced node performance tunings on a set of nodes.
+  displayName: Performance Addon Operator
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - '*'
+        - apiGroups:
+          - performance.openshift.io
+          resources:
+          - performanceprofiles
+          - performanceprofiles/finalizers
+          - performanceprofiles/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - machineconfiguration.openshift.io
+          resources:
+          - machineconfigs
+          - machineconfigpools
+          - kubeletconfigs
+          verbs:
+          - '*'
+        - apiGroups:
+          - tuned.openshift.io
+          resources:
+          - tuneds
+          verbs:
+          - '*'
+        - apiGroups:
+          - node.k8s.io
+          resources:
+          - runtimeclasses
+          verbs:
+          - '*'
+        serviceAccountName: performance-operator
+      deployments:
+      - name: performance-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: performance-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: performance-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: node-role.kubernetes.io/master
+                        operator: Exists
+              containers:
+              - command:
+                - performance-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: performance-operator
+                image: REPLACE_IMAGE
+                imagePullPolicy: Always
+                name: performance-operator
+                resources: {}
+              serviceAccountName: performance-operator
+              tolerations:
+              - effect: NoSchedule
+                key: node-role.kubernetes.io/master
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - configmaps
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resourceNames:
+          - performance-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - '*'
+        serviceAccountName: performance-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - numa
+  - realtime
+  - cpu pinning
+  - hugepages
+  links:
+  - name: Source Code
+    url: https://github.com/openshift-kni/performance-addon-operators
+  maturity: alpha
+  provider:
+    name: Red Hat
+  version: 4.5.1

--- a/deploy/olm-catalog/performance-addon-operator/4.5.1/performance.openshift.io_performanceprofiles_crd.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.5.1/performance.openshift.io_performanceprofiles_crd.yaml
@@ -1,0 +1,377 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: performanceprofiles.performance.openshift.io
+spec:
+  group: performance.openshift.io
+  names:
+    kind: PerformanceProfile
+    listKind: PerformanceProfileList
+    plural: performanceprofiles
+    singular: performanceprofile
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: PerformanceProfile is the Schema for the performanceprofiles
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PerformanceProfileSpec defines the desired state of PerformanceProfile.
+            properties:
+              additionalKernelArgs:
+                description: Addional kernel arguments.
+                items:
+                  type: string
+                type: array
+              cpu:
+                description: CPU defines a set of CPU related parameters.
+                properties:
+                  balanceIsolated:
+                    description: BalanceIsolated toggles whether or not the Isolated
+                      CPU set is eligible for load balancing work loads. When this
+                      option is set to "false", the Isolated CPU set will be static,
+                      meaning workloads have to explicitly assign each thread to a
+                      specific cpu in order to work across multiple CPUs. Setting
+                      this to "true" allows workloads to be balanced across CPUs.
+                      Setting this to "false" offers the most predictable performance
+                      for guaranteed workloads, but it offloads the complexity of
+                      cpu load balancing to the application. Defaults to "true"
+                    type: boolean
+                  isolated:
+                    description: 'Isolated defines a set of CPUs that will be used
+                      to give to application threads the most execution time possible,
+                      which means removing as many extraneous tasks off a CPU as possible.
+                      It is important to notice the CPU manager can choose any CPU
+                      to run the workload except the reserved CPUs. In order to guarantee
+                      that your workload will run on the isolated CPU:   1. The union
+                      of reserved CPUs and isolated CPUs should include all online
+                      CPUs   2. The isolated CPUs field should be the complementary
+                      to reserved CPUs field'
+                    type: string
+                  reserved:
+                    description: Reserved defines a set of CPUs that will not be used
+                      for any container workloads initiated by kubelet.
+                    type: string
+                type: object
+              hugepages:
+                description: HugePages defines a set of huge pages related parameters.
+                  It is possible to set huge pages with multiple size values at the
+                  same time. For example, hugepages can be set with 1G and 2M, both
+                  values will be set on the node by the performance-addon-operator.
+                  It is important to notice that setting hugepages default size to
+                  1G will remove all 2M related folders from the node and it will
+                  be impossible to configure 2M hugepages under the node.
+                properties:
+                  defaultHugepagesSize:
+                    description: DefaultHugePagesSize defines huge pages default size
+                      under kernel boot parameters.
+                    type: string
+                  pages:
+                    description: Pages defines huge pages that we want to allocate
+                      at boot time.
+                    items:
+                      description: HugePage defines the number of allocated huge pages
+                        of the specific size.
+                      properties:
+                        count:
+                          description: Count defines amount of huge pages, maps to
+                            the 'hugepages' kernel boot parameter.
+                          format: int32
+                          type: integer
+                        node:
+                          description: Node defines the NUMA node where hugepages
+                            will be allocated, if not specified, pages will be allocated
+                            equally between NUMA nodes
+                          format: int32
+                          type: integer
+                        size:
+                          description: Size defines huge page size, maps to the 'hugepagesz'
+                            kernel boot parameter.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              machineConfigLabel:
+                additionalProperties:
+                  type: string
+                description: MachineConfigLabel defines the label to add to the MachineConfigs
+                  the operator creates. It has to be used in the MachineConfigSelector
+                  of the MachineConfigPool which targets this performance profile.
+                  Defaults to "machineconfiguration.openshift.io/role=<same role as
+                  in NodeSelector label key>"
+                type: object
+              machineConfigPoolSelector:
+                additionalProperties:
+                  type: string
+                description: MachineConfigPoolSelector defines the MachineConfigPool
+                  label to use in the MachineConfigPoolSelector of resources like
+                  KubeletConfigs created by the operator. Defaults to "machineconfiguration.openshift.io/role=<same
+                  role as in NodeSelector label key>"
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector defines the Node label to use in the NodeSelectors
+                  of resources like Tuned created by the operator. It most likely
+                  should, but does not have to match the node label in the NodeSelector
+                  of the MachineConfigPool which targets this performance profile.
+                type: object
+              numa:
+                description: NUMA defines options related to topology aware affinities
+                properties:
+                  topologyPolicy:
+                    description: Name of the policy applied when TopologyManager is
+                      enabled Operator defaults to "best-effort"
+                    type: string
+                type: object
+              realTimeKernel:
+                description: RealTimeKernel defines a set of real time kernel related
+                  parameters. RT kernel won't be installed when not set.
+                properties:
+                  enabled:
+                    description: Enabled defines if the real time kernel packages
+                      should be installed. Defaults to "false"
+                    type: boolean
+                type: object
+            type: object
+          status:
+            description: PerformanceProfileStatus defines the observed state of PerformanceProfile.
+            properties:
+              conditions:
+                description: Conditions represents the latest available observations
+                  of current state.
+                items:
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              runtimeClass:
+                description: RuntimeClass contains the name of the RuntimeClass resource
+                  created by the operator.
+                type: string
+              tuned:
+                description: Tuned points to the Tuned custom resource object that
+                  contains the tuning values generated by this operator.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PerformanceProfile is the Schema for the performanceprofiles
+          API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PerformanceProfileSpec defines the desired state of PerformanceProfile.
+            properties:
+              additionalKernelArgs:
+                description: Addional kernel arguments.
+                items:
+                  type: string
+                type: array
+              cpu:
+                description: CPU defines a set of CPU related parameters.
+                properties:
+                  balanceIsolated:
+                    description: BalanceIsolated toggles whether or not the Isolated
+                      CPU set is eligible for load balancing work loads. When this
+                      option is set to "false", the Isolated CPU set will be static,
+                      meaning workloads have to explicitly assign each thread to a
+                      specific cpu in order to work across multiple CPUs. Setting
+                      this to "true" allows workloads to be balanced across CPUs.
+                      Setting this to "false" offers the most predictable performance
+                      for guaranteed workloads, but it offloads the complexity of
+                      cpu load balancing to the application. Defaults to "true"
+                    type: boolean
+                  isolated:
+                    description: 'Isolated defines a set of CPUs that will be used
+                      to give to application threads the most execution time possible,
+                      which means removing as many extraneous tasks off a CPU as possible.
+                      It is important to notice the CPU manager can choose any CPU
+                      to run the workload except the reserved CPUs. In order to guarantee
+                      that your workload will run on the isolated CPU:   1. The union
+                      of reserved CPUs and isolated CPUs should include all online
+                      CPUs   2. The isolated CPUs field should be the complementary
+                      to reserved CPUs field'
+                    type: string
+                  reserved:
+                    description: Reserved defines a set of CPUs that will not be used
+                      for any container workloads initiated by kubelet.
+                    type: string
+                type: object
+              hugepages:
+                description: HugePages defines a set of huge pages related parameters.
+                  It is possible to set huge pages with multiple size values at the
+                  same time. For example, hugepages can be set with 1G and 2M, both
+                  values will be set on the node by the performance-addon-operator.
+                  It is important to notice that setting hugepages default size to
+                  1G will remove all 2M related folders from the node and it will
+                  be impossible to configure 2M hugepages under the node.
+                properties:
+                  defaultHugepagesSize:
+                    description: DefaultHugePagesSize defines huge pages default size
+                      under kernel boot parameters.
+                    type: string
+                  pages:
+                    description: Pages defines huge pages that we want to allocate
+                      at boot time.
+                    items:
+                      description: HugePage defines the number of allocated huge pages
+                        of the specific size.
+                      properties:
+                        count:
+                          description: Count defines amount of huge pages, maps to
+                            the 'hugepages' kernel boot parameter.
+                          format: int32
+                          type: integer
+                        node:
+                          description: Node defines the NUMA node where hugepages
+                            will be allocated, if not specified, pages will be allocated
+                            equally between NUMA nodes
+                          format: int32
+                          type: integer
+                        size:
+                          description: Size defines huge page size, maps to the 'hugepagesz'
+                            kernel boot parameter.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              machineConfigLabel:
+                additionalProperties:
+                  type: string
+                description: MachineConfigLabel defines the label to add to the MachineConfigs
+                  the operator creates. It has to be used in the MachineConfigSelector
+                  of the MachineConfigPool which targets this performance profile.
+                  Defaults to "machineconfiguration.openshift.io/role=<same role as
+                  in NodeSelector label key>"
+                type: object
+              machineConfigPoolSelector:
+                additionalProperties:
+                  type: string
+                description: MachineConfigPoolSelector defines the MachineConfigPool
+                  label to use in the MachineConfigPoolSelector of resources like
+                  KubeletConfigs created by the operator. Defaults to "machineconfiguration.openshift.io/role=<same
+                  role as in NodeSelector label key>"
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector defines the Node label to use in the NodeSelectors
+                  of resources like Tuned created by the operator. It most likely
+                  should, but does not have to match the node label in the NodeSelector
+                  of the MachineConfigPool which targets this performance profile.
+                type: object
+              numa:
+                description: NUMA defines options related to topology aware affinities
+                properties:
+                  topologyPolicy:
+                    description: Name of the policy applied when TopologyManager is
+                      enabled Operator defaults to "best-effort"
+                    type: string
+                type: object
+              realTimeKernel:
+                description: RealTimeKernel defines a set of real time kernel related
+                  parameters. RT kernel won't be installed when not set.
+                properties:
+                  enabled:
+                    description: Enabled defines if the real time kernel packages
+                      should be installed. Defaults to "false"
+                    type: boolean
+                type: object
+            type: object
+          status:
+            description: PerformanceProfileStatus defines the observed state of PerformanceProfile.
+            properties:
+              conditions:
+                description: Conditions represents the latest available observations
+                  of current state.
+                items:
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              runtimeClass:
+                description: RuntimeClass contains the name of the RuntimeClass resource
+                  created by the operator.
+                type: string
+              tuned:
+                description: Tuned points to the Tuned custom resource object that
+                  contains the tuning values generated by this operator.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/deploy/olm-catalog/performance-addon-operator/performance-addon-operator.package.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/performance-addon-operator.package.yaml
@@ -1,7 +1,7 @@
 channels:
 - currentCSV: performance-addon-operator.v4.4.0
   name: "4.4"
-- currentCSV: performance-addon-operator.v4.5.0
+- currentCSV: performance-addon-operator.v4.5.1
   name: "4.5"
 - currentCSV: performance-addon-operator.v4.6.0
   name: "4.6"

--- a/openshift-ci/Dockerfile.bundle-4.5.ci
+++ b/openshift-ci/Dockerfile.bundle-4.5.ci
@@ -1,0 +1,15 @@
+# see: https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md
+FROM scratch
+
+ARG CHANNEL=4.5
+ARG ZVERSION=1
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=performance-addon-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=4.5.1
+LABEL operators.operatorframework.io.bundle.channel.default.v1=4.5.1
+
+COPY deploy/metadata/performance-addon-operator/${CHANNEL}.${ZVERSION}/* /metadata/
+COPY deploy/olm-catalog/performance-addon-operator/${CHANNEL}.${ZVERSION}/* /manifests/


### PR DESCRIPTION
- add 4.5.1 CSV
- add 4.5 bundle docker image to test possibility to build
index image that will include multiple versions
- add mcp-only-cluster setup manifests because all other
components deployed by the OpenShift CI

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>