### PR TITLE
[release-4.4] Change functest run parameters

### DIFF
--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -6,7 +6,9 @@ if [ $? -ne 0 ]; then
 	go install github.com/onsi/ginkgo/ginkgo
 fi
 
+# --failFast: ginkgo will stop the suite right after the first spec failure
+# --flakeAttempts: rerun the test if it fails
 # after running "updating profile" tests - some other functional tests might be failed, so it's better to run them separately
-GOFLAGS=-mod=vendor ginkgo functests -- -junit /tmp/artifacts/unit_report.xml -ginkgo.skip "Updating parameters in performance profile"
-GOFLAGS=-mod=vendor ginkgo functests -- -junit /tmp/artifacts/updating_profile_unit_report.xml -ginkgo.focus "Updating parameters in performance profile"
+GOFLAGS=-mod=vendor ginkgo --failFast --flakeAttempts=2 functests -- -junit /tmp/artifacts/unit_report.xml -ginkgo.skip "Updating parameters in performance profile"
+GOFLAGS=-mod=vendor ginkgo --failFast --flakeAttempts=2 functests -- -junit /tmp/artifacts/updating_profile_unit_report.xml -ginkgo.focus "Updating parameters in performance profile"
 


### PR DESCRIPTION
- replace `keepGoing` flag by `failFast`, our CI requires that all tests should pass,
it no taste to wait until all tests will finish to run if one of them failed

- to avoid flakiness, add `flakeAttempts=1`, so once test fail the ginkgo will re-run it once