### PR TITLE
runc: wrapper to move infra pods on reserved cores

### DIFF
--- a/build/assets/configs/99-runtimes.conf
+++ b/build/assets/configs/99-runtimes.conf
@@ -1,6 +1,6 @@
 # We should copy paste the default runtime because this snippet will override the whole runtimes section
 [crio.runtime.runtimes.runc]
-runtime_path = ""
+runtime_path = "/usr/local/bin/runc-wrapper.sh"
 runtime_type = "oci"
 runtime_root = "/run/runc"
 
@@ -9,7 +9,7 @@ runtime_root = "/run/runc"
 # We should provide the runtime_path because we need to inform that we want to re-use runc binary and we
 # do not have high-performance binary under the $PATH that will point to it.
 [crio.runtime.runtimes.high-performance]
-runtime_path = "/bin/runc"
+runtime_path = "/usr/local/bin/runc-wrapper.sh"
 runtime_type = "oci"
 runtime_root = "/run/runc"
 allowed_annotations = ["cpu-load-balancing.crio.io", "cpu-quota.crio.io", "irq-load-balancing.crio.io"]

--- a/build/assets/scripts/runc-wrapper.sh
+++ b/build/assets/scripts/runc-wrapper.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+if [ "{{.CPUList}}" == "UNRESTRICTED" ]; then
+	exec /bin/runc "$@"
+fi
+if [ -n "$3" ] && [ "$3" == "start" ]; then
+        if [ -n "$4" ]; then
+                bundle=$(/bin/runc state "$4" 2>/dev/null | jq .bundle -r)
+                if [ -n "$bundle" -a -f "$bundle/config.json" ]; then
+                        command=$(grep "/usr/bin/pod" "$bundle/config.json")
+                        if [ -n "$command" ]; then
+                                cpuset=$(find /sys/fs/cgroup/cpuset/ -name cpuset.cpus | grep $4)
+                                echo "{{.CPUList}}" > $cpuset
+                        fi
+                fi
+        fi
+fi
+taskset -c "{{.CPUList}}" /bin/runc "$@"


### PR DESCRIPTION
Until bug https://bugzilla.redhat.com/1775444
is (reopened and) fixed, we need to make sure that the infra container
for kubernetes pods is not running on isolated cores.

To do it now, the only viable option is to add a runc wrapper,
which we do with this patch.

Signed-off-by: Francesco Romani <fromani@redhat.com>