### PR TITLE
machineconfig: fix the RPS boot failures

### DIFF
--- a/build/assets/scripts/set-rps-mask.sh
+++ b/build/assets/scripts/set-rps-mask.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+dev=$1
+[ -n "${dev}" ] || { echo "The device argument is missing" >&2 ; exit 1; }
+
+mask=$2
+[ -n "${mask}" ] || { echo "The mask argument is missing" >&2 ; exit 1; }
+
+dev_dir="/sys/class/net/${dev}"
+if [ ! -d "${dev_dir}" ]; then      # the net device was renamed, find the new name
+    systemd_devs=$(systemctl list-units -t device | grep sys-subsystem-net-devices | cut -d' ' -f1)
+
+    for systemd_dev in ${systemd_devs}; do
+        dev_sysfs=$(systemctl show "${systemd_dev}" -p SysFSPath --value)
+
+        dev_orig_name="${dev_sysfs##*/}"
+        if [ "${dev_orig_name}" = "${dev}" ]; then
+            dev_name="${systemd_dev##*-}"
+            dev_name="${dev_name%%.device}"
+            echo "${dev} device was renamed to $dev_name"
+
+            dev_dir="/sys/class/net/${dev_name}"
+            break
+        fi
+    done
+fi
+
+[ -d "${dev_dir}" ] || { echo "${dev_dir}" directory not found >&2 ; exit 1; }
+
+find "${dev_dir}"/queues -type f -name rps_cpus -exec sh -c "echo ${mask} | cat > {}" \;

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -47,6 +47,7 @@ const (
 	ociTemplateRPSMask = "RPSMask"
 	udevRulesDir       = "/etc/udev/rules.d"
 	udevRpsRule        = "99-netdev-rps"
+	setRPSMask         = "set-rps-mask"
 )
 
 const (
@@ -126,7 +127,7 @@ func getIgnitionConfig(assetsDir string, profile *performancev2.PerformanceProfi
 
 	// add script files under the node /usr/local/bin directory
 	mode := 0700
-	for _, script := range []string{hugepagesAllocation, ociHooks} {
+	for _, script := range []string{hugepagesAllocation, ociHooks, setRPSMask} {
 		src := filepath.Join(assetsDir, "scripts", fmt.Sprintf("%s.sh", script))
 		if err := addFile(ignitionConfig, src, getBashScriptPath(script), &mode); err != nil {
 			return nil, err
@@ -306,7 +307,7 @@ func getHugepagesAllocationUnitOptions(hugepagesSize string, hugepagesCount int3
 }
 
 func getRPSUnitOptions(rpsMask string) []*unit.UnitOption {
-	cmd := fmt.Sprintf("/bin/find /sys/class/net/%%i/queues -type f -name rps_cpus -exec sh -c \"echo %s | cat > {}\" \\;", rpsMask)
+	cmd := fmt.Sprintf("%s %%i %s", getBashScriptPath(setRPSMask), rpsMask)
 	return []*unit.UnitOption{
 		// [Unit]
 		// Description


### PR DESCRIPTION
It turns out the veth devices are renamed as soon as they are created,
resulting in a race between that time and the time the update-rps
service handles the interface.

If the net device directory does not exist assume the net device
has already been renamed and trace it using the systemd device
dependencies.

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>