### PR TITLE
Update discovery mode performance profile selector to choose by NODE_SELECTOR environment variable

### DIFF
--- a/functests/utils/consts.go
+++ b/functests/utils/consts.go
@@ -42,7 +42,7 @@ func init() {
 	}
 
 	if discovery.Enabled() {
-		profile, err := discovery.GetDiscoveryPerformanceProfile()
+		profile, err := discovery.GetDiscoveryPerformanceProfile(NodesSelector)
 		if err == discovery.ErrProfileNotFound {
 			ProfileNotFound = true
 			return


### PR DESCRIPTION
Currently when running cnf-tests in discovery mode the performance
profile selector is choosing the profile in the cluster with the
most nodes using it.
When running in a cluster with more than one performance profile,
the profile selector should choose the performance profile by
NODES_SELECTOR env var if it is set.