### PR TITLE
must-gather: fix fall-back namespace

### DIFF
--- a/must-gather/collection-scripts/namespace
+++ b/must-gather/collection-scripts/namespace
@@ -5,7 +5,9 @@ function namespace() {
   ns=$( oc get subs -A --field-selector metadata.name='performance-addon-operator-subscription' -o=jsonpath='{.items[0].metadata.namespace}{"\n"}' 2> /dev/null )
   # trying again with the pods, which are _usually_ reliable - but users can change them
   [ -z "${ns}" ] && ns=$( oc get pods -A -l name='performance-operator' -o=jsonpath='{.items[0].metadata.namespace}{"\n"}' 2> /dev/null )
-  # if namespace not found, fallback to the old default
-  [ -z "${ns}" ] && ns="openshift-performance-addon"
+  # namespace suggested by the documentation. This is a fancier way to check for its existence
+  [ -z "${ns}" ] && ns=$( oc get ns openshift-performance-addon-operator -o jsonpath='{.metadata.name}{"\n"}' 2> /dev/null )
+  # we should never get there. This is the last resort.
+  [ -z "${ns}" ] && ns="openshift-operators"
   echo ${ns}
 }


### PR DESCRIPTION
Per https://docs.openshift.com/container-platform/4.6/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#install-operator-cli_cnf-master
the suggested namespace is `openshift-performance-addon-operator`, so
we use it as fallback for consistency.

Signed-off-by: Francesco Romani <fromani@redhat.com>