### PR TITLE
Fix CI upgrade test

### DIFF
--- a/cluster-setup/ci-upgrade-test-cluster/performance/performance_profile.yaml
+++ b/cluster-setup/ci-upgrade-test-cluster/performance/performance_profile.yaml
@@ -1,7 +1,7 @@
 apiVersion: performance.openshift.io/v1alpha1
 kind: PerformanceProfile
 metadata:
-  name: upgrade-test
+  name: ci-upgrade-test
 spec:
   additionalKernelArgs:
     - "nmi_watchdog=0"


### PR DESCRIPTION
The wait-for-mcp script expects that the MCP will consume the
MC with the name `performance-${CLUSTER}`, but the MC name generated
by the pattern `performance-<performance-profile-name>`.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>