### PR TITLE
Don't check for errors while waiting for profile to be applied.

### DIFF
--- a/functests/utils/mcps/mcps.go
+++ b/functests/utils/mcps/mcps.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,7 +41,27 @@ func GetByLabel(key, value string) ([]machineconfigv1.MachineConfigPool, error) 
 	if err := testclient.Client.List(context.TODO(), mcps, &client.ListOptions{LabelSelector: selector}); err != nil {
 		return nil, err
 	}
-	return mcps.Items, nil
+	if len(mcps.Items) > 0 {
+		return mcps.Items, nil
+	}
+	// fallback to look for a mcp with the same nodeselector.
+	// key value may come from a node selector, so looking for a mcp
+	// that targets the same nodes is legit
+	if err := testclient.Client.List(context.TODO(), mcps); err != nil {
+		return nil, err
+	}
+	res := []machineconfigv1.MachineConfigPool{}
+	for _, item := range mcps.Items {
+		if item.Spec.NodeSelector.MatchLabels[key] == value {
+			res = append(res, item)
+		}
+		nodeRoleKey := components.NodeRoleLabelPrefix + value
+
+		if _, ok := item.Spec.NodeSelector.MatchLabels[nodeRoleKey]; ok {
+			res = append(res, item)
+		}
+	}
+	return res, nil
 }
 
 // GetByName returns the MCP with the specified name
@@ -51,6 +72,18 @@ func GetByName(name string) (*machineconfigv1.MachineConfigPool, error) {
 		Namespace: metav1.NamespaceNone,
 	}
 	err := testclient.GetWithRetry(context.TODO(), key, mcp)
+	return mcp, err
+}
+
+// GetByNameNoRetry returns the MCP with the specified name without retrying to poke
+// the api server
+func GetByNameNoRetry(name string) (*machineconfigv1.MachineConfigPool, error) {
+	mcp := &machineconfigv1.MachineConfigPool{}
+	key := types.NamespacedName{
+		Name:      name,
+		Namespace: metav1.NamespaceNone,
+	}
+	err := testclient.Client.Get(context.TODO(), key, mcp)
 	return mcp, err
 }
 
@@ -93,8 +126,12 @@ func New(mcpName string, nodeSelector map[string]string) *machineconfigv1.Machin
 
 // GetConditionStatus return the condition status of the given MCP and condition type
 func GetConditionStatus(mcpName string, conditionType machineconfigv1.MachineConfigPoolConditionType) corev1.ConditionStatus {
-	mcp, err := GetByName(mcpName)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "Failed getting MCP by name")
+	mcp, err := GetByNameNoRetry(mcpName)
+	if err != nil {
+		// In case of any error we just retry, as in case of single node cluster
+		// the only node may be rebooting
+		return corev1.ConditionUnknown
+	}
 	for _, condition := range mcp.Status.Conditions {
 		if condition.Type == conditionType {
 			return condition.Status
@@ -117,18 +154,32 @@ func GetConditionReason(mcpName string, conditionType machineconfigv1.MachineCon
 
 // WaitForCondition waits for the MCP with given name having a condition of given type with given status
 func WaitForCondition(mcpName string, conditionType machineconfigv1.MachineConfigPoolConditionType, conditionStatus corev1.ConditionStatus) {
-	mcp, err := GetByName(mcpName)
-	Expect(err).ToNot(HaveOccurred(), "Failed getting MCP by name")
 
-	nodeLabels := mcp.Spec.NodeSelector.MatchLabels
-	key, _ := components.GetFirstKeyAndValue(nodeLabels)
-	req, err := labels.NewRequirement(key, selection.Operator(selection.Exists), []string{})
-	Expect(err).ToNot(HaveOccurred(), "Failed creating node selector")
+	var cnfNodes []corev1.Node
+	// checking in eventually as in case of single node cluster the only node may
+	// be rebooting
+	EventuallyWithOffset(1, func() error {
+		mcp, err := GetByName(mcpName)
+		if err != nil {
+			return errors.Wrap(err, "Failed getting MCP by name")
+		}
 
-	selector := labels.NewSelector()
-	selector = selector.Add(*req)
-	cnfNodes, err := nodes.GetBySelector(selector)
-	Expect(err).ToNot(HaveOccurred(), "Failed getting nodes by selector")
+		nodeLabels := mcp.Spec.NodeSelector.MatchLabels
+		key, _ := components.GetFirstKeyAndValue(nodeLabels)
+		req, err := labels.NewRequirement(key, selection.Operator(selection.Exists), []string{})
+		if err != nil {
+			return errors.Wrap(err, "Failed creating node selector")
+		}
+
+		selector := labels.NewSelector()
+		selector = selector.Add(*req)
+		cnfNodes, err = nodes.GetBySelector(selector)
+		if err != nil {
+			return errors.Wrap(err, "Failed getting nodes by selector")
+		}
+		return nil
+	}, 10*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
+
 	Expect(cnfNodes).ToNot(BeEmpty(), "Found no CNF nodes")
 	klog.Infof("MCP is targeting %v node(s)", len(cnfNodes))
 
@@ -142,9 +193,14 @@ func WaitForCondition(mcpName string, conditionType machineconfigv1.MachineConfi
 
 // WaitForProfilePickedUp waits for the MCP with given name containing the MC created for the PerformanceProfile with the given name
 func WaitForProfilePickedUp(mcpName string, profileName string) {
+	klog.Infof("Waiting for profile %s to be picked up by the %s machine config pool", profileName, mcpName)
+	defer klog.Infof("Profile %s picked up by the %s machine config pool", profileName, mcpName)
 	EventuallyWithOffset(1, func() bool {
 		mcp, err := GetByName(mcpName)
-		Expect(err).ToNot(HaveOccurred(), "Failed getting MCP by name")
+		// we ignore the error and just retry in case of single node cluster
+		if err != nil {
+			return false
+		}
 		for _, source := range mcp.Spec.Configuration.Source {
 			if source.Name == fmt.Sprintf("%s-%s", components.ComponentNamePrefix, profileName) {
 				return true

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/openshift/machine-config-operator v4.2.0-alpha.0.0.20190917115525-033375cbe820+incompatible
 	github.com/operator-framework/api v0.3.15
 	github.com/operator-framework/operator-lifecycle-manager v3.11.0+incompatible
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.6.0 // indirect
 	github.com/prometheus/common v0.10.0 // indirect
 	github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50 // indirect

--- a/pkg/controller/performanceprofile/components/consts.go
+++ b/pkg/controller/performanceprofile/components/consts.go
@@ -12,6 +12,8 @@ const (
 	ComponentNamePrefix = "performance"
 	// MachineConfigRoleLabelKey is the label key to use as label and in MachineConfigSelector of MCP which targets the performance profile
 	MachineConfigRoleLabelKey = "machineconfiguration.openshift.io/role"
+	// NodeRoleLabelPrefix is the prefix for the role label of a node
+	NodeRoleLabelPrefix = "node-role.kubernetes.io/"
 )
 
 const (


### PR DESCRIPTION
In order to make the tests work with a single node cluster, every time there is a chance the node is rebooted (after applying / deleting a profile), we just need to wait for conditions without checking the errors. This is because if polling happens when the cluster is down, the api calls will fail.