### PR TITLE
Replace tools base image from centos to ubi

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM registry.access.redhat.com/ubi7/ubi
 
 ENV HOME=/home/ci
 ENV GOROOT /usr/local/go


### PR DESCRIPTION
Docker hub added rate limit that prevents from us to build
the tools image. To avoid the problem we will use the
ubi image from the redhat registry.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>