### PR TITLE
Fix for upgrade script: make deploying PAO optional

### DIFF
--- a/hack/run-upgrade-tests.sh
+++ b/hack/run-upgrade-tests.sh
@@ -9,6 +9,7 @@ OC_TOOL="${OC_TOOL:-oc}"
 RUN_TESTS_AFTER_UPGRADE="${RUN_TESTS_AFTER_UPGRADE:-true}"
 PERF_TEST_PROFILE="${PERF_TEST_PROFILE:-upgrade-test}"
 CLUSTER="${CLUSTER:-upgrade-test}"
+DEPLOY_PAO="${DEPLOY_PAO:-true}"
 
 # check if operator is already installed with right version
 subs=$(${OC_TOOL} get subscriptions -o name -n openshift-performance-addon)
@@ -21,9 +22,11 @@ if [ -n "$subs" ]; then
   fi
 fi
 
-CLUSTER="${CLUSTER}" make cluster-deploy
-make cluster-label-worker-cnf
-CLUSTER="upgrade-test" make cluster-wait-for-mcp
+if [ "$DEPLOY_PAO" == true ]; then
+  CLUSTER="${CLUSTER}" make cluster-deploy
+  make cluster-label-worker-cnf
+  CLUSTER="upgrade-test" make cluster-wait-for-mcp
+fi
 
 which ginkgo
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Deploying PAO should be optional for running upgrade tests in d/s environment (since we already have it deployed thru d/s stuff)