### PR TITLE
Add a loop to the hugepages allocation script

### DIFF
--- a/build/assets/scripts/hugepages-allocation.sh
+++ b/build/assets/scripts/hugepages-allocation.sh
@@ -5,14 +5,22 @@ set -euo pipefail
 nodes_path="/sys/devices/system/node"
 hugepages_file="${nodes_path}/node${NUMA_NODE}/hugepages/hugepages-${HUGEPAGES_SIZE}kB/nr_hugepages"
 
-if [ ! -f  ${hugepages_file} ]; then
-    echo "ERROR: ${hugepages_file} does not exist"
-    exit 1
+if [ ! -f "${hugepages_file}" ]; then
+  echo "ERROR: ${hugepages_file} does not exist"
+  exit 1
 fi
 
-echo ${HUGEPAGES_COUNT} > ${hugepages_file}
+timeout=60
+sample=1
+current_time=0
+while [ "$(cat "${hugepages_file}")" -ne "${HUGEPAGES_COUNT}" ]; do
+  echo "${HUGEPAGES_COUNT}" >"${hugepages_file}"
 
-if [ $(cat ${hugepages_file}) -ne ${HUGEPAGES_COUNT} ]; then
+  current_time=$((current_time + sample))
+  if [ $current_time -gt $timeout ]; then
     echo "ERROR: ${hugepages_file} does not have the expected number of hugepages ${HUGEPAGES_COUNT}"
     exit 1
-fi
+  fi
+
+  sleep $sample
+done


### PR DESCRIPTION
The allocation of hugepages dynamically via the allocation
the script sometimes failed(the reason still under the investigation)
and does not allocate the specified number of hugepages.

And on the second try, the allocation succeeds. To try allocation
again we added the while loop that will try to allocate again for
the whole minute with the frequency one sample per second.

Fixes #279 

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>