### PR TITLE
Small improvements to the generate-index-database script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ Developers can build and push the Performance Operator images from the source tr
 ```
 export REGISTRY_NAMESPACE=<your quay.io namespace>
 export IMAGE_TAG=<the image tag to use> #defaults to "latest"
-make generate-manifests-tree
 make build-containers
 make push-containers
 ```
+
+The building of the index image requires that the bundle image will be public available under the image registry,
+otherwise the creation of the index image will fail.
 
 # Building and pushing z-stream release
 

--- a/hack/generate-index-database.sh
+++ b/hack/generate-index-database.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 # shellcheck source=common.sh
 source "$(dirname "$0")/common.sh"
@@ -8,22 +8,25 @@ source "$(dirname "$0")/common.sh"
 BUNDLES=${BUNDLES:-"quay.io/openshift-kni/performance-addon-operator-bundle:4.7-snapshot"}
 OPM_BUILDER_TAG="v1.14.3"
 
+stop_containers() {
+  if [ -n "${opm_container_id}" ]; then
+    ${IMAGE_BUILD_CMD} stop "${opm_container_id}"
+    ${IMAGE_BUILD_CMD} rm "${opm_container_id}"
+  fi
+}
+
+trap stop_containers EXIT SIGINT SIGTERM
+
+opm_container_id=$(${IMAGE_BUILD_CMD} run -d \
+-e BUNDLES="${BUNDLES}" \
+quay.io/operator-framework/upstream-opm-builder:${OPM_BUILDER_TAG} \
+/bin/sh -c "opm index add --mode semver --bundles ${BUNDLES} --generate")
+
+${IMAGE_BUILD_CMD} wait "${opm_container_id}"
+${IMAGE_BUILD_CMD} logs "${opm_container_id}"
+
 rm -rf "${OUT_DIR}/index.Dockerfile"
 rm -rf "${OUT_DIR}/database"
 
-container_id=$(${IMAGE_BUILD_CMD} run --rm -d \
--e BUNDLES="${BUNDLES}" \
-quay.io/operator-framework/upstream-opm-builder:${OPM_BUILDER_TAG} \
-/bin/sh -c "cd sources; opm index add --mode semver --bundles ${BUNDLES} --generate; sleep inf")
-
-trap '{ ${IMAGE_BUILD_CMD} stop "${container_id}"; }' EXIT SIGINT SIGTERM
-
-# it can take some time until the Dockerfile appears under the file system after generation
-# and you will get Error: error evaluating symlinks ""
-until ${IMAGE_BUILD_CMD} cp "${container_id}:/index.Dockerfile" "${OUT_DIR}"; do
-  sleep 10
-done
-
-until ${IMAGE_BUILD_CMD} cp "${container_id}:/database" "${OUT_DIR}"; do
-  sleep 10
-done
+${IMAGE_BUILD_CMD} cp "${opm_container_id}:/index.Dockerfile" "${OUT_DIR}"
+${IMAGE_BUILD_CMD} cp "${opm_container_id}:/database" "${OUT_DIR}"


### PR DESCRIPTION
- output the log from the opm container
- wait for opm container to stop before copy the generated files

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>