### PR TITLE
Bug 1923220: Do not install and enable stalld service

### DIFF
--- a/build/assets/tuned/openshift-node-performance
+++ b/build/assets/tuned/openshift-node-performance
@@ -25,8 +25,10 @@ governor=performance                          #  latency-performance
 energy_perf_bias=performance                  #  latency-performance 
 min_perf_pct=100                              #  latency-performance 
 
+# Disable the stalld service until bugs https://bugzilla.redhat.com/show_bug.cgi?id=1912118 and
+# https://bugzilla.redhat.com/show_bug.cgi?id=1903302 will be fixed
 [service]
-service.stalld=start,enable
+service.stalld=stop,disable
 
 [vm]
 transparent_hugepages=never                   #  network-latency

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -192,13 +192,13 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 		})
 
 		It("[test_id:35363][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] stalld daemon is running on the host", func() {
+			Skip("until bugs https://bugzilla.redhat.com/show_bug.cgi?id=1912118 and https://bugzilla.redhat.com/show_bug.cgi?id=1903302 fixed")
 			for _, node := range workerRTNodes {
 				tuned := tunedForNode(&node)
 				_, err := pods.ExecCommandOnPod(tuned, []string{"pidof", "stalld"})
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})
-
 	})
 
 	Context("Additional kernel arguments added from perfomance profile", func() {


### PR DESCRIPTION
Service stalld is enabling high resolution timer that currently has a bug.
To avoid system hangs the PAO will not install and enable stalld by default
until bugs https://bugzilla.redhat.com/show_bug.cgi?id=1903302 and
https://bugzilla.redhat.com/show_bug.cgi?id=1912118 fixed.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>