### PR TITLE
bundle: make annotations consistent

### DIFF
--- a/openshift-ci/Dockerfile.bundle.ci
+++ b/openshift-ci/Dockerfile.bundle.ci
@@ -8,8 +8,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=performance-addon-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=4.7.0
-LABEL operators.operatorframework.io.bundle.channel.default.v1=4.7.0
+LABEL operators.operatorframework.io.bundle.channels.v1=${CHANNEL}
+LABEL operators.operatorframework.io.bundle.channel.default.v1=${CHANNEL}
 
 COPY deploy/metadata/performance-addon-operator/${CHANNEL}.${ZVERSION}/* /metadata/
 COPY deploy/olm-catalog/performance-addon-operator/${CHANNEL}.${ZVERSION}/* /manifests/

--- a/openshift-ci/Dockerfile.bundle.upstream.dev
+++ b/openshift-ci/Dockerfile.bundle.upstream.dev
@@ -2,13 +2,14 @@
 FROM scratch
 
 ARG CHANNEL=4.7
+ARG ZVERSION=0
 ARG OLM_SOURCE=build/_output/manifests
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=performance-addon-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=4.7.0
-LABEL operators.operatorframework.io.bundle.channel.default.v1=4.7.0
+LABEL operators.operatorframework.io.bundle.channels.v1=${CHANNEL}
+LABEL operators.operatorframework.io.bundle.channel.default.v1=$CHANNEL}
 
-COPY ${OLM_SOURCE}/performance-addon-operator/${CHANNEL}.0/ /
+COPY ${OLM_SOURCE}/performance-addon-operator/${CHANNEL}.${ZVERSION}/ /


### PR DESCRIPTION
let's avoid the same error we made in 4.6: elide Z version from channel
name, use only "$MAJOR.$MINOR' version.

Signed-off-by: Francesco Romani <fromani@redhat.com>