### PR TITLE
latency-test: add initial delay

### DIFF
--- a/functests/4_latency/run-tests.sh
+++ b/functests/4_latency/run-tests.sh
@@ -4,6 +4,11 @@ set -e
 # Setting -e is fine as we want both config to succeed
 # before running the "real" tests.
 
+delay=${LATENCY_TEST_DELAY:-0}
+
+echo "waiting ${delay}s before to run the tests"
+sleep ${delay}s
+
 suites=(0_config 4_latency)
 
 for suite in "${suites[@]}"; do


### PR DESCRIPTION
We add an optional delay before to actually run the latency test
to give more room to the kubelet reconcile loop to kick in and make
sure all the pods are running in the proper cpusets.

Without this delay is harder to guarantee that other pods do not
run on exclusively allocated cpus.

Please note that using a delay is a mitigation of the inherent (lack of)
synchronization between the test and the kubelet cpumanager reconcile
loop. It is very possible that the reconciliation happens fast enough
even with initial zero delay, so this change add a test/troubleshooting
knob rather than fixing a misbehaviour.

Signed-off-by: Francesco Romani <fromani@redhat.com>