### PR TITLE
Change the user during the registry build

### DIFF
--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -9,8 +9,13 @@ COPY deploy/olm-catalog /registry/performance-addon-operator-catalog
 #ENV REG_URL=registry.svc.ci.openshift.org
 ENV REG_URL=registry.build02.ci.openshift.org
 
+USER root
+
 # replaces performance-addon-operator image with the one built by openshift ci
 RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|${REG_URL}/${OPENSHIFT_BUILD_NAMESPACE}/stable:performance-addon-operator|g" {} \; || :
+
+USER 1001
+
 # Initialize the database
 RUN initializer --manifests /registry/performance-addon-operator-catalog --output bundles.db
 


### PR DESCRIPTION
The registry image started to use the custom user, because durring the build process
it can not run the sed command under the registry folder.

```
STEP 6: RUN find /registry/performance-addon-operator-catalog/ -type f -exec sed -i "s|REPLACE_IMAGE|${REG_URL}/${OPENSHIFT_BUILD_NAMESPACE}/stable:performance-addon-operator|g" {} \; || :
sed: couldn't open temporary file /registry/performance-addon-operator-catalog/performance-addon-operator/4.4.0/sedRpZqNd: Permission denied
sed: couldn't open temporary file /registry/performance-addon-operator-catalog/performance-addon-operator/4.4.0/sediiWctc: Permission denied
sed: couldn't open temporary file /registry/performance-addon-operator-catalog/performance-addon-operator/4.4.1/sedWUwric: Permission denied
sed: couldn't open temporary file /registry/performance-addon-operator-catalog/performance-addon-operator/4.4.1/sed9mrr9b: Permission denied
sed: couldn't open temporary file /registry/performance-addon-operator-catalog/performance-addon-operator/sedGEoFMf: Permission denied
```

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>