### PR TITLE
hack: Add run-perf-profile-creator wrapper

### DIFF
--- a/cmd/performance-profile-creator/README.md
+++ b/cmd/performance-profile-creator/README.md
@@ -6,7 +6,6 @@ A tool to automate the process of creating Performance Profile using the user su
 
 ## Flow
 1. PPC consumes a must-gather output.
-1. PPC may run must-gather directly if the must-gather output is not given.
 1. PPC output is a bunch of YAML data (PAO profile + NTO tuned part).
 
 ## Things to note before running Performance Profile Creator
@@ -45,11 +44,11 @@ Depending on how must-gather directory was setup run the Performance profile Cre
 
 1. Option 1: Using must-gather output dir (obtained after running must gather manually)
    ```bash
-   podman run --entrypoint performance-profile-creator -v ./must-gather:/must-gather:z\
-   quay.io/openshift-kni/performance-addon-operator:4.8-snapshot > my-profile.yaml
+   podman run --entrypoint performance-profile-creator -v /path/to/must-gather-output:/must-gather:z\
+   quay.io/openshift-kni/performance-addon-operator:4.8-snapshot -M /must-gather > performance-profile.yaml
    ```
 1. Option 2: Using an existing must-gather tarball which is decompressed to a directory.
    ```bash
-   podman run --entrypoint performance-profile-creator -v :/must-gather:z \
-   quay.io/openshift-kni/performance-addon-operator:4.8-snapshot -M /must-gather  > my-profile.yaml
+   podman run --entrypoint performance-profile-creator -v /path/to/decompressed-tarball:/must-gather:z \
+   quay.io/openshift-kni/performance-addon-operator:4.8-snapshot -M /must-gather > performance-profile.yaml
     ```

--- a/hack/run-perf-profile-creator.sh
+++ b/hack/run-perf-profile-creator.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+readonly CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-podman}
+readonly CURRENT_SCRIPT=$(basename "$0")
+readonly CMD="${CONTAINER_RUNTIME} run --entrypoint performance-profile-creator"
+readonly IMG_EXISTS_CMD="${CONTAINER_RUNTIME} image exists"
+readonly IMG_PULL_CMD="${CONTAINER_RUNTIME} image pull"
+readonly MUST_GATHER_VOL="/must-gather"
+
+PAO_IMG="quay.io/openshift-kni/performance-addon-operator:4.8-snapshot"
+MG_TARBALL=""
+DATA_DIR=""
+
+usage() {
+  print "Wrapper usage:"
+  print "  ${CURRENT_SCRIPT} [-h] [-p image][-t path] -- [performance-profile-creator flags]"
+  print ""
+  print "Options:"
+  print "   -h                 help for ${CURRENT_SCRIPT}"
+  print "   -p                 Performance Addon Operator image"
+  print "   -t                 path to a must-gather tarball"
+
+  ${IMG_EXISTS_CMD} "${PAO_IMG}" && ${CMD} "${PAO_IMG}" -h
+}
+
+function cleanup {
+  [ -d "${DATA_DIR}" ] && rm -rf "${DATA_DIR}"
+}
+trap cleanup EXIT
+
+exit_error() {
+  print "error: $*"
+  usage
+  exit 1
+}
+
+print() {
+  echo  "$*" >&2
+}
+
+check_requirements() {
+  ${IMG_EXISTS_CMD} "${PAO_IMG}" || ${IMG_PULL_CMD} "${PAO_IMG}" || \
+      exit_error "Performance Addon Operator image not found"
+
+  [ -n "${MG_TARBALL}" ] || exit_error "Must-gather tarball file path is mandatory"
+  [ -f "${MG_TARBALL}" ] || exit_error "Must-gather tarball file not found"
+
+  DATA_DIR=$(mktemp -d -t "${CURRENT_SCRIPT}XXXX") || exit_error "Cannot create the data directory"
+  tar -zxf "${MG_TARBALL}" --directory "${DATA_DIR}" || exit_error "Cannot decompress the must-gather tarball"
+
+  return 0
+}
+
+main() {
+  while getopts ':hp:t:' OPT; do
+    case "${OPT}" in
+      h)
+        usage
+        exit 0
+        ;;
+      p)
+        PAO_IMG="${OPTARG}"
+        ;;
+      t)
+        MG_TARBALL="${OPTARG}"
+        ;;
+      ?)
+        exit_error "invalid argument: ${OPTARG}"
+        ;;
+    esac
+  done
+  shift $((OPTIND - 1))
+
+  check_requirements || exit 1
+
+  ${CMD} -v "${DATA_DIR}:${MUST_GATHER_VOL}:z" "${PAO_IMG}" "$@" -M "${MUST_GATHER_VOL}"
+}
+
+main "$@"


### PR DESCRIPTION
It is a convenience only script that automates PAO/must-gather
images retrieval and runs the Performance Creator Tool.

Expect a must-gather tarball or run must-gather to get the data.

Mount the data directory into the container and point
the Performance Creator Tool to it.

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>