### PR TITLE
must-gather: gather sysinfo from host data

### DIFF
--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -65,7 +65,7 @@ do
     oc exec $pod -n perf-node-gather -- cat /proc/cmdline 2>/dev/null >> $NODE_PATH/proc_cmdline
     WORKER_NODES+=($node)
 
-    oc exec $pod -n perf-node-gather -- gather_sysinfo --output="/sysinfo.tgz"
+    oc exec $pod -n perf-node-gather -- gather_sysinfo --root=/host --output="/sysinfo.tgz"
     oc cp --loglevel 1 -n perf-node-gather "$pod":/sysinfo.tgz "${NODE_PATH}"/sysinfo.tgz > /dev/null 2>&1 && SYSINFO_PIDS+=($!)
 done
 wait "${SYSINFO_PIDS[@]}"

--- a/must-gather/node-gather/daemonset.yaml
+++ b/must-gather/node-gather/daemonset.yaml
@@ -36,5 +36,17 @@ spec:
               - /tmp/healthy
           initialDelaySeconds: 5
           periodSeconds: 5
-        securityContext:
-          privileged: true
+        volumeMounts:
+          - name: sys
+            mountPath: /host/sys
+          - name: proc
+            mountPath: /host/proc
+      volumes:
+      - name: sys
+        hostPath:
+          path: /sys
+          type: Directory
+      - name: proc
+        hostPath:
+          path: /proc
+          type: Directory


### PR DESCRIPTION
With this PR we explicitely mount host /sys and /proc inside the container, because what we care about is host content, not container content. Even if likely, we don't have record of guarantee that the container view matches the host view. Now the intent is explicit. This also allows us to narrow down further the container privileges.