### PR TITLE
Fix the tuned profile when IRQ load balancing is not disabled globally

### DIFF
--- a/build/assets/tuned/openshift-node-performance
+++ b/build/assets/tuned/openshift-node-performance
@@ -35,6 +35,9 @@ transparent_hugepages=never                   #  network-latency
 [irqbalance]
 # Override the value set by cpu-partitioning with an empty one
 banned_cpus=""
+
+[scheduler]
+default_irq_smp_affinity = ignore
 {{end}}
 
 [sysctl]


### PR DESCRIPTION
By default tuned sets the default IRQ SMP affinity to the non isolated
CPUs set.

However, when the IRQ load balancing is set dynamically depending on pod
annotations, the default IRQ SMP affinity should remain all machine
CPUs.

Fix the behavior by setting the new tuned option:
"default_irq_smp_affinity" to "ignore."

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>