### PR TITLE
dockerfile: add ping-helper image

### DIFF
--- a/openshift-ci/Dockerfile.ping-helper
+++ b/openshift-ci/Dockerfile.ping-helper
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+RUN microdnf install -y iputils && microdnf clean all
+ENTRYPOINT [ "/bin/ping" ]


### PR DESCRIPTION
we want a dead-simple, minimal, trivial to maintain
image which we can use for connectivity tests
in our and openshift e2e tests.

Signed-off-by: Francesco Romani <fromani@redhat.com>