### PR TITLE
bug 1906355 must-gather: wait when gathering node logs

### DIFF
--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -65,13 +65,16 @@ done
 
 # Collect journal logs for specified units for all nodes
 NODE_UNITS=(kubelet)
+ADM_PIDS=()
 for NODE in $(oc get nodes --no-headers -o custom-columns=':metadata.name'); do
     NODE_PATH=${NODES_PATH}/$NODE
     mkdir -p ${NODE_PATH}
     for UNIT in ${NODE_UNITS[@]}; do
-        oc adm node-logs $NODE -u $UNIT > ${NODE_PATH}/${NODE}_logs_$UNIT &
+        timeout -k 5m 30m oc adm node-logs $NODE -u $UNIT > ${NODE_PATH}/${NODE}_logs_$UNIT &
+	ADM_PIDS+=($!)
     done
 done
+wait "${ADM_PIDS[@]}"
 
 oc delete -f $DAEMONSET_MANIFEST
 oc delete -f $SERVICEACCOUNT_MANIFEST


### PR DESCRIPTION
In must-gather, we use a shell for loop to gather
the node logs for all the relevant units.
We run each gather process in background, which is a good
thing to speed up the task.

However, we need to wait for these processes to complete
before we move forward, otherwise we will terminate discarding
the background process data.

Signed-off-by: Francesco Romani <fromani@redhat.com>