### PR TITLE
e2e: fix getting a profile by the node selector

### DIFF
--- a/functests/utils/profiles/profiles.go
+++ b/functests/utils/profiles/profiles.go
@@ -25,12 +25,12 @@ func GetByNodeLabels(nodeLabels map[string]string) (*performancev1.PerformancePr
 	}
 
 	var result *performancev1.PerformanceProfile
-	for _, profile := range profiles.Items {
-		if reflect.DeepEqual(profile.Spec.NodeSelector, nodeLabels) {
+	for i := 0; i < len(profiles.Items); i++ {
+		if reflect.DeepEqual(profiles.Items[i].Spec.NodeSelector, nodeLabels) {
 			if result != nil {
 				return nil, fmt.Errorf("found more than one performance profile with specified node selector %v", nodeLabels)
 			}
-			result = &profile
+			result = &profiles.Items[i]
 		}
 	}
 


### PR DESCRIPTION
When the range used under the `for` loop it will create a new
scoped variable, that will have a different value for each loop cycle.
Once you will get the pointer on this variable it will point to the latest
element that the `for` loop will pass.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>