### PR TITLE
Change upgrade test PerformanceProfile version to v1

### DIFF
--- a/cluster-setup/ci-upgrade-test-cluster/performance/performance_profile.yaml
+++ b/cluster-setup/ci-upgrade-test-cluster/performance/performance_profile.yaml
@@ -1,4 +1,4 @@
-apiVersion: performance.openshift.io/v1alpha1
+apiVersion: performance.openshift.io/v1
 kind: PerformanceProfile
 metadata:
   name: upgrade-test

--- a/cluster-setup/upgrade-test-cluster/performance/performance_profile.yaml
+++ b/cluster-setup/upgrade-test-cluster/performance/performance_profile.yaml
@@ -1,4 +1,4 @@
-apiVersion: performance.openshift.io/v1alpha1
+apiVersion: performance.openshift.io/v1
 kind: PerformanceProfile
 metadata:
   name: upgrade-test


### PR DESCRIPTION
When new 4.7 CSV was introduced(#419), it included the change for the upgrade test flow from `4.5->4.6` to `4.6->4.7`, but `4.6` does not have a conversion webhook and does not support the creation of new `PerformanceProfile` v1alpha1 resource.

To fix the upgrade flow the new `PerformanceProfile` should have version v1.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>