### PR TITLE
[release-4.6] comment the stalld section

### DIFF
--- a/build/assets/tuned/openshift-node-performance
+++ b/build/assets/tuned/openshift-node-performance
@@ -27,8 +27,8 @@ min_perf_pct=100                              #  latency-performance
 
 # Disable the stalld service until bugs https://bugzilla.redhat.com/show_bug.cgi?id=1912118 and
 # https://bugzilla.redhat.com/show_bug.cgi?id=1903302 will be fixed
-[service]
-service.stalld=stop,disable
+# [service]
+# service.stalld=start,enable
 
 [vm]
 transparent_hugepages=never                   #  network-latency


### PR DESCRIPTION
Under 4.6 stalld installed without systemd overlay file, so it can not be disabled via
service plugin. Remove the service section to make sure that stalld does not run under
the system.

Related to https://github.com/openshift-kni/performance-addon-operators/pull/524

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>