### PR TITLE
Bug 1885317: Provide a log package that will write to GinkgoWriter

### DIFF
--- a/functests/0_config/config.go
+++ b/functests/0_config/config.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -27,9 +26,9 @@ import (
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/mcps"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
-
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/profile"
 )
@@ -46,12 +45,12 @@ var _ = Describe("[performance][config] Performance configuration", func() {
 		if foundOverride {
 			performanceProfile, err = externalPerformanceProfile(performanceManifest)
 			Expect(err).ToNot(HaveOccurred(), "Failed overriding performance profile", performanceManifest)
-			klog.Warning("Consuming performance profile from ", performanceManifest)
+			testlog.Warningf("Consuming performance profile from %s", performanceManifest)
 		}
 		if discovery.Enabled() {
 			performanceProfile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 			Expect(err).ToNot(HaveOccurred(), "Failed finding a performance profile in discovery mode")
-			klog.Info("Discovery mode: consuming a deployed performance profile from the cluster")
+			testlog.Info("Discovery mode: consuming a deployed performance profile from the cluster")
 			profileAlreadyExists = true
 		}
 
@@ -69,7 +68,7 @@ var _ = Describe("[performance][config] Performance configuration", func() {
 			Eventually(func() error {
 				err := testclient.Client.Create(context.TODO(), performanceProfile)
 				if errors.IsAlreadyExists(err) {
-					klog.Warning(fmt.Sprintf("A PerformanceProfile with name %s already exists! If created externally, tests might have unexpected behaviour", performanceProfile.Name))
+					testlog.Warning(fmt.Sprintf("A PerformanceProfile with name %s already exists! If created externally, tests might have unexpected behaviour", performanceProfile.Name))
 					profileAlreadyExists = true
 					return nil
 				}

--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/klog"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -27,6 +25,7 @@ import (
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/images"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/pods"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
@@ -267,7 +266,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 				sort.Ints(cpuToSchedDomains[cpu])
 			}
 
-			klog.Infof("Scheduler domains: %v", cpuToSchedDomains)
+			testlog.Infof("Scheduler domains: %v", cpuToSchedDomains)
 			return cpuToSchedDomains, nil
 		}
 

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 	"k8s.io/utils/pointer"
 
@@ -36,6 +35,7 @@ import (
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/mcps"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/pods"
@@ -1039,7 +1039,7 @@ func validatTunedActiveProfile(nodes []corev1.Node) {
 
 	for _, t := range tunedList.Items {
 		if len(t.Spec.Profile) > 0 && t.Spec.Profile[0].Data != nil && strings.Contains(*t.Spec.Profile[0].Data, fmt.Sprintf("include=%s", activeProfileName)) {
-			klog.Warning(fmt.Sprintf("PAO tuned profile amended by '%s' profile, test may fail", t.Name))
+			testlog.Warning(fmt.Sprintf("PAO tuned profile amended by '%s' profile, test may fail", t.Name))
 			if t.Spec.Profile[0].Name != nil {
 				activeProfileName = *t.Spec.Profile[0].Name
 			}

--- a/functests/1_performance/test_suite_performance_test.go
+++ b/functests/1_performance/test_suite_performance_test.go
@@ -11,13 +11,13 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/klog"
 
 	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/junit"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/namespaces"
 )
 
@@ -26,7 +26,7 @@ var _ = BeforeSuite(func() {
 	// create test namespace
 	err := testclient.Client.Create(context.TODO(), namespaces.TestingNamespace)
 	if errors.IsAlreadyExists(err) {
-		klog.Warning("test namespace already exists, that is unexpected")
+		testlog.Warning("test namespace already exists, that is unexpected")
 		return
 	}
 	Expect(err).ToNot(HaveOccurred())

--- a/functests/2_performance_update/test_suite_performance_update_test.go
+++ b/functests/2_performance_update/test_suite_performance_update_test.go
@@ -11,13 +11,13 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/klog"
 
 	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/junit"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/namespaces"
 )
 
@@ -26,7 +26,7 @@ var _ = BeforeSuite(func() {
 	// create test namespace
 	err := testclient.Client.Create(context.TODO(), namespaces.TestingNamespace)
 	if errors.IsAlreadyExists(err) {
-		klog.Warning("test namespace already exists, that is unexpected")
+		testlog.Warning("test namespace already exists, that is unexpected")
 		return
 	}
 	Expect(err).ToNot(HaveOccurred())

--- a/functests/3_performance_status/test_suite_performance_status_test.go
+++ b/functests/3_performance_status/test_suite_performance_status_test.go
@@ -11,13 +11,13 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/klog"
 
 	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/junit"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/namespaces"
 )
 
@@ -25,7 +25,7 @@ var _ = BeforeSuite(func() {
 	// create test namespace
 	err := testclient.Client.Create(context.TODO(), namespaces.TestingNamespace)
 	if errors.IsAlreadyExists(err) {
-		klog.Warning("test namespace already exists, that is unexpected")
+		testlog.Warning("test namespace already exists, that is unexpected")
 		return
 	}
 	Expect(err).ToNot(HaveOccurred())

--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -17,6 +17,7 @@ import (
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/images"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/pods"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
@@ -115,11 +116,11 @@ var _ = Describe("[performance] Latency Test", func() {
 		var err error
 		err = testclient.Client.Delete(context.TODO(), oslatPod)
 		if err != nil {
-			klog.Error(err)
+			testlog.Error(err)
 		}
 		err = pods.WaitForDeletion(oslatPod, pods.DefaultDeletionTimeout*time.Second)
 		if err != nil {
-			klog.Error(err)
+			testlog.Error(err)
 		}
 	})
 

--- a/functests/4_latency/test_suite_latency_test.go
+++ b/functests/4_latency/test_suite_latency_test.go
@@ -12,10 +12,10 @@ import (
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/junit"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/namespaces"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/klog"
 
 	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
@@ -25,7 +25,7 @@ var _ = BeforeSuite(func() {
 	// create test namespace
 	err := testclient.Client.Create(context.TODO(), namespaces.TestingNamespace)
 	if errors.IsAlreadyExists(err) {
-		klog.Warning("test namespace already exists, that is unexpected")
+		testlog.Warning("test namespace already exists, that is unexpected")
 		return
 	}
 	Expect(err).ToNot(HaveOccurred())

--- a/functests/utils/clean/clean.go
+++ b/functests/utils/clean/clean.go
@@ -13,6 +13,7 @@ import (
 	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/mcps"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
@@ -20,7 +21,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog"
 )
 
 var cleanPerformance bool
@@ -35,7 +35,7 @@ func init() {
 // All deletes any leftovers created when running the performance tests.
 func All() {
 	if !cleanPerformance {
-		klog.Info("Performance cleaning disabled, skipping")
+		testlog.Info("Performance cleaning disabled, skipping")
 		return
 	}
 

--- a/functests/utils/client/clients.go
+++ b/functests/utils/client/clients.go
@@ -17,14 +17,13 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
-
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-
 	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 
 	performancev1 "github.com/openshift-kni/performance-addon-operators/api/v1"
 	performancev1alpha1 "github.com/openshift-kni/performance-addon-operators/api/v1alpha1"
 	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 )
 
 var (
@@ -73,13 +72,13 @@ func init() {
 	var err error
 	Client, err = New()
 	if err != nil {
-		klog.Info("Failed to initialize client, check the KUBECONFIG env variable", err.Error())
+		testlog.Info("Failed to initialize client, check the KUBECONFIG env variable", err.Error())
 		ClientsEnabled = false
 		return
 	}
 	K8sClient, err = NewK8s()
 	if err != nil {
-		klog.Info("Failed to initialize k8s client, check the KUBECONFIG env variable", err.Error())
+		testlog.Info("Failed to initialize k8s client, check the KUBECONFIG env variable", err.Error())
 		ClientsEnabled = false
 		return
 	}
@@ -116,7 +115,7 @@ func GetWithRetry(ctx context.Context, key client.ObjectKey, obj runtime.Object)
 	EventuallyWithOffset(1, func() error {
 		err = Client.Get(ctx, key, obj)
 		if err != nil {
-			klog.Infof("Getting %s failed, retrying: %v", key.Name, err)
+			testlog.Infof("Getting %s failed, retrying: %v", key.Name, err)
 		}
 		return err
 	}, 1*time.Minute, 10*time.Second).ShouldNot(HaveOccurred(), "Max numbers of retries reached")

--- a/functests/utils/discovery/discovery.go
+++ b/functests/utils/discovery/discovery.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var ErrProfileNotFound = fmt.Errorf("Profile not found in discovery mode")
+var ErrProfileNotFound = fmt.Errorf("profile not found in discovery mode")
 
 // ConditionIterator is the function that accepts element of a PerformanceProfile and returns boolean
 type ConditionIterator func(performancev2.PerformanceProfile) bool

--- a/functests/utils/log/log.go
+++ b/functests/utils/log/log.go
@@ -1,0 +1,52 @@
+package log
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo"
+)
+
+func nowStamp() string {
+	return time.Now().Format(time.StampMilli)
+}
+
+func logf(level string, format string, args ...interface{}) {
+	fmt.Fprintf(ginkgo.GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
+}
+
+func log(level string, args ...interface{}) {
+	fmt.Fprint(ginkgo.GinkgoWriter, nowStamp()+": "+level+": ")
+	fmt.Fprint(ginkgo.GinkgoWriter, args...)
+	fmt.Fprint(ginkgo.GinkgoWriter, "\n")
+}
+
+// Info logs the info
+func Info(args ...interface{}) {
+	log("[INFO]", args...)
+}
+
+// Infof logs the info with arguments
+func Infof(format string, args ...interface{}) {
+	logf("[INFO]", format, args...)
+}
+
+// Warning logs the warning
+func Warning(args ...interface{}) {
+	log("[WARNING]", args...)
+}
+
+// Warningf logs the warning with arguments
+func Warningf(format string, args ...interface{}) {
+	logf("[WARNING]", format, args...)
+}
+
+// Error logs the warning
+func Error(args ...interface{}) {
+	log("[ERROR]", args...)
+}
+
+// Errorf logs the warning with arguments
+func Errorf(format string, args ...interface{}) {
+	logf("[ERROR]", format, args...)
+}

--- a/functests/utils/mcps/mcps.go
+++ b/functests/utils/mcps/mcps.go
@@ -13,13 +13,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
 	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/profile"
@@ -178,7 +178,7 @@ func WaitForCondition(mcpName string, conditionType machineconfigv1.MachineConfi
 			return errors.Wrap(err, "Failed getting nodes by selector")
 		}
 
-		klog.Infof("MCP %q is targeting %v node(s)", mcp.Name, len(cnfNodes))
+		testlog.Infof("MCP %q is targeting %v node(s)", mcp.Name, len(cnfNodes))
 		return nil
 	}, 10*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
 
@@ -195,8 +195,8 @@ func WaitForCondition(mcpName string, conditionType machineconfigv1.MachineConfi
 
 // WaitForProfilePickedUp waits for the MCP with given name containing the MC created for the PerformanceProfile with the given name
 func WaitForProfilePickedUp(mcpName string, profileName string) {
-	klog.Infof("Waiting for profile %s to be picked up by the %s machine config pool", profileName, mcpName)
-	defer klog.Infof("Profile %s picked up by the %s machine config pool", profileName, mcpName)
+	testlog.Infof("Waiting for profile %s to be picked up by the %s machine config pool", profileName, mcpName)
+	defer testlog.Infof("Profile %s picked up by the %s machine config pool", profileName, mcpName)
 	EventuallyWithOffset(1, func() bool {
 		mcp, err := GetByName(mcpName)
 		// we ignore the error and just retry in case of single node cluster

--- a/functests/utils/nodes/nodes.go
+++ b/functests/utils/nodes/nodes.go
@@ -7,18 +7,19 @@ import (
 	"strings"
 
 	"github.com/ghodss/yaml"
-	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
-	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
-	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/klog"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
+	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
 )
 
 // GetByRole returns all nodes with the specified role
@@ -85,7 +86,7 @@ func ExecCommandOnMachineConfigDaemon(node *corev1.Node, command []string) ([]by
 	if err != nil {
 		return nil, err
 	}
-	klog.Infof("found mcd %s for node %s", mcd.Name, node.Name)
+	testlog.Infof("found mcd %s for node %s", mcd.Name, node.Name)
 
 	initialArgs := []string{
 		"exec",
@@ -117,7 +118,7 @@ func GetKubeletConfig(node *corev1.Node) (*kubeletconfigv1beta1.KubeletConfigura
 		return nil, err
 	}
 
-	klog.Infof("command output: %s", string(kubeletBytes))
+	testlog.Infof("command output: %s", string(kubeletBytes))
 	kubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{}
 	if err := yaml.Unmarshal(kubeletBytes, kubeletConfig); err != nil {
 		return nil, err

--- a/functests/utils/profiles/profiles.go
+++ b/functests/utils/profiles/profiles.go
@@ -6,18 +6,17 @@ import (
 	"reflect"
 	"time"
 
-	"k8s.io/klog"
-
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 	v1 "github.com/openshift/custom-resource-status/conditions/v1"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // GetByNodeLabels gets the performance profile that must have node selector equals to passed node labels
@@ -101,7 +100,7 @@ func UpdateWithRetry(profile *performancev2.PerformanceProfile) {
 	EventuallyWithOffset(1, func() error {
 		if err := testclient.Client.Update(context.TODO(), profile); err != nil {
 			if !errors.IsConflict(err) {
-				klog.Errorf("failed to update the profile %q: %v", profile.Name, err)
+				testlog.Errorf("failed to update the profile %q: %v", profile.Name, err)
 			}
 
 			return err

--- a/functests/utils/utils.go
+++ b/functests/utils/utils.go
@@ -8,7 +8,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 
-	"k8s.io/klog"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 )
 
 const defaultExecTimeout = 2 * time.Minute
@@ -29,7 +29,7 @@ func ExecAndLogCommand(name string, arg ...string) ([]byte, error) {
 	defer cancel() // The cancel should be deferred so resources are cleaned up
 
 	out, err := exec.CommandContext(ctx, name, arg...).Output()
-	klog.Infof("run command '%s %v' (err=%v):\n  stdout=%s\n", name, arg, err, out)
+	testlog.Infof("run command '%s %v' (err=%v):\n  stdout=%s\n", name, arg, err, out)
 
 	// We want to check the context error to see if the timeout was executed.
 	// The error returned by cmd.Output() will be OS specific based on what
@@ -39,7 +39,7 @@ func ExecAndLogCommand(name string, arg ...string) ([]byte, error) {
 	}
 
 	if exitError, ok := err.(*exec.ExitError); ok {
-		klog.Infof("run command '%s %v' (err=%v):\n  stderr=%s", name, arg, err, exitError.Stderr)
+		testlog.Infof("run command '%s %v' (err=%v):\n  stderr=%s", name, arg, err, exitError.Stderr)
 	}
 	return out, err
 }


### PR DESCRIPTION
We want to reduce the verbosity of logs output in the case when the test succeeded and provide more information only in case when the test failed.

```
Ginkgo provides a globally available io.Writer called GinkgoWriter that you can write to. GinkgoWriter aggregates input while a test is running and only dumps it to stdout if the test fails.
```