### PR TITLE
must-gather: narrow down permissions

### DIFF
--- a/must-gather/node-gather/daemonset.yaml
+++ b/must-gather/node-gather/daemonset.yaml
@@ -17,7 +17,6 @@ spec:
       serviceaccount: perf-node-gather
       serviceAccountName: perf-node-gather
       terminationGracePeriodSeconds: 0
-      hostNetwork: true
       containers:
       - name: node-probe
         image: MUST_GATHER_IMAGE


### PR DESCRIPTION
reduce must-gather daemonset permissions.
No intended changes in behaviour.