### PR TITLE
Bug 1918788: Avoid unneeded object initialization during profile conversion 

### DIFF
--- a/api/v1alpha1/performanceprofile_conversion.go
+++ b/api/v1alpha1/performanceprofile_conversion.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"k8s.io/utils/pointer"
 
-	"github.com/openshift-kni/performance-addon-operators/api/v1"
+	v1 "github.com/openshift-kni/performance-addon-operators/api/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
@@ -17,8 +17,9 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 	dst.ObjectMeta = curr.ObjectMeta
 
 	// Spec
-	dst.Spec.CPU = new(v1.CPU)
 	if curr.Spec.CPU != nil {
+		dst.Spec.CPU = new(v1.CPU)
+
 		if curr.Spec.CPU.Reserved != nil {
 			reserved := v1.CPUSet(*curr.Spec.CPU.Reserved)
 			dst.Spec.CPU.Reserved = &reserved
@@ -32,58 +33,75 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 		}
 	}
 
-	dst.Spec.HugePages = new(v1.HugePages)
 	if curr.Spec.HugePages != nil {
+		dst.Spec.HugePages = new(v1.HugePages)
+
 		if curr.Spec.HugePages.DefaultHugePagesSize != nil {
 			defaultHugePagesSize := v1.HugePageSize(*curr.Spec.HugePages.DefaultHugePagesSize)
 			dst.Spec.HugePages.DefaultHugePagesSize = &defaultHugePagesSize
 		}
-		dst.Spec.HugePages.Pages = make([]v1.HugePage, len(curr.Spec.HugePages.Pages))
-		for i, p := range curr.Spec.HugePages.Pages {
-			dst.Spec.HugePages.Pages[i] = v1.HugePage{
-				Size: v1.HugePageSize(p.Size), Count: p.Count,
-			}
-			if p.Node != nil {
-				dst.Spec.HugePages.Pages[i].Node = pointer.Int32Ptr(*p.Node)
+
+		if curr.Spec.HugePages.Pages != nil {
+			dst.Spec.HugePages.Pages = make([]v1.HugePage, len(curr.Spec.HugePages.Pages))
+
+			for i, p := range curr.Spec.HugePages.Pages {
+				dst.Spec.HugePages.Pages[i] = v1.HugePage{
+					Size: v1.HugePageSize(p.Size), Count: p.Count,
+				}
+				if p.Node != nil {
+					dst.Spec.HugePages.Pages[i].Node = pointer.Int32Ptr(*p.Node)
+				}
 			}
 		}
 	}
 
-	dst.Spec.MachineConfigLabel = make(map[string]string)
-	for k, v := range curr.Spec.MachineConfigLabel {
-		dst.Spec.MachineConfigLabel[k] = v
+	if curr.Spec.MachineConfigLabel != nil {
+		dst.Spec.MachineConfigLabel = make(map[string]string)
+		for k, v := range curr.Spec.MachineConfigLabel {
+			dst.Spec.MachineConfigLabel[k] = v
+		}
 	}
 
-	dst.Spec.MachineConfigPoolSelector = make(map[string]string)
-	for k, v := range curr.Spec.MachineConfigPoolSelector {
-		dst.Spec.MachineConfigPoolSelector[k] = v
+	if curr.Spec.MachineConfigPoolSelector != nil {
+		dst.Spec.MachineConfigPoolSelector = make(map[string]string)
+		for k, v := range curr.Spec.MachineConfigPoolSelector {
+			dst.Spec.MachineConfigPoolSelector[k] = v
+		}
 	}
 
-	dst.Spec.NodeSelector = make(map[string]string)
-	for k, v := range curr.Spec.NodeSelector {
-		dst.Spec.NodeSelector[k] = v
+	if curr.Spec.NodeSelector != nil {
+		dst.Spec.NodeSelector = make(map[string]string)
+		for k, v := range curr.Spec.NodeSelector {
+			dst.Spec.NodeSelector[k] = v
+		}
 	}
 
-	dst.Spec.RealTimeKernel = new(v1.RealTimeKernel)
 	if curr.Spec.RealTimeKernel != nil {
+		dst.Spec.RealTimeKernel = new(v1.RealTimeKernel)
+
 		if curr.Spec.RealTimeKernel.Enabled != nil {
 			dst.Spec.RealTimeKernel.Enabled = pointer.BoolPtr(*curr.Spec.RealTimeKernel.Enabled)
 		}
 	}
 
-	dst.Spec.AdditionalKernelArgs = make([]string, len(curr.Spec.AdditionalKernelArgs))
-	copy(dst.Spec.AdditionalKernelArgs, curr.Spec.AdditionalKernelArgs)
+	if curr.Spec.AdditionalKernelArgs != nil {
+		dst.Spec.AdditionalKernelArgs = make([]string, len(curr.Spec.AdditionalKernelArgs))
+		copy(dst.Spec.AdditionalKernelArgs, curr.Spec.AdditionalKernelArgs)
+	}
 
-	dst.Spec.NUMA = new(v1.NUMA)
 	if curr.Spec.NUMA != nil {
+		dst.Spec.NUMA = new(v1.NUMA)
+
 		if curr.Spec.NUMA.TopologyPolicy != nil {
 			dst.Spec.NUMA.TopologyPolicy = pointer.StringPtr(*curr.Spec.NUMA.TopologyPolicy)
 		}
 	}
 
 	// Status
-	dst.Status.Conditions = make([]conditionsv1.Condition, len(curr.Status.Conditions))
-	copy(dst.Status.Conditions, curr.Status.Conditions)
+	if curr.Status.Conditions != nil {
+		dst.Status.Conditions = make([]conditionsv1.Condition, len(curr.Status.Conditions))
+		copy(dst.Status.Conditions, curr.Status.Conditions)
+	}
 
 	if curr.Status.Tuned != nil {
 		dst.Status.Tuned = pointer.StringPtr(*curr.Status.Tuned)
@@ -105,8 +123,9 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 	curr.ObjectMeta = src.ObjectMeta
 
 	// Spec
-	curr.Spec.CPU = new(CPU)
 	if src.Spec.CPU != nil {
+		curr.Spec.CPU = new(CPU)
+
 		if src.Spec.CPU.Reserved != nil {
 			reserved := CPUSet(*src.Spec.CPU.Reserved)
 			curr.Spec.CPU.Reserved = &reserved
@@ -120,58 +139,74 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 		}
 	}
 
-	curr.Spec.HugePages = new(HugePages)
 	if src.Spec.HugePages != nil {
+		curr.Spec.HugePages = new(HugePages)
+
 		if src.Spec.HugePages.DefaultHugePagesSize != nil {
 			defaultHugePagesSize := HugePageSize(*src.Spec.HugePages.DefaultHugePagesSize)
 			curr.Spec.HugePages.DefaultHugePagesSize = &defaultHugePagesSize
 		}
-		curr.Spec.HugePages.Pages = make([]HugePage, len(src.Spec.HugePages.Pages))
-		for i, p := range src.Spec.HugePages.Pages {
-			curr.Spec.HugePages.Pages[i] = HugePage{
-				Size: HugePageSize(p.Size), Count: p.Count,
-			}
-			if p.Node != nil {
-				curr.Spec.HugePages.Pages[i].Node = pointer.Int32Ptr(*p.Node)
+
+		if src.Spec.HugePages.Pages != nil {
+			curr.Spec.HugePages.Pages = make([]HugePage, len(src.Spec.HugePages.Pages))
+			for i, p := range src.Spec.HugePages.Pages {
+				curr.Spec.HugePages.Pages[i] = HugePage{
+					Size: HugePageSize(p.Size), Count: p.Count,
+				}
+				if p.Node != nil {
+					curr.Spec.HugePages.Pages[i].Node = pointer.Int32Ptr(*p.Node)
+				}
 			}
 		}
 	}
 
-	curr.Spec.MachineConfigLabel = make(map[string]string)
-	for k, v := range src.Spec.MachineConfigLabel {
-		curr.Spec.MachineConfigLabel[k] = v
+	if src.Spec.MachineConfigLabel != nil {
+		curr.Spec.MachineConfigLabel = make(map[string]string)
+		for k, v := range src.Spec.MachineConfigLabel {
+			curr.Spec.MachineConfigLabel[k] = v
+		}
 	}
 
-	curr.Spec.MachineConfigPoolSelector = make(map[string]string)
-	for k, v := range src.Spec.MachineConfigPoolSelector {
-		curr.Spec.MachineConfigPoolSelector[k] = v
+	if src.Spec.MachineConfigPoolSelector != nil {
+		curr.Spec.MachineConfigPoolSelector = make(map[string]string)
+		for k, v := range src.Spec.MachineConfigPoolSelector {
+			curr.Spec.MachineConfigPoolSelector[k] = v
+		}
 	}
 
-	curr.Spec.NodeSelector = make(map[string]string)
-	for k, v := range src.Spec.NodeSelector {
-		curr.Spec.NodeSelector[k] = v
+	if src.Spec.NodeSelector != nil {
+		curr.Spec.NodeSelector = make(map[string]string)
+		for k, v := range src.Spec.NodeSelector {
+			curr.Spec.NodeSelector[k] = v
+		}
 	}
 
-	curr.Spec.RealTimeKernel = new(RealTimeKernel)
 	if src.Spec.RealTimeKernel != nil {
+		curr.Spec.RealTimeKernel = new(RealTimeKernel)
+
 		if src.Spec.RealTimeKernel.Enabled != nil {
 			curr.Spec.RealTimeKernel.Enabled = pointer.BoolPtr(*src.Spec.RealTimeKernel.Enabled)
 		}
 	}
 
-	curr.Spec.AdditionalKernelArgs = make([]string, len(src.Spec.AdditionalKernelArgs))
-	copy(curr.Spec.AdditionalKernelArgs, src.Spec.AdditionalKernelArgs)
+	if src.Spec.AdditionalKernelArgs != nil {
+		curr.Spec.AdditionalKernelArgs = make([]string, len(src.Spec.AdditionalKernelArgs))
+		copy(curr.Spec.AdditionalKernelArgs, src.Spec.AdditionalKernelArgs)
+	}
 
-	curr.Spec.NUMA = new(NUMA)
 	if src.Spec.NUMA != nil {
+		curr.Spec.NUMA = new(NUMA)
+
 		if src.Spec.NUMA.TopologyPolicy != nil {
 			curr.Spec.NUMA.TopologyPolicy = pointer.StringPtr(*src.Spec.NUMA.TopologyPolicy)
 		}
 	}
 
 	// Status
-	curr.Status.Conditions = make([]conditionsv1.Condition, len(src.Status.Conditions))
-	copy(curr.Status.Conditions, src.Status.Conditions)
+	if src.Status.Conditions != nil {
+		curr.Status.Conditions = make([]conditionsv1.Condition, len(src.Status.Conditions))
+		copy(curr.Status.Conditions, src.Status.Conditions)
+	}
 
 	if src.Status.Tuned != nil {
 		curr.Status.Tuned = pointer.StringPtr(*src.Status.Tuned)

--- a/api/v2/performanceprofile_conversion.go
+++ b/api/v2/performanceprofile_conversion.go
@@ -3,7 +3,7 @@ package v2
 import (
 	"k8s.io/utils/pointer"
 
-	"github.com/openshift-kni/performance-addon-operators/api/v1"
+	v1 "github.com/openshift-kni/performance-addon-operators/api/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
@@ -17,8 +17,9 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 	dst.ObjectMeta = curr.ObjectMeta
 
 	// Spec
-	dst.Spec.CPU = new(v1.CPU)
 	if curr.Spec.CPU != nil {
+		dst.Spec.CPU = new(v1.CPU)
+
 		if curr.Spec.CPU.Reserved != nil {
 			reserved := v1.CPUSet(*curr.Spec.CPU.Reserved)
 			dst.Spec.CPU.Reserved = &reserved
@@ -32,58 +33,75 @@ func (curr *PerformanceProfile) ConvertTo(dstRaw conversion.Hub) error {
 		}
 	}
 
-	dst.Spec.HugePages = new(v1.HugePages)
 	if curr.Spec.HugePages != nil {
+		dst.Spec.HugePages = new(v1.HugePages)
+
 		if curr.Spec.HugePages.DefaultHugePagesSize != nil {
 			defaultHugePagesSize := v1.HugePageSize(*curr.Spec.HugePages.DefaultHugePagesSize)
 			dst.Spec.HugePages.DefaultHugePagesSize = &defaultHugePagesSize
 		}
-		dst.Spec.HugePages.Pages = make([]v1.HugePage, len(curr.Spec.HugePages.Pages))
-		for i, p := range curr.Spec.HugePages.Pages {
-			dst.Spec.HugePages.Pages[i] = v1.HugePage{
-				Size: v1.HugePageSize(p.Size), Count: p.Count,
-			}
-			if p.Node != nil {
-				dst.Spec.HugePages.Pages[i].Node = pointer.Int32Ptr(*p.Node)
+
+		if curr.Spec.HugePages.Pages != nil {
+			dst.Spec.HugePages.Pages = make([]v1.HugePage, len(curr.Spec.HugePages.Pages))
+
+			for i, p := range curr.Spec.HugePages.Pages {
+				dst.Spec.HugePages.Pages[i] = v1.HugePage{
+					Size: v1.HugePageSize(p.Size), Count: p.Count,
+				}
+				if p.Node != nil {
+					dst.Spec.HugePages.Pages[i].Node = pointer.Int32Ptr(*p.Node)
+				}
 			}
 		}
 	}
 
-	dst.Spec.MachineConfigLabel = make(map[string]string)
-	for k, v := range curr.Spec.MachineConfigLabel {
-		dst.Spec.MachineConfigLabel[k] = v
+	if curr.Spec.MachineConfigLabel != nil {
+		dst.Spec.MachineConfigLabel = make(map[string]string)
+		for k, v := range curr.Spec.MachineConfigLabel {
+			dst.Spec.MachineConfigLabel[k] = v
+		}
 	}
 
-	dst.Spec.MachineConfigPoolSelector = make(map[string]string)
-	for k, v := range curr.Spec.MachineConfigPoolSelector {
-		dst.Spec.MachineConfigPoolSelector[k] = v
+	if curr.Spec.MachineConfigPoolSelector != nil {
+		dst.Spec.MachineConfigPoolSelector = make(map[string]string)
+		for k, v := range curr.Spec.MachineConfigPoolSelector {
+			dst.Spec.MachineConfigPoolSelector[k] = v
+		}
 	}
 
-	dst.Spec.NodeSelector = make(map[string]string)
-	for k, v := range curr.Spec.NodeSelector {
-		dst.Spec.NodeSelector[k] = v
+	if curr.Spec.NodeSelector != nil {
+		dst.Spec.NodeSelector = make(map[string]string)
+		for k, v := range curr.Spec.NodeSelector {
+			dst.Spec.NodeSelector[k] = v
+		}
 	}
 
-	dst.Spec.RealTimeKernel = new(v1.RealTimeKernel)
 	if curr.Spec.RealTimeKernel != nil {
+		dst.Spec.RealTimeKernel = new(v1.RealTimeKernel)
+
 		if curr.Spec.RealTimeKernel.Enabled != nil {
 			dst.Spec.RealTimeKernel.Enabled = pointer.BoolPtr(*curr.Spec.RealTimeKernel.Enabled)
 		}
 	}
 
-	dst.Spec.AdditionalKernelArgs = make([]string, len(curr.Spec.AdditionalKernelArgs))
-	copy(dst.Spec.AdditionalKernelArgs, curr.Spec.AdditionalKernelArgs)
+	if curr.Spec.AdditionalKernelArgs != nil {
+		dst.Spec.AdditionalKernelArgs = make([]string, len(curr.Spec.AdditionalKernelArgs))
+		copy(dst.Spec.AdditionalKernelArgs, curr.Spec.AdditionalKernelArgs)
+	}
 
-	dst.Spec.NUMA = new(v1.NUMA)
 	if curr.Spec.NUMA != nil {
+		dst.Spec.NUMA = new(v1.NUMA)
+
 		if curr.Spec.NUMA.TopologyPolicy != nil {
 			dst.Spec.NUMA.TopologyPolicy = pointer.StringPtr(*curr.Spec.NUMA.TopologyPolicy)
 		}
 	}
 
 	// Status
-	dst.Status.Conditions = make([]conditionsv1.Condition, len(curr.Status.Conditions))
-	copy(dst.Status.Conditions, curr.Status.Conditions)
+	if curr.Status.Conditions != nil {
+		dst.Status.Conditions = make([]conditionsv1.Condition, len(curr.Status.Conditions))
+		copy(dst.Status.Conditions, curr.Status.Conditions)
+	}
 
 	if curr.Status.Tuned != nil {
 		dst.Status.Tuned = pointer.StringPtr(*curr.Status.Tuned)
@@ -105,8 +123,9 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 	curr.ObjectMeta = src.ObjectMeta
 
 	// Spec
-	curr.Spec.CPU = new(CPU)
 	if src.Spec.CPU != nil {
+		curr.Spec.CPU = new(CPU)
+
 		if src.Spec.CPU.Reserved != nil {
 			reserved := CPUSet(*src.Spec.CPU.Reserved)
 			curr.Spec.CPU.Reserved = &reserved
@@ -120,50 +139,64 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 		}
 	}
 
-	curr.Spec.HugePages = new(HugePages)
 	if src.Spec.HugePages != nil {
+		curr.Spec.HugePages = new(HugePages)
+
 		if src.Spec.HugePages.DefaultHugePagesSize != nil {
 			defaultHugePagesSize := HugePageSize(*src.Spec.HugePages.DefaultHugePagesSize)
 			curr.Spec.HugePages.DefaultHugePagesSize = &defaultHugePagesSize
 		}
-		curr.Spec.HugePages.Pages = make([]HugePage, len(src.Spec.HugePages.Pages))
-		for i, p := range src.Spec.HugePages.Pages {
-			curr.Spec.HugePages.Pages[i] = HugePage{
-				Size: HugePageSize(p.Size), Count: p.Count,
-			}
-			if p.Node != nil {
-				curr.Spec.HugePages.Pages[i].Node = pointer.Int32Ptr(*p.Node)
+
+		if src.Spec.HugePages.Pages != nil {
+			curr.Spec.HugePages.Pages = make([]HugePage, len(src.Spec.HugePages.Pages))
+			for i, p := range src.Spec.HugePages.Pages {
+				curr.Spec.HugePages.Pages[i] = HugePage{
+					Size: HugePageSize(p.Size), Count: p.Count,
+				}
+				if p.Node != nil {
+					curr.Spec.HugePages.Pages[i].Node = pointer.Int32Ptr(*p.Node)
+				}
 			}
 		}
 	}
 
-	curr.Spec.MachineConfigLabel = make(map[string]string)
-	for k, v := range src.Spec.MachineConfigLabel {
-		curr.Spec.MachineConfigLabel[k] = v
+	if src.Spec.MachineConfigLabel != nil {
+		curr.Spec.MachineConfigLabel = make(map[string]string)
+		for k, v := range src.Spec.MachineConfigLabel {
+			curr.Spec.MachineConfigLabel[k] = v
+		}
 	}
 
-	curr.Spec.MachineConfigPoolSelector = make(map[string]string)
-	for k, v := range src.Spec.MachineConfigPoolSelector {
-		curr.Spec.MachineConfigPoolSelector[k] = v
+	if src.Spec.MachineConfigPoolSelector != nil {
+		curr.Spec.MachineConfigPoolSelector = make(map[string]string)
+		for k, v := range src.Spec.MachineConfigPoolSelector {
+			curr.Spec.MachineConfigPoolSelector[k] = v
+		}
 	}
 
-	curr.Spec.NodeSelector = make(map[string]string)
-	for k, v := range src.Spec.NodeSelector {
-		curr.Spec.NodeSelector[k] = v
+	if src.Spec.NodeSelector != nil {
+		curr.Spec.NodeSelector = make(map[string]string)
+		for k, v := range src.Spec.NodeSelector {
+			curr.Spec.NodeSelector[k] = v
+		}
 	}
 
-	curr.Spec.RealTimeKernel = new(RealTimeKernel)
 	if src.Spec.RealTimeKernel != nil {
+		curr.Spec.RealTimeKernel = new(RealTimeKernel)
+
 		if src.Spec.RealTimeKernel.Enabled != nil {
 			curr.Spec.RealTimeKernel.Enabled = pointer.BoolPtr(*src.Spec.RealTimeKernel.Enabled)
 		}
 	}
 
-	curr.Spec.AdditionalKernelArgs = make([]string, len(src.Spec.AdditionalKernelArgs))
-	copy(curr.Spec.AdditionalKernelArgs, src.Spec.AdditionalKernelArgs)
+	if src.Spec.AdditionalKernelArgs != nil {
+		curr.Spec.AdditionalKernelArgs = make([]string, len(src.Spec.AdditionalKernelArgs))
+		copy(curr.Spec.AdditionalKernelArgs, src.Spec.AdditionalKernelArgs)
+	}
 
-	curr.Spec.NUMA = new(NUMA)
 	if src.Spec.NUMA != nil {
+		curr.Spec.NUMA = new(NUMA)
+
 		if src.Spec.NUMA.TopologyPolicy != nil {
 			curr.Spec.NUMA.TopologyPolicy = pointer.StringPtr(*src.Spec.NUMA.TopologyPolicy)
 		}
@@ -173,8 +206,10 @@ func (curr *PerformanceProfile) ConvertFrom(srcRaw conversion.Hub) error {
 	curr.Spec.GloballyDisableIrqLoadBalancing = pointer.BoolPtr(true)
 
 	// Status
-	curr.Status.Conditions = make([]conditionsv1.Condition, len(src.Status.Conditions))
-	copy(curr.Status.Conditions, src.Status.Conditions)
+	if src.Status.Conditions != nil {
+		curr.Status.Conditions = make([]conditionsv1.Condition, len(src.Status.Conditions))
+		copy(curr.Status.Conditions, src.Status.Conditions)
+	}
 
 	if src.Status.Tuned != nil {
 		curr.Status.Tuned = pointer.StringPtr(*src.Status.Tuned)

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -431,8 +431,41 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 	})
 
 	Context("Verify API Conversions", func() {
-		It("[test_id:35887] Verifies v1 <-> v1alpha1 conversions", func() {
+		verifyV2V1 := func() {
+			By("Checking v2 -> v1 conversion")
+			v1Profile := &performancev1.PerformanceProfile{}
+			key := types.NamespacedName{
+				Name:      profile.Name,
+				Namespace: profile.Namespace,
+			}
 
+			err := testclient.Client.Get(context.TODO(), key, v1Profile)
+			Expect(err).ToNot(HaveOccurred(), "Failed getting v1Profile")
+			Expect(verifyV2Conversion(profile, v1Profile)).ToNot(HaveOccurred())
+
+			By("Checking v1 -> v2 conversion")
+			v1Profile.Name = "v1"
+			v1Profile.ResourceVersion = ""
+			v1Profile.Spec.NodeSelector = map[string]string{"v1/v1": "v1"}
+			Expect(testclient.Client.Create(context.TODO(), v1Profile)).ToNot(HaveOccurred())
+
+			key = types.NamespacedName{
+				Name:      v1Profile.Name,
+				Namespace: v1Profile.Namespace,
+			}
+
+			defer func() {
+				Expect(testclient.Client.Delete(context.TODO(), v1Profile)).ToNot(HaveOccurred())
+				Expect(profiles.WaitForDeletion(key, 60*time.Second)).ToNot(HaveOccurred())
+			}()
+
+			v2Profile := &performancev2.PerformanceProfile{}
+			err = testclient.GetWithRetry(context.TODO(), key, v2Profile)
+			Expect(err).ToNot(HaveOccurred(), "Failed getting v2Profile")
+			Expect(verifyV2Conversion(v2Profile, v1Profile)).ToNot(HaveOccurred())
+		}
+
+		verifyV1VAlpha1 := func() {
 			By("Acquiring the tests profile as a v1 profile")
 			v1Profile := &performancev1.PerformanceProfile{}
 			key := types.NamespacedName{
@@ -457,7 +490,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 			By("Checking v1alpha1 -> v1 conversion")
 			v1alpha1Profile.Name = "v1alpha"
 			v1alpha1Profile.ResourceVersion = ""
-			v1alpha1Profile.Spec.NodeSelector = map[string]string{"test": "test"}
+			v1alpha1Profile.Spec.NodeSelector = map[string]string{"v1alpha/v1alpha": "v1alpha"}
 			Expect(testclient.Client.Create(context.TODO(), v1alpha1Profile)).ToNot(HaveOccurred())
 
 			key = types.NamespacedName{
@@ -474,41 +507,49 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 			err = testclient.GetWithRetry(context.TODO(), key, v1Profile)
 			Expect(err).ToNot(HaveOccurred(), "Failed getting v1profile")
 			Expect(verifyV1alpha1Conversion(v1alpha1Profile, v1Profile)).ToNot(HaveOccurred())
+		}
+
+		When("the performance profile does not contain NUMA field", func() {
+			BeforeEach(func() {
+				key := types.NamespacedName{
+					Name:      profile.Name,
+					Namespace: profile.Namespace,
+				}
+				err := testclient.Client.Get(context.TODO(), key, profile)
+				Expect(err).ToNot(HaveOccurred(), "Failed getting v1Profile")
+
+				profile.Name = "without-numa"
+				profile.ResourceVersion = ""
+				profile.Spec.NodeSelector = map[string]string{"withoutNUMA/withoutNUMA": "withoutNUMA"}
+				profile.Spec.NUMA = nil
+
+				err = testclient.Client.Create(context.TODO(), profile)
+				Expect(err).ToNot(HaveOccurred(), "Failed to create profile without NUMA")
+			})
+
+			AfterEach(func() {
+				Expect(testclient.Client.Delete(context.TODO(), profile)).ToNot(HaveOccurred())
+				Expect(profiles.WaitForDeletion(types.NamespacedName{
+					Name:      profile.Name,
+					Namespace: profile.Namespace,
+				}, 60*time.Second)).ToNot(HaveOccurred())
+			})
+
+			It("Verifies v1 <-> v1alpha1 conversions", func() {
+				verifyV1VAlpha1()
+			})
+
+			It("Verifies v1 <-> v2 conversions", func() {
+				verifyV2V1()
+			})
+		})
+
+		It("[test_id:35887] Verifies v1 <-> v1alpha1 conversions", func() {
+			verifyV1VAlpha1()
 		})
 
 		It("[test_id:35888] Verifies v1 <-> v2 conversions", func() {
-
-			By("Checking v2 -> v1 conversion")
-			v1Profile := &performancev1.PerformanceProfile{}
-			key := types.NamespacedName{
-				Name:      profile.Name,
-				Namespace: profile.Namespace,
-			}
-
-			err := testclient.Client.Get(context.TODO(), key, v1Profile)
-			Expect(err).ToNot(HaveOccurred(), "Failed getting v1Profile")
-			Expect(verifyV2Conversion(profile, v1Profile)).ToNot(HaveOccurred())
-
-			By("Checking v1 -> v2 conversion")
-			v1Profile.Name = "v1"
-			v1Profile.ResourceVersion = ""
-			v1Profile.Spec.NodeSelector = map[string]string{"test": "test"}
-			Expect(testclient.Client.Create(context.TODO(), v1Profile)).ToNot(HaveOccurred())
-
-			key = types.NamespacedName{
-				Name:      v1Profile.Name,
-				Namespace: v1Profile.Namespace,
-			}
-
-			defer func() {
-				Expect(testclient.Client.Delete(context.TODO(), v1Profile)).ToNot(HaveOccurred())
-				Expect(profiles.WaitForDeletion(key, 60*time.Second)).ToNot(HaveOccurred())
-			}()
-
-			v2Profile := &performancev2.PerformanceProfile{}
-			err = testclient.GetWithRetry(context.TODO(), key, v2Profile)
-			Expect(err).ToNot(HaveOccurred(), "Failed getting v2Profile")
-			Expect(verifyV2Conversion(v2Profile, v1Profile)).ToNot(HaveOccurred())
+			verifyV2V1()
 		})
 	})
 })


### PR DESCRIPTION
It possible the situation when the source conversion object has nil for
some field, but we initialize this field under the destination object.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>