### PR TITLE
Bug 1894861: tests: allow override operator namespace

### DIFF
--- a/cluster-setup/base/performance/operator_namespace.yaml
+++ b/cluster-setup/base/performance/operator_namespace.yaml
@@ -3,5 +3,5 @@ kind: Namespace
 metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
-  name: openshift-performance-addon
+  name: openshift-performance-addon-operator
 spec: {}

--- a/cluster-setup/base/performance/operator_operatorgroup.yaml
+++ b/cluster-setup/base/performance/operator_operatorgroup.yaml
@@ -2,4 +2,4 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: performance-addon-operator
-  namespace: openshift-performance-addon
+  namespace: openshift-performance-addon-operator

--- a/cluster-setup/base/performance/operator_subscription.yaml
+++ b/cluster-setup/base/performance/operator_subscription.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: performance-addon-operator
-  namespace: openshift-performance-addon
+  namespace: openshift-performance-addon-operator
 spec:
   channel: "4.7"
   name: performance-addon-operator

--- a/cluster-setup/upgrade-test-cluster/performance/operator_subscription.patch.yaml
+++ b/cluster-setup/upgrade-test-cluster/performance/operator_subscription.patch.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: performance-addon-operator
-  namespace: openshift-performance-addon
+  namespace: openshift-performance-addon-operator
 spec:
   channel: "4.5"
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -47,7 +47,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: performance-operator
-  namespace: openshift-performance-addon
+  namespace: openshift-performance-addon-operator
 rules:
 - apiGroups:
   - apps

--- a/controllers/performanceprofile_controller.go
+++ b/controllers/performanceprofile_controller.go
@@ -139,10 +139,10 @@ func (r *PerformanceProfileReconciler) SetupWithManager(mgr ctrl.Manager) error 
 // +kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs;machineconfigpools;kubeletconfigs,verbs=*
 // +kubebuilder:rbac:groups=tuned.openshift.io,resources=tuneds,verbs=*
 // +kubebuilder:rbac:groups=node.k8s.io,resources=runtimeclasses,verbs=*
-// +kubebuilder:rbac:namespace="openshift-performance-addon",groups=core,resources=pods;services;services/finalizers;configmaps,verbs=*
-// +kubebuilder:rbac:namespace="openshift-performance-addon",groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=*
-// +kubebuilder:rbac:namespace="openshift-performance-addon",groups=apps,resourceNames=performance-operator,resources=deployments/finalizers,verbs=update
-// +kubebuilder:rbac:namespace="openshift-performance-addon",groups=monitoring.coreos.com,resources=servicemonitors,verbs=*
+// +kubebuilder:rbac:namespace="openshift-performance-addon-operator",groups=core,resources=pods;services;services/finalizers;configmaps,verbs=*
+// +kubebuilder:rbac:namespace="openshift-performance-addon-operator",groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=*
+// +kubebuilder:rbac:namespace="openshift-performance-addon-operator",groups=apps,resourceNames=performance-operator,resources=deployments/finalizers,verbs=update
+// +kubebuilder:rbac:namespace="openshift-performance-addon-operator",groups=monitoring.coreos.com,resources=servicemonitors,verbs=*
 
 // Reconcile reads that state of the cluster for a PerformanceProfile object and makes changes based on the state read
 // and what is in the PerformanceProfile.Spec

--- a/functests-extended/1_performance_operator_upgrade/upgrade_operator.go
+++ b/functests-extended/1_performance_operator_upgrade/upgrade_operator.go
@@ -13,8 +13,8 @@ import (
 
 	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 
-	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/namespaces"
 )
 
 var fromVersion string
@@ -31,7 +31,7 @@ var _ = Describe("[rfe_id:28567][performance] Performance Addon Operator Upgrade
 
 	BeforeEach(func() {
 		subscriptionsList := &olmv1alpha1.SubscriptionList{}
-		err := testclient.Client.List(context.TODO(), subscriptionsList, &client.ListOptions{Namespace: testutils.PerformanceOperatorNamespace})
+		err := testclient.Client.List(context.TODO(), subscriptionsList, &client.ListOptions{Namespace: namespaces.PerformanceOperator})
 		ExpectWithOffset(1, err).ToNot(HaveOccurred(), "Failed getting Subscriptions")
 		Expect(len(subscriptionsList.Items)).To(Equal(1), fmt.Sprintf("Unexpected number of Subscriptions found: %v", len(subscriptionsList.Items)))
 		subscription = &subscriptionsList.Items[0]
@@ -45,11 +45,11 @@ var _ = Describe("[rfe_id:28567][performance] Performance Addon Operator Upgrade
 		By(fmt.Sprintf("Upgrading from %s to %s", fromVersion, toVersion))
 
 		By(fmt.Sprintf("Verifying that %s channel is active", fromVersion))
-		subscription = getSubscription(subscription.Name, testutils.PerformanceOperatorNamespace)
+		subscription = getSubscription(subscription.Name, namespaces.PerformanceOperator)
 		Expect(subscription.Spec.Channel).To(Equal(fromVersion))
 		Expect(subscription.Status.CurrentCSV).To(ContainSubstring(fromVersion))
 
-		csv := getCSV(subscription.Status.CurrentCSV, testutils.PerformanceOperatorNamespace)
+		csv := getCSV(subscription.Status.CurrentCSV, namespaces.PerformanceOperator)
 		fromImage := csv.ObjectMeta.Annotations["containerImage"]
 
 		By(fmt.Sprintf("Switch subscription channel to %s version", toVersion))
@@ -61,12 +61,12 @@ var _ = Describe("[rfe_id:28567][performance] Performance Addon Operator Upgrade
 		)).ToNot(HaveOccurred())
 
 		By(fmt.Sprintf("Verifying that channel was updated to %s", toVersion))
-		subscriptionWaitForUpdate(subscription.Name, testutils.PerformanceOperatorNamespace, toVersion)
+		subscriptionWaitForUpdate(subscription.Name, namespaces.PerformanceOperator, toVersion)
 
 		// CSV is updated and image tag was changed
-		subscription = getSubscription(subscription.Name, testutils.PerformanceOperatorNamespace)
-		csv = getCSV(subscription.Status.CurrentCSV, testutils.PerformanceOperatorNamespace)
-		csvWaitForPhaseWithConditionReason(csv.Name, testutils.PerformanceOperatorNamespace, olmv1alpha1.CSVPhaseSucceeded, olmv1alpha1.CSVReasonInstallSuccessful)
+		subscription = getSubscription(subscription.Name, namespaces.PerformanceOperator)
+		csv = getCSV(subscription.Status.CurrentCSV, namespaces.PerformanceOperator)
+		csvWaitForPhaseWithConditionReason(csv.Name, namespaces.PerformanceOperator, olmv1alpha1.CSVPhaseSucceeded, olmv1alpha1.CSVReasonInstallSuccessful)
 		Expect(csv.ObjectMeta.Annotations["containerImage"]).NotTo(Equal(fromImage))
 	})
 })

--- a/functests/utils/consts.go
+++ b/functests/utils/consts.go
@@ -79,8 +79,6 @@ const (
 )
 
 const (
-	// PerformanceOperatorNamespace contains the name of the performance operator namespace
-	PerformanceOperatorNamespace = "openshift-performance-addon"
 	// NamespaceMachineConfigOperator contains the namespace of the machine-config-opereator
 	NamespaceMachineConfigOperator = "openshift-machine-config-operator"
 	// NamespaceTesting contains the name of the testing namespace

--- a/functests/utils/namespaces/namespaces.go
+++ b/functests/utils/namespaces/namespaces.go
@@ -2,6 +2,7 @@ package namespaces
 
 import (
 	"context"
+	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -13,6 +14,17 @@ import (
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 )
+
+// PerformanceOperator contains the name of the performance operator namespace
+// default as recommended in
+// https://docs.openshift.com/container-platform/4.6/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#install-operator-cli_cnf-master
+var PerformanceOperator string = "openshift-performance-addon-operator"
+
+func init() {
+	if operatorNS, ok := os.LookupEnv("PERFORMANCE_OPERATOR_NAMESPACE"); ok {
+		PerformanceOperator = operatorNS
+	}
+}
 
 // TestingNamespace is the namespace the tests will use for running test pods
 var TestingNamespace = &corev1.Namespace{

--- a/functests/utils/pods/pods.go
+++ b/functests/utils/pods/pods.go
@@ -20,6 +20,7 @@ import (
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/images"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/namespaces"
 )
 
 // GetTestPod returns pod with the busybox image
@@ -155,7 +156,7 @@ func GetPerformanceOperatorPod() (*corev1.Pod, error) {
 
 	pods := &corev1.PodList{}
 
-	opts := &client.ListOptions{LabelSelector: selector, Namespace: testutils.PerformanceOperatorNamespace}
+	opts := &client.ListOptions{LabelSelector: selector, Namespace: namespaces.PerformanceOperator}
 	if err := testclient.Client.List(context.TODO(), pods, opts); err != nil {
 		return nil, err
 	}

--- a/hack/clean-deploy.sh
+++ b/hack/clean-deploy.sh
@@ -54,12 +54,12 @@ sleep 30
 
 # Delete subscription: this will undeploy the operator and delete CRDs
 echo "[INFO] Deleting Subscription and giving OLM some time to undeploy the operator and CRDs"
-$OC_TOOL -n openshift-performance-addon delete subscription performance-addon-operator
+$OC_TOOL -n openshift-performance-addon-operator delete subscription performance-addon-operator
 sleep 10
 
 # Delete operatorgroup and catalogsource
 echo "[INFO] Deleting OperatorGroup and CatalogSource"
-$OC_TOOL -n openshift-performance-addon delete operatorgroup openshift-performance-addon
+$OC_TOOL -n openshift-performance-addon-operator delete operatorgroup openshift-performance-addon
 $OC_TOOL -n openshift-marketplace delete catalogsource performance-addon-operator
 
 # Delete worker-cnf MCP
@@ -71,4 +71,4 @@ done
 
 # Delete ns
 echo "[INFO] Deleting Namespace"
-$OC_TOOL delete ns openshift-performance-addon --force --grace-period 0
+$OC_TOOL delete ns openshift-performance-addon-operator --force --grace-period 0

--- a/hack/run-upgrade-tests.sh
+++ b/hack/run-upgrade-tests.sh
@@ -12,10 +12,10 @@ CLUSTER="${CLUSTER:-upgrade-test}"
 DEPLOY_PAO="${DEPLOY_PAO:-true}"
 
 # check if operator is already installed with right version
-subs=$(${OC_TOOL} get subscriptions -o name -n openshift-performance-addon)
+subs=$(${OC_TOOL} get subscriptions -o name -n openshift-performance-addon-operator)
 if [ -n "$subs" ]; then
   echo "Operator exists, verifying the version"
-  channel=$(oc get $subs -n openshift-performance-addon -o jsonpath={.spec.channel})
+  channel=$(oc get $subs -n openshift-performance-addon-operator -o jsonpath={.spec.channel})
   if [[ "$channel" != "$FROM_VERSION" ]]; then
     echo "Channel $channel is not equal to $FROM_VERSION, exit"
     exit 1


### PR DESCRIPTION
Allow to override the namespace name the tests wants to consume;
this is needed because when doing validation, we need to make sure to
check what was actually installed in the cluster, and there is no hard
requirement on the namespace name - only suggestions.

Additionally, change the fallback name to the one suggested in the last
docs.

Signed-off-by: Francesco Romani <fromani@redhat.com>