### PR TITLE
scripts: Yet another improvement to the set-rps-mask.sh script

### DIFF
--- a/build/assets/scripts/set-rps-mask.sh
+++ b/build/assets/scripts/set-rps-mask.sh
@@ -7,24 +7,30 @@ mask=$2
 [ -n "${mask}" ] || { echo "The mask argument is missing" >&2 ; exit 1; }
 
 dev_dir="/sys/class/net/${dev}"
-if [ ! -d "${dev_dir}" ]; then      # the net device was renamed, find the new name
-    systemd_devs=$(systemctl list-units -t device | grep sys-subsystem-net-devices | cut -d' ' -f1)
 
-    for systemd_dev in ${systemd_devs}; do
-        dev_sysfs=$(systemctl show "${systemd_dev}" -p SysFSPath --value)
+function find_dev_dir {
+  systemd_devs=$(systemctl list-units -t device | grep sys-subsystem-net-devices | cut -d' ' -f1)
 
-        dev_orig_name="${dev_sysfs##*/}"
-        if [ "${dev_orig_name}" = "${dev}" ]; then
-            dev_name="${systemd_dev##*-}"
-            dev_name="${dev_name%%.device}"
-            echo "${dev} device was renamed to $dev_name"
+  for systemd_dev in ${systemd_devs}; do
+    dev_sysfs=$(systemctl show "${systemd_dev}" -p SysFSPath --value)
 
-            dev_dir="/sys/class/net/${dev_name}"
-            break
-        fi
-    done
-fi
+    dev_orig_name="${dev_sysfs##*/}"
+    if [ "${dev_orig_name}" = "${dev}" ]; then
+      dev_name="${systemd_dev##*-}"
+      dev_name="${dev_name%%.device}"
+      if [ "${dev_name}" = "${dev}" ]; then # disregard the original device unit
+              continue
+      fi
 
-[ -d "${dev_dir}" ] || { echo "${dev_dir}" directory not found >&2 ; exit 1; }
+      echo "${dev} device was renamed to $dev_name"
+      dev_dir="/sys/class/net/${dev_name}"
+      break
+    fi
+  done
+}
+
+[ -d "${dev_dir}" ] || find_dev_dir                # the net device was renamed, find the new name
+[ -d "${dev_dir}" ] || { sleep 5; find_dev_dir; }  # search failed, wait a little and try again
+[ -d "${dev_dir}" ] || { echo "${dev_dir}" directory not found >&2 ; exit 0; } # the interface disappeared, not an error
 
 find "${dev_dir}"/queues -type f -name rps_cpus -exec sh -c "echo ${mask} | cat > {}" \;


### PR DESCRIPTION
A few service failures were spotted in a long running BM node.
It seems there may still be a race between the interface renaming
and the systemd service running the script.

Improve it by re-trying to find the renamed network device
after a few seconds.

While at it:
 - do not consider not finding the device a service error, sometimes
   the interfaces vanish fast.
 - consider the improbable case when going over the systemd services
   we find first the original device and not the new one.

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>