### PR TITLE
Generate a machine config name with the numerical prefix

### DIFF
--- a/controllers/performanceprofile_controller_test.go
+++ b/controllers/performanceprofile_controller_test.go
@@ -78,9 +78,8 @@ var _ = Describe("Controller", func() {
 
 			Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
-			name := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
 			key := types.NamespacedName{
-				Name:      name,
+				Name:      machineconfig.GetMachineConfigName(profile),
 				Namespace: metav1.NamespaceNone,
 			}
 
@@ -88,6 +87,11 @@ var _ = Describe("Controller", func() {
 			mc := &mcov1.MachineConfig{}
 			err := r.Get(context.TODO(), key, mc)
 			Expect(err).ToNot(HaveOccurred())
+
+			key = types.NamespacedName{
+				Name:      components.GetComponentName(profile.Name, components.ComponentNamePrefix),
+				Namespace: metav1.NamespaceNone,
+			}
 
 			// verify KubeletConfig creation
 			kc := &mcov1.KubeletConfig{}
@@ -363,9 +367,8 @@ var _ = Describe("Controller", func() {
 
 				Expect(reconcileTimes(r, request, 1)).To(Equal(reconcile.Result{}))
 
-				name := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
 				key := types.NamespacedName{
-					Name:      name,
+					Name:      machineconfig.GetMachineConfigName(profile),
 					Namespace: metav1.NamespaceNone,
 				}
 
@@ -517,7 +520,7 @@ var _ = Describe("Controller", func() {
 
 				By("Verifying MC update")
 				key = types.NamespacedName{
-					Name:      components.GetComponentName(profile.Name, components.ComponentNamePrefix),
+					Name:      machineconfig.GetMachineConfigName(profile),
 					Namespace: metav1.NamespaceNone,
 				}
 				mc := &mcov1.MachineConfig{}

--- a/functests/0_config/config.go
+++ b/functests/0_config/config.go
@@ -89,7 +89,7 @@ var _ = Describe("[performance][config] Performance configuration", func() {
 		}
 
 		By("Waiting for the MCP to pick the PerformanceProfile's MC")
-		mcps.WaitForProfilePickedUp(performanceMCP.Name, performanceProfile.Name)
+		mcps.WaitForProfilePickedUp(performanceMCP.Name, performanceProfile)
 
 		// If the profile is already there, it's likely to have been through the updating phase, so we only
 		// wait for updated.

--- a/functests/utils/mcps/mcps.go
+++ b/functests/utils/mcps/mcps.go
@@ -2,7 +2,6 @@ package mcps
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	. "github.com/onsi/gomega"
@@ -22,6 +21,7 @@ import (
 	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/machineconfig"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/profile"
 )
 
@@ -194,9 +194,9 @@ func WaitForCondition(mcpName string, conditionType machineconfigv1.MachineConfi
 }
 
 // WaitForProfilePickedUp waits for the MCP with given name containing the MC created for the PerformanceProfile with the given name
-func WaitForProfilePickedUp(mcpName string, profileName string) {
-	testlog.Infof("Waiting for profile %s to be picked up by the %s machine config pool", profileName, mcpName)
-	defer testlog.Infof("Profile %s picked up by the %s machine config pool", profileName, mcpName)
+func WaitForProfilePickedUp(mcpName string, profile *performancev2.PerformanceProfile) {
+	testlog.Infof("Waiting for profile %s to be picked up by the %s machine config pool", profile.Name, mcpName)
+	defer testlog.Infof("Profile %s picked up by the %s machine config pool", profile.Name, mcpName)
 	EventuallyWithOffset(1, func() bool {
 		mcp, err := GetByName(mcpName)
 		// we ignore the error and just retry in case of single node cluster
@@ -204,10 +204,10 @@ func WaitForProfilePickedUp(mcpName string, profileName string) {
 			return false
 		}
 		for _, source := range mcp.Spec.Configuration.Source {
-			if source.Name == fmt.Sprintf("%s-%s", components.ComponentNamePrefix, profileName) {
+			if source.Name == machineconfig.GetMachineConfigName(profile) {
 				return true
 			}
 		}
 		return false
-	}, 10*time.Minute, 30*time.Second).Should(BeTrue(), "PerformanceProfile's %q MC was not picked up by MCP  %qin time", profileName, mcpName)
+	}, 10*time.Minute, 30*time.Second).Should(BeTrue(), "PerformanceProfile's %q MC was not picked up by MCP %q in time", profile.Name, mcpName)
 }

--- a/hack/wait-for-mcp.sh
+++ b/hack/wait-for-mcp.sh
@@ -27,8 +27,12 @@ do
   set -e
 
   echo "[INFO] Checking if MCP picked up the performance MC"
+  # MC with new generated name
+  mc_new="$(${OC_TOOL} get mcp worker-cnf -o jsonpath='{.spec.configuration.source[?(@.name=="50-performance-'$CLUSTER'")].name}')"
+  # MC with old generated name
+  mc_old="$(${OC_TOOL} get mcp worker-cnf -o jsonpath='{.spec.configuration.source[?(@.name=="performance-'$CLUSTER'")].name}')"
   # No output means that the new machine config wasn't picked by MCO yet
-  if [ -z "$(${OC_TOOL} get mcp worker-cnf -o jsonpath='{.spec.configuration.source[?(@.name=="performance-'$CLUSTER'")].name}')" ]
+  if [ -z "${mc_new}" ] && [ -z "${mc_old}" ]
   then
     iterations=$((iterations + 1))
     iterations_left=$((max_iterations - iterations))

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -80,9 +80,9 @@ const (
 	templateReservedCpus = "ReservedCpus"
 )
 
-// New returns new machine configuration object for performance sensetive workflows
+// New returns new machine configuration object for performance sensitive workloads
 func New(assetsDir string, profile *performancev2.PerformanceProfile) (*machineconfigv1.MachineConfig, error) {
-	name := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
+	name := GetMachineConfigName(profile)
 	mc := &machineconfigv1.MachineConfig{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: machineconfigv1.GroupVersion.String(),
@@ -117,6 +117,12 @@ func New(assetsDir string, profile *performancev2.PerformanceProfile) (*machinec
 	}
 
 	return mc, nil
+}
+
+// GetMachineConfigName generates machine config name from the performance profile
+func GetMachineConfigName(profile *performancev2.PerformanceProfile) string {
+	name := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
+	return fmt.Sprintf("50-%s", name)
 }
 
 func getIgnitionConfig(assetsDir string, profile *performancev2.PerformanceProfile) (*igntypes.Config, error) {


### PR DESCRIPTION
Currently, the operator generates a MachineConfig with the name of performance-<pao-name> and
does not follows a convention of pretending a numerical value to the name so when the rendered
version of the MCP is generated it is applied in whatever alphanumerical order it shows in the
list of oc get mc.
Now, when a cluster-admin wants to do further customizations, it cannot longer create MC with
a prepend index like 99-my-custom-mc-fix as it will not be applied correctly when the MCP is rendered.

Fixes #490

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>