### PR TITLE
Bug 1905492: Update the tuned profile to set higher scheduler priority

### DIFF
--- a/build/assets/tuned/openshift-node-performance
+++ b/build/assets/tuned/openshift-node-performance
@@ -35,8 +35,12 @@ transparent_hugepages=never                   #  network-latency
 [irqbalance]
 # Override the value set by cpu-partitioning with an empty one
 banned_cpus=""
+{{end}}
 
 [scheduler]
+group.ksoftirqd=0:f:11:*:ksoftirqd.*
+group.rcuc=0:f:11:*:rcuc.*
+{{if not .GloballyDisableIrqLoadBalancing}}
 default_irq_smp_affinity = ignore
 {{end}}
 


### PR DESCRIPTION
The stalld service has higher priority than `ksoftirqd`, `rcub` and `rcuc` that
can lead to the system freeze under the load pressure. To avoid it we should
raise the scheduler priority of these threads to be higher than the stalld service.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>