### PR TITLE
Revert the change of the generated runtime class name

### DIFF
--- a/build/assets/configs/99-runtimes.conf
+++ b/build/assets/configs/99-runtimes.conf
@@ -4,11 +4,11 @@ runtime_path = ""
 runtime_type = "oci"
 runtime_root = "/run/runc"
 
-# The CRI-O will check the allowed_annotations under the runtime handler and apply low-latency hooks when one of
-# low-latency annotations presents under it.
+# The CRI-O will check the allowed_annotations under the runtime handler and apply high-performance hooks when one of
+# high-performance annotations presents under it.
 # We should provide the runtime_path because we need to inform that we want to re-use runc binary and we
-# do not have low-latency binary under the $PATH that will point to it.
-[crio.runtime.runtimes.low-latency]
+# do not have high-performance binary under the $PATH that will point to it.
+[crio.runtime.runtimes.high-performance]
 runtime_path = "/bin/runc"
 runtime_type = "oci"
 runtime_root = "/run/runc"

--- a/controllers/performanceprofile_controller.go
+++ b/controllers/performanceprofile_controller.go
@@ -357,7 +357,7 @@ func (r *PerformanceProfileReconciler) applyComponents(profile *performancev2.Pe
 	}
 
 	// get mutated RuntimeClass
-	runtimeClass := runtimeclass.New(profile, machineconfig.LowLatencyRuntime)
+	runtimeClass := runtimeclass.New(profile, machineconfig.HighPerformanceRuntime)
 	if err := controllerutil.SetControllerReference(profile, runtimeClass, r.Scheme); err != nil {
 		return nil, err
 	}

--- a/controllers/performanceprofile_controller_test.go
+++ b/controllers/performanceprofile_controller_test.go
@@ -372,7 +372,7 @@ var _ = Describe("Controller", func() {
 				tunedPerformance, err = tuned.NewNodePerformance(assetsDir, profile)
 				Expect(err).ToNot(HaveOccurred())
 
-				runtimeClass = runtimeclass.New(profile, machineconfig.LowLatencyRuntime)
+				runtimeClass = runtimeclass.New(profile, machineconfig.HighPerformanceRuntime)
 			})
 
 			It("should not record new create event", func() {
@@ -695,7 +695,7 @@ var _ = Describe("Controller", func() {
 			tunedPerformance, err := tuned.NewNodePerformance(assetsDir, profile)
 			Expect(err).ToNot(HaveOccurred())
 
-			runtimeClass := runtimeclass.New(profile, machineconfig.LowLatencyRuntime)
+			runtimeClass := runtimeclass.New(profile, machineconfig.HighPerformanceRuntime)
 
 			r := newFakeReconciler(profile, mc, kc, tunedPerformance, runtimeClass)
 			result, err := r.Reconcile(request)

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -381,7 +381,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 			runtimeClass := &v1beta1.RuntimeClass{}
 			err = testclient.GetWithRetry(context.TODO(), configKey, runtimeClass)
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("cannot find RuntimeClass profile object %s", runtimeClass.Name))
-			Expect(runtimeClass.Handler).Should(Equal(machineconfig.LowLatencyRuntime))
+			Expect(runtimeClass.Handler).Should(Equal(machineconfig.HighPerformanceRuntime))
 
 			By("Checking that new Tuned profile created")
 			tunedKey := types.NamespacedName{

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -32,8 +32,8 @@ const (
 	MCKernelRT = "realtime"
 	// MCKernelDefault is the value of the kernel setting in MachineConfig for the default kernel
 	MCKernelDefault = "default"
-	// LowLatencyRuntime contains the name of the low-latency runtime
-	LowLatencyRuntime = "low-latency"
+	// HighPerformanceRuntime contains the name of the high-performance runtime
+	HighPerformanceRuntime = "high-performance"
 
 	hugepagesAllocation = "hugepages-allocation"
 	bashScriptsDir      = "/usr/local/bin"


### PR DESCRIPTION
It was not a good idea to change the name of the generate runtime class
because the name is immutable field and during the upgrade you will have
failure:

```
2020-12-17T07:07:31.743Z	ERROR	controller	Reconciler error	{"reconcilerGroup": "performance.openshift.io", "reconcilerKind": "PerformanceProfile", "controller": "performanceprofile", "name": "ci-upgrade-test", "namespace": "", "error": "RuntimeClass.node.k8s.io \"performance-ci-upgrade-test\" is invalid: handler: Invalid value: \"low-latency\": field is immutable"}
```

To make it possible to change the name, we should first delete the runtime class and after the
performance-addon-operator will re-create it with the updated name.

I will check under a separate PR if it is possible, but to fix the upgrade-test I will revert the runtime-class name now.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>