### PR TITLE
machineconfig: Set RPS mask for both containers and host

### DIFF
--- a/build/assets/configs/99-low-latency-hooks.json
+++ b/build/assets/configs/99-low-latency-hooks.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.0.0",
+  "hook": {
+    "path": "/usr/local/bin/low-latency-hooks.sh",
+    "args": ["low-latency-hooks.sh", "{{.RPSMask}}"]
+  },
+  "when": {
+    "always": true
+  },
+  "stages": ["prestart"]
+}

--- a/build/assets/configs/99-netdev-rps.rules
+++ b/build/assets/configs/99-netdev-rps.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="net", ACTION=="add", TAG+="systemd", ENV{SYSTEMD_WANTS}="update-rps@%k.service"

--- a/build/assets/scripts/low-latency-hooks.sh
+++ b/build/assets/scripts/low-latency-hooks.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+mask="${1}"
+[ -n "${mask}" ] || { logger "${0}: The rps-mask parameter is missing" ; exit 0; }
+
+pid=$(jq '.pid' /dev/stdin 2>&1)
+[[ $? -eq 0 && -n "${pid}" ]] || { logger "${0}: Failed to extract the pid: ${pid}"; exit 0; }
+
+ns=$(ip netns identify "${pid}" 2>&1)
+[[ $? -eq 0 && -n "${ns}" ]] || { logger "${0} Failed to identify the namespace: ${ns}"; exit 0; }
+
+mode=$(ip netns exec "${ns}" [ -w /sys ] && echo "rw" || echo "ro" 2>&1)
+[ $? -eq 0 ] || { logger "${0} Failed to determine if the /sys is writable: ${mode}"; exit 0; }
+
+if [ "${mode}" = "ro" ]; then
+    res=$(ip netns exec "${ns}" mount -o remount,rw /sys 2>&1)
+    [ $? -eq 0 ] || { logger "${0}: Failed to remount /sys as rw: ${res}"; exit 0; }
+fi
+
+# /sys/class/net can't be used recursively to find the rps_cpus file, use /sys/devices instead
+res=$(ip netns exec "${ns}" find /sys/devices -type f -name rps_cpus -exec sh -c "echo ${mask} | cat > {}" \; 2>&1)
+[[ $? -eq 0 && -z "${res}" ]] || logger "${0}: Failed to apply the RPS mask: ${res}"
+
+if [ "${mode}" = "ro" ]; then
+    ip netns exec "${ns}" mount -o remount,ro /sys
+    [ $? -eq 0 ] || exit 1 # Error out so the pod will not start with a writable /sys
+fi


### PR DESCRIPTION
Add a pre-start OCI hook setting the CPUs RPS mask to the performance profile's reserved CPUs.

To-do:
- Some tests

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>