### PR TITLE
e2e: increase the pod deletion timeout

### DIFF
--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -453,6 +453,6 @@ func deleteTestPod(testpod *corev1.Pod) {
 	err = testclient.Client.Delete(context.TODO(), testpod)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = pods.WaitForDeletion(testpod, 60*time.Second)
+	err = pods.WaitForDeletion(testpod, pods.DefaultDeletionTimeout*time.Second)
 	Expect(err).ToNot(HaveOccurred())
 }

--- a/functests/1_performance/hugepages.go
+++ b/functests/1_performance/hugepages.go
@@ -109,7 +109,7 @@ var _ = Describe("[performance]Hugepages", func() {
 			err := testclient.Client.Delete(context.TODO(), testpod)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = pods.WaitForDeletion(testpod, 60*time.Second)
+			err = pods.WaitForDeletion(testpod, pods.DefaultDeletionTimeout*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -117,7 +117,7 @@ var _ = Describe("[performance] Latency Test", func() {
 		if err != nil {
 			klog.Error(err)
 		}
-		err = pods.WaitForDeletion(oslatPod, 60*time.Second)
+		err = pods.WaitForDeletion(oslatPod, pods.DefaultDeletionTimeout*time.Second)
 		if err != nil {
 			klog.Error(err)
 		}

--- a/functests/utils/pods/pods.go
+++ b/functests/utils/pods/pods.go
@@ -23,6 +23,9 @@ import (
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/namespaces"
 )
 
+// DefaultDeletionTimeout contains the default pod deletion timeout in seconds
+const DefaultDeletionTimeout = 120
+
 // GetTestPod returns pod with the busybox image
 func GetTestPod() *corev1.Pod {
 	return &corev1.Pod{


### PR DESCRIPTION
Sometimes the pod deletion fails because of the timeout, the patch
increases the timeout for pod deletion to two minutes.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>