### PR TITLE
No profile creation in case PPC is run with --help/-h

### DIFF
--- a/cmd/performance-profile-creator/cmd/root.go
+++ b/cmd/performance-profile-creator/cmd/root.go
@@ -33,7 +33,10 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "performance-profile-creator",
 	Short: "A tool that automates creation of Performance Profiles",
-	Run:   func(cmd *cobra.Command, args []string) {},
+	Run: func(cmd *cobra.Command, args []string) {
+		profileName := cmd.Flag("profile-name").Value.String()
+		createProfile(profileName)
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -70,9 +73,6 @@ func init() {
 	// TODO: Input validation
 	// 1) Make flags required/optional
 	// 2) e.g.check to make sure that power consumption string is in {CSTATE NO_CSTATE IDLE_POLL}
-
-	// Creating Performance Profile
-	createProfile(args.profileName)
 }
 
 func createProfile(profileName string) {


### PR DESCRIPTION
This patch ensures that the performance profile is not sent
to STDOUT in case the user specifies --help or -h flag.
Previously, the createProfile function was called from
init function resulting in creation of profile even
when the user wants to see the PPC usage using -h/--help.

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>