### PR TITLE
must-gather: sysinfo: direct copy using stdout

### DIFF
--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -52,7 +52,6 @@ do
 done
 
 WORKER_NODES=()
-SYSINFO_PIDS=()
 for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name --no-headers --field-selector=status.phase=Running -n perf-node-gather)
 do
     node=$(echo $line | awk -F ' ' '{print $1}')
@@ -65,10 +64,8 @@ do
     oc exec $pod -n perf-node-gather -- cat /proc/cmdline 2>/dev/null >> $NODE_PATH/proc_cmdline
     WORKER_NODES+=($node)
 
-    oc exec $pod -n perf-node-gather -- gather_sysinfo --root=/host --output="/sysinfo.tgz"
-    oc cp --loglevel 1 -n perf-node-gather "$pod":/sysinfo.tgz "${NODE_PATH}"/sysinfo.tgz > /dev/null 2>&1 && SYSINFO_PIDS+=($!)
+    oc exec $pod -n perf-node-gather -- gather_sysinfo --debug --root=/host --output=- > $NODE_PATH/sysinfo.tgz 2> $NODE_PATH/sysinfo.log
 done
-wait "${SYSINFO_PIDS[@]}"
 
 # Collect journal logs for specified units for all nodes
 NODE_UNITS=(kubelet)

--- a/tools/gather-sysinfo/gather-sysinfo.go
+++ b/tools/gather-sysinfo/gather-sysinfo.go
@@ -82,8 +82,15 @@ func main() {
 		scratchDir = filepath.Join(scratchDir, *rootDir)
 	}
 
-	if err := snapshot.PackFrom(*output, scratchDir); err != nil {
-		log.Fatalf("error packing %q into %q: %v", scratchDir, *output, err)
+	dest := *output
+	if dest == "-" {
+		err = snapshot.PackWithWriter(os.Stdout, scratchDir)
+		dest = "stdout"
+	} else {
+		err = snapshot.PackFrom(dest, scratchDir)
+	}
+	if err != nil {
+		log.Fatalf("error packing %q to %q: %v", scratchDir, dest, err)
 	}
 }
 


### PR DESCRIPTION
`gather-sysinfo` can emit the tar file directly to stdout.
Avoiding the local file, we can simplify our gathering script and
make the process a bit faster.

Signed-off-by: Francesco Romani <fromani@redhat.com>