### PR TITLE
e2e: fix the runtime class test

### DIFF
--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -7,7 +7,7 @@ COPY deploy/olm-catalog /registry/performance-addon-operator-catalog
 # easier switching between CI clusters...
 # ENV REG_URL=default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com
 # ENV REG_URL=registry.svc.ci.openshift.org
-ENV REG_URL=registry.build02.ci.openshift.org
+ENV REG_URL=registry.build01.ci.openshift.org
 
 # replaces performance-addon-operator image with the one built by openshift ci
 RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|${REG_URL}/${OPENSHIFT_BUILD_NAMESPACE}/stable:performance-addon-operator|g" {} \; || :


### PR DESCRIPTION
Under our CI it happens pretty often that the test
does not get the path to the container cpuset cgroup,
probably it takes some time to sync cgroup changes between host
and machine-config-daemon container.

To see if it indeed the case I will add `Eventually` that will try
to fetch container cpuset cgroup for two minutes with 30 seconds samples.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>