### PR TITLE
Configure CRI-O infra containers CPUs

### DIFF
--- a/build/assets/configs/99-runtimes.conf
+++ b/build/assets/configs/99-runtimes.conf
@@ -1,3 +1,8 @@
+{{if .ReservedCpus}}
+[crio.runtime]
+infra_ctr_cpuset = "{{.ReservedCpus}}"
+{{end}}
+
 # We should copy paste the default runtime because this snippet will override the whole runtimes section
 [crio.runtime.runtimes.runc]
 runtime_path = ""


### PR DESCRIPTION
The PAO will update the CRI-O configuration and will set infra containers
CPUs to one that specified under the performance profile.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>