### PR TITLE
functests: don't read stderr when getting logs

### DIFF
--- a/functests/utils/utils.go
+++ b/functests/utils/utils.go
@@ -19,7 +19,7 @@ func BeforeAll(fn func()) {
 }
 
 func ExecAndLogCommand(name string, arg ...string) ([]byte, error) {
-	out, err := exec.Command(name, arg...).CombinedOutput()
+	out, err := exec.Command(name, arg...).Output()
 	klog.Infof("run command '%s %v':\n  out=%s\n  err=%v", name, arg, out, err)
 	return out, err
 }

--- a/functests/utils/utils.go
+++ b/functests/utils/utils.go
@@ -20,6 +20,9 @@ func BeforeAll(fn func()) {
 
 func ExecAndLogCommand(name string, arg ...string) ([]byte, error) {
 	out, err := exec.Command(name, arg...).Output()
-	klog.Infof("run command '%s %v':\n  out=%s\n  err=%v", name, arg, out, err)
+	klog.Infof("run command '%s %v' (err=%v):\n  stdout=%s\n", name, arg, err, out)
+	if exitError, ok := err.(*exec.ExitError); ok {
+		klog.Infof("run command '%s %v' (err=%v):\n  stderr=%s", name, arg, err, exitError.Stderr)
+	}
 	return out, err
 }


### PR DESCRIPTION
We expect nothing useful from stderr, so let's not even read it
Capturing stderr is useful to troubleshoot failures, but it should not mixed with stdout and should be captured and kept separate.