### PR TITLE
deploy: Rollback the 4.6 CSV and CRD to before the webhook conversion

### DIFF
--- a/deploy/olm-catalog/performance-addon-operator/4.6.0/performance-addon-operator.v4.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.6.0/performance-addon-operator.v4.6.0.clusterserviceversion.yaml
@@ -45,11 +45,7 @@ metadata:
       ]
     capabilities: Basic Install
     containerImage: quay.io/openshift-kni/performance-addon-operator:4.6-snapshot
-    description: Operator to optimize OpenShift clusters for applications sensitive to CPU and network latency.
     olm.skipRange: '>=4.5.0 <4.6.0'
-    operators.operatorframework.io/builder: operator-sdk-v1.0.0
-    operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-    repository: https://github.com/operator-kni/performance-addon-operators
   name: performance-addon-operator.v4.6.0
   namespace: placeholder
 spec:
@@ -81,20 +77,6 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - machineconfiguration.openshift.io
-          resources:
-          - kubeletconfigs
-          - machineconfigpools
-          - machineconfigs
-          verbs:
-          - '*'
-        - apiGroups:
-          - node.k8s.io
-          resources:
-          - runtimeclasses
-          verbs:
-          - '*'
-        - apiGroups:
           - performance.openshift.io
           resources:
           - performanceprofiles
@@ -103,9 +85,23 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - machineconfiguration.openshift.io
+          resources:
+          - machineconfigs
+          - machineconfigpools
+          - kubeletconfigs
+          verbs:
+          - '*'
+        - apiGroups:
           - tuned.openshift.io
           resources:
           - tuneds
+          verbs:
+          - '*'
+        - apiGroups:
+          - node.k8s.io
+          resources:
+          - runtimeclasses
           verbs:
           - '*'
         serviceAccountName: performance-operator
@@ -154,10 +150,19 @@ spec:
       permissions:
       - rules:
         - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - configmaps
+          verbs:
+          - '*'
+        - apiGroups:
           - apps
           resources:
-          - daemonsets
           - deployments
+          - daemonsets
           - replicasets
           - statefulsets
           verbs:
@@ -171,15 +176,6 @@ spec:
           verbs:
           - update
         - apiGroups:
-          - ""
-          resources:
-          - configmaps
-          - pods
-          - services
-          - services/finalizers
-          verbs:
-          - '*'
-        - apiGroups:
           - monitoring.coreos.com
           resources:
           - servicemonitors
@@ -188,9 +184,9 @@ spec:
         serviceAccountName: performance-operator
     strategy: deployment
   installModes:
-  - supported: false
+  - supported: true
     type: OwnNamespace
-  - supported: false
+  - supported: true
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
@@ -208,16 +204,3 @@ spec:
   provider:
     name: Red Hat
   version: 4.6.0
-  webhookdefinitions:
-  - admissionReviewVersions:
-    - v1
-    - v1alpha1
-    containerPort: 443
-    conversionCRDs:
-    - performanceprofiles.performance.openshift.io
-    deploymentName: performance-operator
-    generateName: cwb.performance.openshift.io
-    sideEffects: None
-    targetPort: 4343
-    type: ConversionWebhook
-    webhookPath: /convert

--- a/deploy/olm-catalog/performance-addon-operator/4.6.0/performance.openshift.io_performanceprofiles_crd.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.6.0/performance.openshift.io_performanceprofiles_crd.yaml
@@ -1,9 +1,6 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  annotations:
-    controller-gen.kubebuilder.io/version: (devel)
-  creationTimestamp: null
   name: performanceprofiles.performance.openshift.io
 spec:
   group: performance.openshift.io
@@ -17,13 +14,18 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: PerformanceProfile is the Schema for the performanceprofiles API
+        description: PerformanceProfile is the Schema for the performanceprofiles
+          API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -39,36 +41,66 @@ spec:
                 description: CPU defines a set of CPU related parameters.
                 properties:
                   balanceIsolated:
-                    description: BalanceIsolated toggles whether or not the Isolated CPU set is eligible for load balancing work loads. When this option is set to "false", the Isolated CPU set will be static, meaning workloads have to explicitly assign each thread to a specific cpu in order to work across multiple CPUs. Setting this to "true" allows workloads to be balanced across CPUs. Setting this to "false" offers the most predictable performance for guaranteed workloads, but it offloads the complexity of cpu load balancing to the application. Defaults to "true"
+                    description: BalanceIsolated toggles whether or not the Isolated
+                      CPU set is eligible for load balancing work loads. When this
+                      option is set to "false", the Isolated CPU set will be static,
+                      meaning workloads have to explicitly assign each thread to a
+                      specific cpu in order to work across multiple CPUs. Setting
+                      this to "true" allows workloads to be balanced across CPUs.
+                      Setting this to "false" offers the most predictable performance
+                      for guaranteed workloads, but it offloads the complexity of
+                      cpu load balancing to the application. Defaults to "true"
                     type: boolean
                   isolated:
-                    description: 'Isolated defines a set of CPUs that will be used to give to application threads the most execution time possible, which means removing as many extraneous tasks off a CPU as possible. It is important to notice the CPU manager can choose any CPU to run the workload except the reserved CPUs. In order to guarantee that your workload will run on the isolated CPU:   1. The union of reserved CPUs and isolated CPUs should include all online CPUs   2. The isolated CPUs field should be the complementary to reserved CPUs field'
+                    description: 'Isolated defines a set of CPUs that will be used
+                      to give to application threads the most execution time possible,
+                      which means removing as many extraneous tasks off a CPU as possible.
+                      It is important to notice the CPU manager can choose any CPU
+                      to run the workload except the reserved CPUs. In order to guarantee
+                      that your workload will run on the isolated CPU:   1. The union
+                      of reserved CPUs and isolated CPUs should include all online
+                      CPUs   2. The isolated CPUs field should be the complementary
+                      to reserved CPUs field'
                     type: string
                   reserved:
-                    description: Reserved defines a set of CPUs that will not be used for any container workloads initiated by kubelet.
+                    description: Reserved defines a set of CPUs that will not be used
+                      for any container workloads initiated by kubelet.
                     type: string
                 type: object
               hugepages:
-                description: HugePages defines a set of huge pages related parameters. It is possible to set huge pages with multiple size values at the same time. For example, hugepages can be set with 1G and 2M, both values will be set on the node by the performance-addon-operator. It is important to notice that setting hugepages default size to 1G will remove all 2M related folders from the node and it will be impossible to configure 2M hugepages under the node.
+                description: HugePages defines a set of huge pages related parameters.
+                  It is possible to set huge pages with multiple size values at the
+                  same time. For example, hugepages can be set with 1G and 2M, both
+                  values will be set on the node by the performance-addon-operator.
+                  It is important to notice that setting hugepages default size to
+                  1G will remove all 2M related folders from the node and it will
+                  be impossible to configure 2M hugepages under the node.
                 properties:
                   defaultHugepagesSize:
-                    description: DefaultHugePagesSize defines huge pages default size under kernel boot parameters.
+                    description: DefaultHugePagesSize defines huge pages default size
+                      under kernel boot parameters.
                     type: string
                   pages:
-                    description: Pages defines huge pages that we want to allocate at boot time.
+                    description: Pages defines huge pages that we want to allocate
+                      at boot time.
                     items:
-                      description: HugePage defines the number of allocated huge pages of the specific size.
+                      description: HugePage defines the number of allocated huge pages
+                        of the specific size.
                       properties:
                         count:
-                          description: Count defines amount of huge pages, maps to the 'hugepages' kernel boot parameter.
+                          description: Count defines amount of huge pages, maps to
+                            the 'hugepages' kernel boot parameter.
                           format: int32
                           type: integer
                         node:
-                          description: Node defines the NUMA node where hugepages will be allocated, if not specified, pages will be allocated equally between NUMA nodes
+                          description: Node defines the NUMA node where hugepages
+                            will be allocated, if not specified, pages will be allocated
+                            equally between NUMA nodes
                           format: int32
                           type: integer
                         size:
-                          description: Size defines huge page size, maps to the 'hugepagesz' kernel boot parameter.
+                          description: Size defines huge page size, maps to the 'hugepagesz'
+                            kernel boot parameter.
                           type: string
                       type: object
                     type: array
@@ -76,30 +108,43 @@ spec:
               machineConfigLabel:
                 additionalProperties:
                   type: string
-                description: MachineConfigLabel defines the label to add to the MachineConfigs the operator creates. It has to be used in the MachineConfigSelector of the MachineConfigPool which targets this performance profile. Defaults to "machineconfiguration.openshift.io/role=<same role as in NodeSelector label key>"
+                description: MachineConfigLabel defines the label to add to the MachineConfigs
+                  the operator creates. It has to be used in the MachineConfigSelector
+                  of the MachineConfigPool which targets this performance profile.
+                  Defaults to "machineconfiguration.openshift.io/role=<same role as
+                  in NodeSelector label key>"
                 type: object
               machineConfigPoolSelector:
                 additionalProperties:
                   type: string
-                description: MachineConfigPoolSelector defines the MachineConfigPool label to use in the MachineConfigPoolSelector of resources like KubeletConfigs created by the operator. Defaults to "machineconfiguration.openshift.io/role=<same role as in NodeSelector label key>"
+                description: MachineConfigPoolSelector defines the MachineConfigPool
+                  label to use in the MachineConfigPoolSelector of resources like
+                  KubeletConfigs created by the operator. Defaults to "machineconfiguration.openshift.io/role=<same
+                  role as in NodeSelector label key>"
                 type: object
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector defines the Node label to use in the NodeSelectors of resources like Tuned created by the operator. It most likely should, but does not have to match the node label in the NodeSelector of the MachineConfigPool which targets this performance profile.
+                description: NodeSelector defines the Node label to use in the NodeSelectors
+                  of resources like Tuned created by the operator. It most likely
+                  should, but does not have to match the node label in the NodeSelector
+                  of the MachineConfigPool which targets this performance profile.
                 type: object
               numa:
                 description: NUMA defines options related to topology aware affinities
                 properties:
                   topologyPolicy:
-                    description: Name of the policy applied when TopologyManager is enabled Operator defaults to "best-effort"
+                    description: Name of the policy applied when TopologyManager is
+                      enabled Operator defaults to "best-effort"
                     type: string
                 type: object
               realTimeKernel:
-                description: RealTimeKernel defines a set of real time kernel related parameters. RT kernel won't be installed when not set.
+                description: RealTimeKernel defines a set of real time kernel related
+                  parameters. RT kernel won't be installed when not set.
                 properties:
                   enabled:
-                    description: Enabled defines if the real time kernel packages should be installed. Defaults to "false"
+                    description: Enabled defines if the real time kernel packages
+                      should be installed. Defaults to "false"
                     type: boolean
                 type: object
             type: object
@@ -107,9 +152,11 @@ spec:
             description: PerformanceProfileStatus defines the observed state of PerformanceProfile.
             properties:
               conditions:
-                description: Conditions represents the latest available observations of current state.
+                description: Conditions represents the latest available observations
+                  of current state.
                 items:
-                  description: Condition represents the state of the operator's reconciliation functionality.
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
                   properties:
                     lastHeartbeatTime:
                       format: date-time
@@ -124,7 +171,8 @@ spec:
                     status:
                       type: string
                     type:
-                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
                       type: string
                   required:
                   - status
@@ -132,10 +180,12 @@ spec:
                   type: object
                 type: array
               runtimeClass:
-                description: RuntimeClass contains the name of the RuntimeClass resource created by the operator.
+                description: RuntimeClass contains the name of the RuntimeClass resource
+                  created by the operator.
                 type: string
               tuned:
-                description: Tuned points to the Tuned custom resource object that contains the tuning values generated by this operator.
+                description: Tuned points to the Tuned custom resource object that
+                  contains the tuning values generated by this operator.
                 type: string
             type: object
         type: object
@@ -146,13 +196,18 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: PerformanceProfile is the Schema for the performanceprofiles API
+        description: PerformanceProfile is the Schema for the performanceprofiles
+          API.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -168,36 +223,66 @@ spec:
                 description: CPU defines a set of CPU related parameters.
                 properties:
                   balanceIsolated:
-                    description: BalanceIsolated toggles whether or not the Isolated CPU set is eligible for load balancing work loads. When this option is set to "false", the Isolated CPU set will be static, meaning workloads have to explicitly assign each thread to a specific cpu in order to work across multiple CPUs. Setting this to "true" allows workloads to be balanced across CPUs. Setting this to "false" offers the most predictable performance for guaranteed workloads, but it offloads the complexity of cpu load balancing to the application. Defaults to "true"
+                    description: BalanceIsolated toggles whether or not the Isolated
+                      CPU set is eligible for load balancing work loads. When this
+                      option is set to "false", the Isolated CPU set will be static,
+                      meaning workloads have to explicitly assign each thread to a
+                      specific cpu in order to work across multiple CPUs. Setting
+                      this to "true" allows workloads to be balanced across CPUs.
+                      Setting this to "false" offers the most predictable performance
+                      for guaranteed workloads, but it offloads the complexity of
+                      cpu load balancing to the application. Defaults to "true"
                     type: boolean
                   isolated:
-                    description: 'Isolated defines a set of CPUs that will be used to give to application threads the most execution time possible, which means removing as many extraneous tasks off a CPU as possible. It is important to notice the CPU manager can choose any CPU to run the workload except the reserved CPUs. In order to guarantee that your workload will run on the isolated CPU:   1. The union of reserved CPUs and isolated CPUs should include all online CPUs   2. The isolated CPUs field should be the complementary to reserved CPUs field'
+                    description: 'Isolated defines a set of CPUs that will be used
+                      to give to application threads the most execution time possible,
+                      which means removing as many extraneous tasks off a CPU as possible.
+                      It is important to notice the CPU manager can choose any CPU
+                      to run the workload except the reserved CPUs. In order to guarantee
+                      that your workload will run on the isolated CPU:   1. The union
+                      of reserved CPUs and isolated CPUs should include all online
+                      CPUs   2. The isolated CPUs field should be the complementary
+                      to reserved CPUs field'
                     type: string
                   reserved:
-                    description: Reserved defines a set of CPUs that will not be used for any container workloads initiated by kubelet.
+                    description: Reserved defines a set of CPUs that will not be used
+                      for any container workloads initiated by kubelet.
                     type: string
                 type: object
               hugepages:
-                description: HugePages defines a set of huge pages related parameters. It is possible to set huge pages with multiple size values at the same time. For example, hugepages can be set with 1G and 2M, both values will be set on the node by the performance-addon-operator. It is important to notice that setting hugepages default size to 1G will remove all 2M related folders from the node and it will be impossible to configure 2M hugepages under the node.
+                description: HugePages defines a set of huge pages related parameters.
+                  It is possible to set huge pages with multiple size values at the
+                  same time. For example, hugepages can be set with 1G and 2M, both
+                  values will be set on the node by the performance-addon-operator.
+                  It is important to notice that setting hugepages default size to
+                  1G will remove all 2M related folders from the node and it will
+                  be impossible to configure 2M hugepages under the node.
                 properties:
                   defaultHugepagesSize:
-                    description: DefaultHugePagesSize defines huge pages default size under kernel boot parameters.
+                    description: DefaultHugePagesSize defines huge pages default size
+                      under kernel boot parameters.
                     type: string
                   pages:
-                    description: Pages defines huge pages that we want to allocate at boot time.
+                    description: Pages defines huge pages that we want to allocate
+                      at boot time.
                     items:
-                      description: HugePage defines the number of allocated huge pages of the specific size.
+                      description: HugePage defines the number of allocated huge pages
+                        of the specific size.
                       properties:
                         count:
-                          description: Count defines amount of huge pages, maps to the 'hugepages' kernel boot parameter.
+                          description: Count defines amount of huge pages, maps to
+                            the 'hugepages' kernel boot parameter.
                           format: int32
                           type: integer
                         node:
-                          description: Node defines the NUMA node where hugepages will be allocated, if not specified, pages will be allocated equally between NUMA nodes
+                          description: Node defines the NUMA node where hugepages
+                            will be allocated, if not specified, pages will be allocated
+                            equally between NUMA nodes
                           format: int32
                           type: integer
                         size:
-                          description: Size defines huge page size, maps to the 'hugepagesz' kernel boot parameter.
+                          description: Size defines huge page size, maps to the 'hugepagesz'
+                            kernel boot parameter.
                           type: string
                       type: object
                     type: array
@@ -205,30 +290,43 @@ spec:
               machineConfigLabel:
                 additionalProperties:
                   type: string
-                description: MachineConfigLabel defines the label to add to the MachineConfigs the operator creates. It has to be used in the MachineConfigSelector of the MachineConfigPool which targets this performance profile. Defaults to "machineconfiguration.openshift.io/role=<same role as in NodeSelector label key>"
+                description: MachineConfigLabel defines the label to add to the MachineConfigs
+                  the operator creates. It has to be used in the MachineConfigSelector
+                  of the MachineConfigPool which targets this performance profile.
+                  Defaults to "machineconfiguration.openshift.io/role=<same role as
+                  in NodeSelector label key>"
                 type: object
               machineConfigPoolSelector:
                 additionalProperties:
                   type: string
-                description: MachineConfigPoolSelector defines the MachineConfigPool label to use in the MachineConfigPoolSelector of resources like KubeletConfigs created by the operator. Defaults to "machineconfiguration.openshift.io/role=<same role as in NodeSelector label key>"
+                description: MachineConfigPoolSelector defines the MachineConfigPool
+                  label to use in the MachineConfigPoolSelector of resources like
+                  KubeletConfigs created by the operator. Defaults to "machineconfiguration.openshift.io/role=<same
+                  role as in NodeSelector label key>"
                 type: object
               nodeSelector:
                 additionalProperties:
                   type: string
-                description: NodeSelector defines the Node label to use in the NodeSelectors of resources like Tuned created by the operator. It most likely should, but does not have to match the node label in the NodeSelector of the MachineConfigPool which targets this performance profile.
+                description: NodeSelector defines the Node label to use in the NodeSelectors
+                  of resources like Tuned created by the operator. It most likely
+                  should, but does not have to match the node label in the NodeSelector
+                  of the MachineConfigPool which targets this performance profile.
                 type: object
               numa:
                 description: NUMA defines options related to topology aware affinities
                 properties:
                   topologyPolicy:
-                    description: Name of the policy applied when TopologyManager is enabled Operator defaults to "best-effort"
+                    description: Name of the policy applied when TopologyManager is
+                      enabled Operator defaults to "best-effort"
                     type: string
                 type: object
               realTimeKernel:
-                description: RealTimeKernel defines a set of real time kernel related parameters. RT kernel won't be installed when not set.
+                description: RealTimeKernel defines a set of real time kernel related
+                  parameters. RT kernel won't be installed when not set.
                 properties:
                   enabled:
-                    description: Enabled defines if the real time kernel packages should be installed. Defaults to "false"
+                    description: Enabled defines if the real time kernel packages
+                      should be installed. Defaults to "false"
                     type: boolean
                 type: object
             type: object
@@ -236,9 +334,11 @@ spec:
             description: PerformanceProfileStatus defines the observed state of PerformanceProfile.
             properties:
               conditions:
-                description: Conditions represents the latest available observations of current state.
+                description: Conditions represents the latest available observations
+                  of current state.
                 items:
-                  description: Condition represents the state of the operator's reconciliation functionality.
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
                   properties:
                     lastHeartbeatTime:
                       format: date-time
@@ -253,7 +353,8 @@ spec:
                     status:
                       type: string
                     type:
-                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
                       type: string
                   required:
                   - status
@@ -261,10 +362,12 @@ spec:
                   type: object
                 type: array
               runtimeClass:
-                description: RuntimeClass contains the name of the RuntimeClass resource created by the operator.
+                description: RuntimeClass contains the name of the RuntimeClass resource
+                  created by the operator.
                 type: string
               tuned:
-                description: Tuned points to the Tuned custom resource object that contains the tuning values generated by this operator.
+                description: Tuned points to the Tuned custom resource object that
+                  contains the tuning values generated by this operator.
                 type: string
             type: object
         type: object
@@ -272,9 +375,3 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
Replace only the REPLACE_IMAGE place holder, other than that
all the files are exactly as in release-4.6 branch.

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>