### PR TITLE
Update tools image to use ubi8

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi7/ubi
+FROM registry.access.redhat.com/ubi8/ubi
 
 ENV HOME=/home/ci
 ENV GOROOT /usr/local/go
@@ -16,7 +16,6 @@ RUN yum --setopt=install_weak_deps=False -y install \
     make \
     gettext \
     which \
-    skopeo \
     findutils \
     python2 \
     && yum clean all


### PR DESCRIPTION
We have troubles with glibc library under the ubi8, so it can be a good reason to advance
tools image version to ubi8.

ubi8 does not have skopeo package, I can not find a single place where it should be used.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>