### PR TITLE
Bug 1912118: does not set RT parameters for non-RT kernel

### DIFF
--- a/build/assets/tuned/openshift-node-performance
+++ b/build/assets/tuned/openshift-node-performance
@@ -23,10 +23,15 @@ not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
 force_latency=cstate.id:1|3                   #  latency-performance  (override)
 governor=performance                          #  latency-performance 
 energy_perf_bias=performance                  #  latency-performance 
-min_perf_pct=100                              #  latency-performance 
+min_perf_pct=100                              #  latency-performance
 
+{{if .RealtimeKernel}}
 [service]
 service.stalld=start,enable
+{{else}}
+[service]
+service.stalld=stop,disable
+{{end}}
 
 [vm]
 transparent_hugepages=never                   #  network-latency
@@ -47,8 +52,10 @@ default_irq_smp_affinity = ignore
 [sysctl]
 kernel.hung_task_timeout_secs = 600           # cpu-partitioning #realtime
 kernel.nmi_watchdog = 0                       # cpu-partitioning #realtime
-kernel.sched_rt_runtime_us = -1               # realtime 
+{{if .RealtimeKernel}}
+kernel.sched_rt_runtime_us = -1               # realtime
 kernel.timer_migration = 0                    # cpu-partitioning (= 1) #realtime (= 0)
+{{end}}
 kernel.numa_balancing=0                       # network-latency
 net.core.busy_read=50                         # network-latency
 net.core.busy_poll=50                         # network-latency

--- a/pkg/controller/performanceprofile/components/tuned/tuned.go
+++ b/pkg/controller/performanceprofile/components/tuned/tuned.go
@@ -26,6 +26,7 @@ const (
 	templateHugepages                       = "Hugepages"
 	templateAdditionalArgs                  = "AdditionalArgs"
 	templateGloballyDisableIrqLoadBalancing = "GloballyDisableIrqLoadBalancing"
+	templateRealtimeKernel                  = "RealtimeKernel"
 )
 
 func new(name string, profiles []tunedv1.TunedProfile, recommends []tunedv1.TunedRecommend) *tunedv1.Tuned {
@@ -49,6 +50,12 @@ func new(name string, profiles []tunedv1.TunedProfile, recommends []tunedv1.Tune
 func NewNodePerformance(assetsDir string, profile *performancev2.PerformanceProfile) (*tunedv1.Tuned, error) {
 
 	templateArgs := make(map[string]string)
+
+	if profile.Spec.RealTimeKernel != nil && profile.Spec.RealTimeKernel.Enabled != nil {
+		if *profile.Spec.RealTimeKernel.Enabled {
+			templateArgs[templateRealtimeKernel] = "true"
+		}
+	}
 
 	if profile.Spec.CPU.Isolated != nil {
 		templateArgs[templateIsolatedCpus] = string(*profile.Spec.CPU.Isolated)

--- a/pkg/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/controller/performanceprofile/components/tuned/tuned_test.go
@@ -159,6 +159,43 @@ var _ = Describe("Tuned", func() {
 					Expect(cmdlineMultipleHugePages.MatchString(manifest)).To(BeFalse())
 				})
 			})
+
+			It("should contain sched_rt_runtime_us parameter", func() {
+				manifest := getTunedManifest(profile)
+				Expect(manifest).To(ContainSubstring("sched_rt_runtime_us"))
+			})
+
+			It("should contain timer_migration parameter", func() {
+				manifest := getTunedManifest(profile)
+				Expect(manifest).To(ContainSubstring("timer_migration"))
+			})
+
+			It("should start and enable stalld service", func() {
+				manifest := getTunedManifest(profile)
+				Expect(manifest).To(ContainSubstring("service.stalld=start,enable"))
+			})
+		})
+
+		When("real time kernel disable", func() {
+			BeforeEach(func() {
+				profile = testutils.NewPerformanceProfile("test")
+				profile.Spec.RealTimeKernel.Enabled = pointer.BoolPtr(false)
+			})
+
+			It("should not contain sched_rt_runtime_us parameter", func() {
+				manifest := getTunedManifest(profile)
+				Expect(manifest).NotTo(ContainSubstring("sched_rt_runtime_us"))
+			})
+
+			It("should not contain timer_migration parameter", func() {
+				manifest := getTunedManifest(profile)
+				Expect(manifest).NotTo(ContainSubstring("timer_migration"))
+			})
+
+			It("should stop and disable stalld service", func() {
+				manifest := getTunedManifest(profile)
+				Expect(manifest).To(ContainSubstring("service.stalld=stop,disable"))
+			})
 		})
 	})
 })


### PR DESCRIPTION
Avoid setting real-time related parameters for the non-RT kernel.
Setting these parameters can hang the system.

- the most problematic parameter is `sched_rt_runtime_us` that can prevent to get the CPU time for some tasks with a small priority.
- the stalld service does not start without `sched_rt_runtime_us=-1`

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>