### PR TITLE
must gather: more sysinfo debug logs

### DIFF
--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -52,7 +52,6 @@ do
 done
 
 WORKER_NODES=()
-SYSINFO_PIDS=()
 for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name --no-headers --field-selector=status.phase=Running -n perf-node-gather)
 do
     node=$(echo $line | awk -F ' ' '{print $1}')
@@ -66,9 +65,8 @@ do
     WORKER_NODES+=($node)
 
     oc exec $pod -n perf-node-gather -- gather_sysinfo --root=/host --output="/sysinfo.tgz"
-    oc cp --loglevel 1 -n perf-node-gather "$pod":/sysinfo.tgz "${NODE_PATH}"/sysinfo.tgz > /dev/null 2>&1 && SYSINFO_PIDS+=($!)
+    oc cp --loglevel 1 -n perf-node-gather "$pod":/sysinfo.tgz "${NODE_PATH}"/sysinfo.tgz > /dev/null 2>&1
 done
-wait "${SYSINFO_PIDS[@]}"
 
 # Collect journal logs for specified units for all nodes
 NODE_UNITS=(kubelet)

--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -64,8 +64,8 @@ do
     oc exec $pod -n perf-node-gather -- cat /proc/cmdline 2>/dev/null >> $NODE_PATH/proc_cmdline
     WORKER_NODES+=($node)
 
-    oc exec $pod -n perf-node-gather -- gather_sysinfo --root=/host --output="/sysinfo.tgz"
-    oc cp --loglevel 1 -n perf-node-gather "$pod":/sysinfo.tgz "${NODE_PATH}"/sysinfo.tgz > /dev/null 2>&1
+    oc exec $pod -n perf-node-gather -- gather_sysinfo --debug --root=/host --output="/sysinfo.tgz"
+    oc cp --loglevel 3 -n perf-node-gather "$pod":/sysinfo.tgz "${NODE_PATH}"/sysinfo.tgz
 done
 
 # Collect journal logs for specified units for all nodes


### PR DESCRIPTION
improve sysinfo debuggability. We had cases on which the toolsilently failed to retrieve the sysinfo data which must be investigated.
Worth pointing out that according to logs the collection on the worker nodes seems to have happened.
We need to narrow down where the issue is.