### PR TITLE
[release-4.5] Change functest run parameters

### DIFF
--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -14,6 +14,7 @@ fi
 
 # -v: print out the text and location for each spec before running it and flush output to stdout in realtime
 # -r: run suites recursively
-# --keepGoing: don't stop on failing suite
+# --failFast: ginkgo will stop the suite right after the first spec failure
+# --flakeAttempts: rerun the test if it fails
 # -requireSuite: fail if tests are not executed because of missing suite
-GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --keepGoing -requireSuite functests -- -junitDir /tmp/artifacts
+GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --failFast --flakeAttempts=2 -requireSuite ${GINKGO_SUITS} -- -junitDir /tmp/artifacts

--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -17,4 +17,4 @@ fi
 # --failFast: ginkgo will stop the suite right after the first spec failure
 # --flakeAttempts: rerun the test if it fails
 # -requireSuite: fail if tests are not executed because of missing suite
-GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --failFast --flakeAttempts=2 -requireSuite ${GINKGO_SUITS} -- -junitDir /tmp/artifacts
+GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --failFast --flakeAttempts=2 -requireSuite functests -- -junitDir /tmp/artifacts


### PR DESCRIPTION
- replace `keepGoing` flag by `failFast`, our CI requires that all tests should pass,
it no taste to wait until all tests will finish to run if one of them failed

- to avoid flakiness, add `flakeAttempts=1`, so once test fail the ginkgo will re-run it once

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>