### PR TITLE
Align CPU load balancing functionality with the latest CRI-O changes

### DIFF
--- a/build/assets/configs/99-runtimes.conf
+++ b/build/assets/configs/99-runtimes.conf
@@ -4,11 +4,12 @@ runtime_path = ""
 runtime_type = "oci"
 runtime_root = "/run/runc"
 
-# The CRI-O will check the runtime handler name under the code and will activate high-performance features,
-# like CPU load balancing.
+# The CRI-O will check the allowed_annotations under the runtime handler and apply low-latency hooks when one of
+# low-latency annotations presents under it.
 # We should provide the runtime_path because we need to inform that we want to re-use runc binary and we
-# do not have high-performance binary under the $PATH that will point to it.
-[crio.runtime.runtimes.high-performance]
+# do not have low-latency binary under the $PATH that will point to it.
+[crio.runtime.runtimes.low-latency]
 runtime_path = "/bin/runc"
 runtime_type = "oci"
 runtime_root = "/run/runc"
+allowed_annotations = ["cpu-load-balancing.crio.io", "cpu-quota.crio.io", "irq-load-balancing.crio.io"]

--- a/controllers/performanceprofile_controller.go
+++ b/controllers/performanceprofile_controller.go
@@ -339,7 +339,7 @@ func (r *PerformanceProfileReconciler) applyComponents(profile *performancev2.Pe
 	}
 
 	// get mutated RuntimeClass
-	runtimeClass := runtimeclass.New(profile, machineconfig.HighPerformanceRuntime)
+	runtimeClass := runtimeclass.New(profile, machineconfig.LowLatencyRuntime)
 	if err := controllerutil.SetControllerReference(profile, runtimeClass, r.Scheme); err != nil {
 		return nil, err
 	}

--- a/controllers/performanceprofile_controller_test.go
+++ b/controllers/performanceprofile_controller_test.go
@@ -279,7 +279,7 @@ var _ = Describe("Controller", func() {
 				tunedPerformance, err = tuned.NewNodePerformance(assetsDir, profile)
 				Expect(err).ToNot(HaveOccurred())
 
-				runtimeClass = runtimeclass.New(profile, machineconfig.HighPerformanceRuntime)
+				runtimeClass = runtimeclass.New(profile, machineconfig.LowLatencyRuntime)
 			})
 
 			It("should not record new create event", func() {
@@ -602,7 +602,7 @@ var _ = Describe("Controller", func() {
 			tunedPerformance, err := tuned.NewNodePerformance(assetsDir, profile)
 			Expect(err).ToNot(HaveOccurred())
 
-			runtimeClass := runtimeclass.New(profile, machineconfig.HighPerformanceRuntime)
+			runtimeClass := runtimeclass.New(profile, machineconfig.LowLatencyRuntime)
 
 			r := newFakeReconciler(profile, mc, kc, tunedPerformance, runtimeClass)
 			result, err := r.Reconcile(request)

--- a/docs/cpu-load-balancing.md
+++ b/docs/cpu-load-balancing.md
@@ -33,7 +33,7 @@ Functionality to disable/enable the CPU load balancing will be implemented on th
 the code under the CRI-O will disable/enable CPU load balancing only when:
 
 - the pod uses ***performance-<profile_name>*** runtime class
-- the pod has ***cpu-load-balancing.crio.io: true*** annotation
+- the pod has ***cpu-load-balancing.crio.io: disable*** annotation
 
 The performance-addon-operator will be responsible for the creation of the high-performance runtime handler config snippet,
 it will have the same content as default runtime handler, under relevant nodes, 
@@ -50,7 +50,7 @@ metadata:
   ...
   annotations:
     ...
-    cpu-load-balancing.crio.io: "true"
+    cpu-load-balancing.crio.io: "disable"
     ...
   ... 
 spec:

--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -256,7 +256,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 
 			testpod = pods.GetTestPod()
 			testpod.Annotations = map[string]string{
-				"cpu-load-balancing.crio.io": "true",
+				"cpu-load-balancing.crio.io": "disable",
 			}
 			testpod.Namespace = testutils.NamespaceTesting
 

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -381,7 +381,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 			runtimeClass := &v1beta1.RuntimeClass{}
 			err = testclient.GetWithRetry(context.TODO(), configKey, runtimeClass)
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("cannot find RuntimeClass profile object %s", runtimeClass.Name))
-			Expect(runtimeClass.Handler).Should(Equal(machineconfig.HighPerformanceRuntime))
+			Expect(runtimeClass.Handler).Should(Equal(machineconfig.LowLatencyRuntime))
 
 			By("Checking that new Tuned profile created")
 			tunedKey := types.NamespacedName{

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -32,8 +32,8 @@ const (
 	MCKernelRT = "realtime"
 	// MCKernelDefault is the value of the kernel setting in MachineConfig for the default kernel
 	MCKernelDefault = "default"
-	// HighPerformanceRuntime contains the name of the CPU load balancing runtime
-	HighPerformanceRuntime = "high-performance"
+	// LowLatencyRuntime contains the name of the low-latency runtime
+	LowLatencyRuntime = "low-latency"
 
 	hugepagesAllocation = "hugepages-allocation"
 	bashScriptsDir      = "/usr/local/bin"


### PR DESCRIPTION
- add allowed_annotations under the runtime handler configuration
- change the runtime handler name to the low-latency
- use disable value for the CPU load balancing annotation
- update the documentation

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>