### PR TITLE
e2e: check that it no error before accessing the profile fields

### DIFF
--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -51,11 +51,9 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 		Expect(workerRTNodes).ToNot(BeEmpty())
 		workerRTNode = &workerRTNodes[0]
 		profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
-		By(fmt.Sprintf("Checking the profile %s with cpus %#v", profile.Name, profile.Spec.CPU))
-
 		Expect(err).ToNot(HaveOccurred())
-		Expect(profile.Spec.HugePages).ToNot(BeNil())
 
+		By(fmt.Sprintf("Checking the profile %s with cpus %#v", profile.Name, profile.Spec.CPU))
 		balanceIsolated = true
 		if profile.Spec.CPU.BalanceIsolated != nil {
 			balanceIsolated = *profile.Spec.CPU.BalanceIsolated


### PR DESCRIPTION
It will prevent panics under our CPU tests:
```
    runtime error: invalid memory address or nil pointer dereference
    /usr/local/go/src/runtime/panic.go:199
    Full Stack Trace
    github.com/openshift-kni/performance-addon-operators/functests/1_performance.glob..func1.1()
    	/go/src/github.com/openshift-kni/performance-addon-operators/functests/1_performance/cpu_management.go:54 +0x506
    github.com/openshift-kni/performance-addon-operators/functests/1_performance_test.TestPerformance(0xc0002a9a00)
    	/go/src/github.com/openshift-kni/performance-addon-operators/functests/1_performance/test_suite_performance_test.go:49 +0x239
    testing.tRunner(0xc0002a9a00, 0x1831a28)
    	/usr/local/go/src/testing/testing.go:909 +0xc9
    created by testing.(*T).Run
    	/usr/local/go/src/testing/testing.go:960 +0x350
```
Signed-off-by: Artyom Lukianov <alukiano@redhat.com>