### PR TITLE
During the build of the bundle image use manifests from the _output directory

### DIFF
--- a/openshift-ci/Dockerfile.bundle.ci
+++ b/openshift-ci/Dockerfile.bundle.ci
@@ -12,4 +12,4 @@ LABEL operators.operatorframework.io.bundle.channels.v1=4.6.0
 LABEL operators.operatorframework.io.bundle.channel.default.v1=4.6.0
 
 COPY deploy/metadata/performance-addon-operator/${CHANNEL}.${ZVERSION}/* /metadata/
-COPY deploy/olm-catalog/performance-addon-operator/${CHANNEL}.${ZVERSION}/* /manifests/
+COPY manifests/performance-addon-operator/${CHANNEL}.${ZVERSION}/* /manifests/


### PR DESCRIPTION
Signed-off-by: Artyom Lukianov <alukiano@redhat.com>