### PR TITLE
validate: check for no isolated/reserved cpus

### DIFF
--- a/pkg/controller/performanceprofile/components/profile/profile_test.go
+++ b/pkg/controller/performanceprofile/components/profile/profile_test.go
@@ -88,6 +88,24 @@ var _ = Describe("PerformanceProfile", func() {
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("the page size should be equal to %q or %q", hugepagesSize1G, hugepagesSize2M)))
 		})
 
+		It("should allow cpus allocation with no reserved CPUs", func() {
+			reservedCPUs := performancev2.CPUSet("")
+			isolatedCPUs := performancev2.CPUSet("0-7")
+			profile.Spec.CPU.Reserved = &reservedCPUs
+			profile.Spec.CPU.Isolated = &isolatedCPUs
+			err := ValidateParameters(profile)
+			Expect(err).Should(Not(HaveOccurred()))
+		})
+
+		It("should reject cpus allocation with no isolated CPUs", func() {
+			reservedCPUs := performancev2.CPUSet("0-3")
+			isolatedCPUs := performancev2.CPUSet("")
+			profile.Spec.CPU.Reserved = &reservedCPUs
+			profile.Spec.CPU.Isolated = &isolatedCPUs
+			err := ValidateParameters(profile)
+			Expect(err.Error()).To(ContainSubstring("must contain isolated cpus"))
+		})
+
 		It("should allow cpus allocation with not overlapping sets", func() {
 			reservedCPUs := performancev2.CPUSet("0-3")
 			isolatedCPUs := performancev2.CPUSet("4-15")

--- a/pkg/controller/performanceprofile/components/utils.go
+++ b/pkg/controller/performanceprofile/components/utils.go
@@ -109,17 +109,36 @@ func CPUListToMaskList(cpulist string) (hexMask string, err error) {
 	return trimmedCPUMaskList, nil
 }
 
-// CPUListIntersect returns cpu ids found in both the provided cpuLists, if any
-func CPUListIntersect(cpuListA, cpuListB string) ([]int, error) {
+// CPULists allows easy checks between reserved and isolated cpu set definitons
+type CPULists struct {
+	reserved cpuset.CPUSet
+	isolated cpuset.CPUSet
+}
+
+// Intersect returns cpu ids found in both the provided cpuLists, if any
+func (c *CPULists) Intersect() []int {
+	commonSet := c.reserved.Intersection(c.isolated)
+	return commonSet.ToSlice()
+}
+
+// CountIsolated returns how many isolated cpus where specified
+func (c *CPULists) CountIsolated() int {
+	return c.isolated.Size()
+}
+
+// NewCPULists parse text representations of reserved and isolated cpusets definiton and returns a CPULists object
+func NewCPULists(reservedList, isolatedList string) (*CPULists, error) {
 	var err error
-	cpusA, err := cpuset.Parse(cpuListA)
+	reserved, err := cpuset.Parse(reservedList)
 	if err != nil {
 		return nil, err
 	}
-	cpusB, err := cpuset.Parse(cpuListB)
+	isolated, err := cpuset.Parse(isolatedList)
 	if err != nil {
 		return nil, err
 	}
-	commonSet := cpusA.Intersection(cpusB)
-	return commonSet.ToSlice(), nil
+	return &CPULists{
+		reserved: reserved,
+		isolated: isolated,
+	}, nil
 }

--- a/pkg/controller/performanceprofile/components/utils_test.go
+++ b/pkg/controller/performanceprofile/components/utils_test.go
@@ -22,6 +22,14 @@ var cpuListToInvertMask = []listToMask{
 	{"80", "ffffffff,ffffffff"},
 }
 
+func intersectHelper(cpuListA, cpuListB string) ([]int, error) {
+	cpuLists, err := NewCPULists(cpuListA, cpuListB)
+	if err != nil {
+		return nil, err
+	}
+	return cpuLists.Intersect(), nil
+}
+
 var _ = Describe("Components utils", func() {
 	Context("Convert CPU list to CPU mask", func() {
 		It("should generate a valid CPU mask from CPU list ", func() {
@@ -47,13 +55,13 @@ var _ = Describe("Components utils", func() {
 			}
 
 			for _, entry := range cpuListInvalid {
-				_, err := CPUListIntersect(entry, entry)
+				_, err := intersectHelper(entry, entry)
 				Expect(err).To(HaveOccurred())
 
-				_, err = CPUListIntersect(entry, "0-3")
+				_, err = intersectHelper(entry, "0-3")
 				Expect(err).To(HaveOccurred())
 
-				_, err = CPUListIntersect("0-3", entry)
+				_, err = intersectHelper("0-3", entry)
 				Expect(err).To(HaveOccurred())
 			}
 		})
@@ -66,6 +74,8 @@ var _ = Describe("Components utils", func() {
 			}
 
 			var cpuListIntersectTestcases = []cpuListIntersect{
+				{"", "0-3", []int{}},
+				{"0-3", "", []int{}},
 				{"0-3", "4-15", []int{}},
 				{"0-3", "8-15", []int{}},
 				{"0-3", "0-15", []int{0, 1, 2, 3}},
@@ -74,7 +84,7 @@ var _ = Describe("Components utils", func() {
 			}
 
 			for _, entry := range cpuListIntersectTestcases {
-				res, err := CPUListIntersect(entry.cpuListA, entry.cpuListB)
+				res, err := intersectHelper(entry.cpuListA, entry.cpuListB)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(len(res)).To(Equal(len(entry.result)))


### PR DESCRIPTION
It's legal, albeit probably not what users want, to
have empty sets for either reserved and isolated CPUs.
Hence make sure tests cover this case.

Signed-off-by: Francesco Romani <fromani@redhat.com>