### PR TITLE
must-gather: dockerfile: rebase on 4.7.0

### DIFF
--- a/openshift-ci/Dockerfile.must-gather
+++ b/openshift-ci/Dockerfile.must-gather
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-must-gather:4.6.0 AS builder
+FROM quay.io/openshift/origin-must-gather:4.7.0 AS builder
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 RUN microdnf install -y pciutils util-linux hostname rsync


### PR DESCRIPTION
it seems we forgot to update to 4.7.0 some time ago.

Signed-off-by: Francesco Romani <fromani@redhat.com>