### PR TITLE
latency-test: add and pass initial delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ You can run the container with different ENV variables, but the bare minimum is 
 `KUBECONFIG` mount and ENV variable, to give to the test access to the cluster and
 `LATENCY_TEST_RUN=true` to run the latency test.
 
+- `LATENCY_TEST_DELAY` indicates an (optional) delay in seconds to be used between the container is created and the tests actually start. Default is zero (start immediately).
 - `LATENCY_TEST_RUN` indicates if the latency test should run.
 - `LATENCY_TEST_RUNTIME` the amount of time in seconds that the latency test should run.
 - `LATENCY_TEST_IMAGE` the image that used under the latency test.

--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -30,6 +30,7 @@ import (
 )
 
 var (
+	latencyTestDelay   = "0"
 	latencyTestRun     = false
 	latencyTestRuntime = "300"
 	latencyTestImage   = "quay.io/openshift-kni/oslat:latest"
@@ -56,6 +57,11 @@ func init() {
 	latencyTestImageEnv := os.Getenv("LATENCY_TEST_IMAGE")
 	if latencyTestImageEnv != "" {
 		latencyTestImage = latencyTestImageEnv
+	}
+
+	latencyTestDelayEnv := os.Getenv("LATENCY_TEST_DELAY")
+	if latencyTestDelayEnv != "" {
+		latencyTestDelay = latencyTestDelayEnv
 	}
 
 	maximumLatencyEnv := os.Getenv("OSLAT_MAXIMUM_LATENCY")
@@ -206,6 +212,10 @@ func getOslatPod(profile *v1.PerformanceProfile, node *corev1.Node) *corev1.Pod 
 						{
 							Name:  "RUNTIME_SECONDS",
 							Value: latencyTestRuntime,
+						},
+						{
+							Name:  "INITIAL_DELAY",
+							Value: latencyTestDelay,
 						},
 					},
 					Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
We add an optional delay before to actually run the latency test
to give more room to the kubelet reconcile loop to kick in and make
sure all the pods are running in the proper cpusets.

Without this delay is harder to guarantee that other pods do not
run on exclusively allocated cpus.

Please note that using a delay is a mitigation of the inherent (lack of)
synchronization between the test and the kubelet cpumanager reconcile
loop. It is very possible that the reconciliation happens fast enough
even with initial zero delay, so this change add a test/troubleshooting
knob rather than fixing a misbehaviour.

Signed-off-by: Francesco Romani <fromani@redhat.com>