### PR TITLE
docs: Add irq-load-balancing documentation

### DIFF
--- a/docs/api-versions.md
+++ b/docs/api-versions.md
@@ -2,30 +2,38 @@
 
 ## Supported API Versions
 
-The Performance Addon Operator supports *v1* and *v1alpha1* [Performance Profile](docs/performance_profile.md) versions.
+The Performance Addon Operator supports *v2*, *v1* and *v1alpha1* [Performance Profile](docs/performance_profile.md) versions.
 There are no differences between the *v1* and *v1alpha1* versions, the upgrade has been made in order to
-mark the Performance Profile API as stable.
+mark the Performance Profile API as stable. The *v2* API introduces the new optional boolean field 
+```GloballyDisableIrqLoadBalancing``` with the default value ```false```.
 
 ## Upgrade from *v1alpha1* to *v1*.
 When upgrading from an older Performance Addon Operator version supporting only *v1alpha1* API to a newer one supporting
 also the *v1* API, the existing *v1alpha1* Performance Profiles will be converted on-the-fly using a "None" Conversion
 strategy and served to the Performance Addon Operator as *v1*.
 
+## Upgrade from *v1alpha1* and *v1* to *v2*
+When upgrading from an older Performance Addon Operator version, the existing *v1* and *v1alpha1* profiles will be converted
+using a Conversion Webhook that injects the ```GloballyDisableIrqLoadBalancing``` field with the value ```true``` in order
+to keep the legacy behaviour, see [Performance Profile](docs/irq-load-balancing.md).
+
 ## Q&A
-What happens in practice if I install a v1-enabled PAO on a cluster? What should I expect?
-- PAO will expect v1 Performance Profiles and query only them. Existing v1alpha1 profiles will be served as v1 and
+What happens in practice if I install a v2-enabled PAO on a cluster? What should I expect?
+- PAO will expect v2 Performance Profiles and query only them. Existing vi and v1alpha1 profiles will be served as v2 and
   PAO works with them as usual.
 
-What happens if I submit a v1alpha1 profile, will I always get back a v1 profile?
-- Any of the existent Performance Profile CRs can be retrieved as both v1 and v1alpha1 since the Performance Profile CRD
-supports both API versions.
-    For example if we have a "manual" Performance Profile in the system we can query it as both v1alpha1 and v1:
+What happens if I submit a v1alpha1 profile, will I always get back a v2 profile?
+- Any of the existent Performance Profile CRs can be retrieved as v2, v1 and v1alpha1 since the Performance Profile CRD
+supports all API versions.
+    For example if we have a "manual" Performance Profile in the system we can query it as v1, v2 and v1alpha1:
 
+    ```oc get performanceprofiles.v2.performance.openshift.io manual```
+    
     ```oc get performanceprofiles.v1.performance.openshift.io manual```
 
     ```oc get performanceprofiles.v1alpha1.performance.openshift.io manual```
 
-    However, the Performance Addon Operator will use all the existent Performance Profiles as v1 no matter
+    However, the Performance Addon Operator will use all the existent Performance Profiles as v2 no matter
     if they have been submitted as v1alpha1 or v1.
 
 Where can I find more information on API versioning?

--- a/docs/irq-load-balancing.md
+++ b/docs/irq-load-balancing.md
@@ -1,0 +1,61 @@
+# Disable IRQ load balancing globally or on-demand
+
+<!-- toc -->
+- [Summary](#summary)
+- [Goals](#goals)
+- [Design Details](#design-details)
+<!-- /toc -->
+
+## Summary
+
+In order to provide low-latency, exclusive CPU usage for guaranteed pods, the Performance Addons Operator can apply tuning
+to remove all non-reserved CPUs from being eligible CPUs for processing device interrupts. 
+Sometimes the reserved CPUs are not enough to handle networking device interrupts, in this case some isolated CPUs
+will be needed to join the effort. It is done is by annotating the pods that have stricter RT requirements, removing
+only the annotated pod's CPUs from the list of the CPUs that are allowed to handle device interrupts.
+
+### Goals
+
+- Provide a way to enable/disable device interrupts globally
+- Allow disabling device interrupts only for specific pods when the device interrupts are not disabled globally
+- Keep the existing behaviour for existing deployments (The device interrupts are disabled globally)
+
+## Design Details
+
+The Performance Profile CRD is promoted to 'v2', having a new optional boolean field ```GloballyDisableIrqLoadBalancing```
+with default value ```false```. The Performance Addon Operator disables device interrupts on all isolated CPUs only
+when ```GloballyDisableIrqLoadBalancing``` is set to ```true```.
+
+Existing Performance Profile CRs with API versions 'v1' or 'v1alpha1' are converted to 'v2' using a Conversion Webhook
+that injects the ```GloballyDisableIrqLoadBalancing``` field with the value ```true```.
+
+When ```GloballyDisableIrqLoadBalancing``` is ```false```, the functionality to disable device interrupts on pod CPUs
+it is implemented on the CRI-O level based on
+- the pod using ***performance-<profile_name>*** runtime class
+- the pod having ***irq-load-balancing.crio.io: true*** annotation
+- the pod having ***cpu-quota.crio.io: true*** annotation
+
+The Performance Addons Operator will be responsible for the creation of the high-performance runtime handler config snippet,
+it will have the same content as default runtime handler, under relevant nodes, 
+and for creation of the high-performance runtime class under the cluster.
+
+A user will be responsible for specifying the relevant runtime class and annotation under the pod.
+
+To disable device interrupts on pod CPUs, the pod specification will need to include the following fields:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  ...
+  annotations:
+    ...
+    irq-load-balancing.crio.io: "true"
+    cpu-quota.crio.io: "true"
+    ...
+  ... 
+spec:
+  ... 
+  runtimeClassName: performance-<profile_name>
+  ...
+```


### PR DESCRIPTION
Document both the GloballyDisableIrqLoadBalancing field and the
annotations used to disable IRQs only for the pod CPUs.

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>