### PR TITLE
must-gather: use 'Always' pull policy

### DIFF
--- a/must-gather/node-gather/daemonset.yaml
+++ b/must-gather/node-gather/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       - name: node-probe
         image: MUST_GATHER_IMAGE
         command: ["/bin/bash", "-c", "echo ok > /tmp/healthy && sleep INF"]
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         resources:
           requests:
             cpu: "100m"


### PR DESCRIPTION
Using the 'Always' pull policy improves the security of this flow
and cost nothing in the common path, on which must-gather is run
rarely if ever - so the first pull need to happen anyway.

Signed-off-by: Francesco Romani <fromani@redhat.com>