### PR TITLE
e2e: fix runtime class test failures

### DIFF
--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -276,6 +276,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 			// use the CPU load balancing runtime class
 			runtimeClassName := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
 			testpod.Spec.RuntimeClassName = &runtimeClassName
+			testpod.Spec.NodeSelector = map[string]string{testutils.LabelHostname: workerRTNode.Name}
 		})
 
 		AfterEach(func() {

--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -306,20 +306,15 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Getting the container cpuset.cpus cgroup")
-			var containerCgroup string
-			Eventually(func() string {
-				containerID, err := pods.GetContainerIDByName(testpod, "test")
-				Expect(err).ToNot(HaveOccurred())
+			containerID, err := pods.GetContainerIDByName(testpod, "test")
+			Expect(err).ToNot(HaveOccurred())
 
-				cmd := []string{"/bin/bash", "-c", fmt.Sprintf("find /rootfs/sys/fs/cgroup/cpuset/ -name *%s*", containerID)}
-				containerCgroup, err = nodes.ExecCommandOnNode(cmd, workerRTNode)
-				Expect(err).ToNot(HaveOccurred())
-
-				return containerCgroup
-			}, 2*time.Minute, 30*time.Second).ShouldNot(BeEmpty())
+			cmd := []string{"/bin/bash", "-c", fmt.Sprintf("find /rootfs/sys/fs/cgroup/cpuset/ -name *%s*", containerID)}
+			containerCgroup, err := nodes.ExecCommandOnNode(cmd, workerRTNode)
+			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking what CPU the pod is using")
-			cmd := []string{"/bin/bash", "-c", fmt.Sprintf("cat %s/cpuset.cpus", containerCgroup)}
+			cmd = []string{"/bin/bash", "-c", fmt.Sprintf("cat %s/cpuset.cpus", containerCgroup)}
 			output, err := nodes.ExecCommandOnNode(cmd, workerRTNode)
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Fix runtime class test failures when it runs on the environment with more than one worker-cnf node.

- add proper node selector to the pod
- revert `Eventually` that I added before because thought it was some race
the condition between the start of the container and the update of the cgroup

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>