### PR TITLE
Fix the expected kubeletconfig failure condition status

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -234,10 +234,6 @@ func (r *PerformanceProfileReconciler) getKubeletConditionsByProfile(profile *pe
 		return nil, nil
 	}
 
-	if latestCondition.Status != corev1.ConditionTrue {
-		return nil, nil
-	}
-
 	return r.getDegradedConditions(conditionKubeletFailed, latestCondition.Message), nil
 }
 


### PR DESCRIPTION
Remove the kubeletconfig condition status check because
kubeletconfig failure condition has the False status instead of True and I do
not really know if it some use cases when it can be True.

```
Status:
  Conditions:
    Last Transition Time:  2020-12-03T13:37:06Z
    Message:               Error: could not find any MachineConfigPool set for KubeletConfig
    Status:                False
    Type:                  Failure
```

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>