### PR TITLE
bundle: make annotations consistent

### DIFF
--- a/openshift-ci/Dockerfile.bundle-4.7.ci
+++ b/openshift-ci/Dockerfile.bundle-4.7.ci
@@ -8,8 +8,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=performance-addon-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=4.7.0
-LABEL operators.operatorframework.io.bundle.channel.default.v1=4.7.0
+LABEL operators.operatorframework.io.bundle.channels.v1=${CHANNEL}
+LABEL operators.operatorframework.io.bundle.channel.default.v1=${CHANNEL}
 
 COPY deploy/metadata/performance-addon-operator/${CHANNEL}.${ZVERSION}/* /metadata/
 COPY deploy/olm-catalog/performance-addon-operator/${CHANNEL}.${ZVERSION}/* /manifests/

--- a/openshift-ci/Dockerfile.bundle.ci
+++ b/openshift-ci/Dockerfile.bundle.ci
@@ -1,6 +1,9 @@
 # see: https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md
 FROM scratch
 
+# the channel name we settled for is "${MAJOR}.${MINOR}"
+# 1. trivial to crosscheck with OCP version we target
+# 2. Z-stream friendly
 ARG CHANNEL=4.8
 ARG ZVERSION=0
 
@@ -8,8 +11,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=performance-addon-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=4.8.0
-LABEL operators.operatorframework.io.bundle.channel.default.v1=4.8.0
+LABEL operators.operatorframework.io.bundle.channels.v1=${CHANNEL}
+LABEL operators.operatorframework.io.bundle.channel.default.v1=${CHANNEL}
 
 COPY deploy/metadata/performance-addon-operator/${CHANNEL}.${ZVERSION}/* /metadata/
 COPY deploy/olm-catalog/performance-addon-operator/${CHANNEL}.${ZVERSION}/* /manifests/

--- a/openshift-ci/Dockerfile.bundle.upstream.dev
+++ b/openshift-ci/Dockerfile.bundle.upstream.dev
@@ -1,14 +1,18 @@
 # see: https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md
 FROM scratch
 
+# the channel name we settled for is "${MAJOR}.${MINOR}"
+# 1. trivial to crosscheck with OCP version we target
+# 2. Z-stream friendly
 ARG CHANNEL=4.8
+ARG ZVERSION=0
 ARG OLM_SOURCE=build/_output/manifests
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=performance-addon-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=4.8.0
-LABEL operators.operatorframework.io.bundle.channel.default.v1=4.8.0
+LABEL operators.operatorframework.io.bundle.channels.v1=${CHANNEL}
+LABEL operators.operatorframework.io.bundle.channel.default.v1=$CHANNEL}
 
-COPY ${OLM_SOURCE}/performance-addon-operator/${CHANNEL}.0/ /
+COPY ${OLM_SOURCE}/performance-addon-operator/${CHANNEL}.${ZVERSION}/ /


### PR DESCRIPTION
let's avoid the same error we made in 4.6: elide Z version from channel
name, use only "$MAJOR.$MINOR' version.

Signed-off-by: Francesco Romani <fromani@redhat.com>