### PR TITLE
tests: clarify failure reasons

### DIFF
--- a/functests/0_config/config.go
+++ b/functests/0_config/config.go
@@ -49,7 +49,7 @@ var _ = Describe("[performance][config] Performance configuration", func() {
 		}
 		if discovery.Enabled() {
 			performanceProfile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
-			Expect(err).ToNot(HaveOccurred(), "Failed finding a performance profile in discovery mode")
+			Expect(err).ToNot(HaveOccurred(), "Failed finding a performance profile in discovery mode using selector %v", testutils.NodeSelectorLabels)
 			testlog.Info("Discovery mode: consuming a deployed performance profile from the cluster")
 			profileAlreadyExists = true
 		}
@@ -58,7 +58,7 @@ var _ = Describe("[performance][config] Performance configuration", func() {
 		mcpLabel := profile.GetMachineConfigLabel(performanceProfile)
 		key, value := components.GetFirstKeyAndValue(mcpLabel)
 		mcpsByLabel, err := mcps.GetByLabel(key, value)
-		Expect(err).ToNot(HaveOccurred(), "Failed getting MCP")
+		Expect(err).ToNot(HaveOccurred(), "Failed getting MCP by label key %v value %v", key, value)
 		Expect(len(mcpsByLabel)).To(Equal(1), fmt.Sprintf("Unexpected number of MCPs found: %v", len(mcpsByLabel)))
 		performanceMCP := &mcpsByLabel[0]
 

--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -134,7 +134,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 				mask := strings.SplitAfter(taskset, " ")
 				maskSet, err := cpuset.Parse(mask[len(mask)-1])
 				Expect(err).ToNot(HaveOccurred())
-				Expect(reservedCPUSet.IsSubsetOf(maskSet)).To(Equal(true), fmt.Sprintf("The process should have cpu affinity: %s", reservedCPU))
+				Expect(reservedCPUSet.IsSubsetOf(maskSet)).To(Equal(true), "The process should have cpu affinity: %s", reservedCPU)
 
 				// check which cpu is used
 				cmd = []string{"/bin/bash", "-c", fmt.Sprintf("ps -o psr %s | tail -1", rcuo)}
@@ -365,7 +365,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 			onlineCPUsSet, err := nodes.GetOnlineCPUsSet(workerRTNode)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(onlineCPUsSet.IsSubsetOf(defaultSmpAffinitySet)).To(BeTrue(), fmt.Sprintf("All online CPUs %s should be subset of default SMP affinity %s", onlineCPUsSet, defaultSmpAffinitySet))
+			Expect(onlineCPUsSet.IsSubsetOf(defaultSmpAffinitySet)).To(BeTrue(), "All online CPUs %s should be subset of default SMP affinity %s", onlineCPUsSet, defaultSmpAffinitySet)
 
 			By("Running pod with annotations that disable specific CPU from IRQ balancer")
 			annotations := map[string]string{
@@ -413,7 +413,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 			defaultSmpAffinitySet, err = nodes.GetDefaultSmpAffinitySet(workerRTNode)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(onlineCPUsSet.IsSubsetOf(defaultSmpAffinitySet)).To(BeTrue(), fmt.Sprintf("All online CPUs %s should be subset of default SMP affinity %s", onlineCPUsSet, defaultSmpAffinitySet))
+			Expect(onlineCPUsSet.IsSubsetOf(defaultSmpAffinitySet)).To(BeTrue(), "All online CPUs %s should be subset of default SMP affinity %s", onlineCPUsSet, defaultSmpAffinitySet)
 		})
 	})
 

--- a/functests/1_performance/hugepages.go
+++ b/functests/1_performance/hugepages.go
@@ -124,7 +124,7 @@ var _ = Describe("[performance]Hugepages", func() {
 			if discovery.Enabled() && usageHugepages != 0 {
 				Skip("Skipping test since other guests might reside in the cluster affecting results")
 			}
-			Expect(usageHugepages).To(Equal(0))
+			Expect(usageHugepages).To(Equal(0), "Found used hugepages, expected 0")
 
 			By("running the POD and waiting while it's installing testing tools")
 			testpod = getCentosPod(workerRTNode.Name)
@@ -154,7 +154,7 @@ var _ = Describe("[performance]Hugepages", func() {
 
 			By("checking hugepages usage in bytes")
 			usageHugepages = checkHugepagesStatus(usageHugepagesFile, workerRTNode)
-			Expect(strconv.Itoa(usageHugepages/1024)).To(Equal(hpSizeKb), fmt.Sprintf("usage in bytes should be %s", hpSizeKb))
+			Expect(strconv.Itoa(usageHugepages/1024)).To(Equal(hpSizeKb), "usage in bytes should be %s", hpSizeKb)
 		})
 	})
 })

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -12,7 +12,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/node/v1beta1"
@@ -61,12 +60,12 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 
 		var err error
 		workerRTNodes, err = nodes.GetByLabels(testutils.NodeSelectorLabels)
-		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for node with role %q: %v", testutils.RoleWorkerCNF, err))
+		Expect(err).ToNot(HaveOccurred(), "error looking for node with role %q: %v", testutils.RoleWorkerCNF, err)
 		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
-		Expect(workerRTNodes).ToNot(BeEmpty(), fmt.Sprintf("no nodes with role %q found", testutils.RoleWorkerCNF))
+		Expect(workerRTNodes).ToNot(BeEmpty(), "no nodes with role %q found", testutils.RoleWorkerCNF)
 		profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred(), "cannot get profile by node labels %v", testutils.NodeSelectorLabels)
 	})
 
 	// self-tests; these are only vaguely related to performance becase these are enablement conditions, not actual settings.
@@ -87,8 +86,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				}
 			}
 
-			// Fail
-			Expect(true).To(Reject(), "Performance Addon Operator is not running in a master node")
+			Fail("Performance Addon Operator is not running in a master node")
 		})
 	})
 
@@ -102,7 +100,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 			}
 			tuned := &tunedv1.Tuned{}
 			err := testclient.Client.Get(context.TODO(), key, tuned)
-			Expect(err).ToNot(HaveOccurred(), "cannot find the Cluster Node Tuning Operator object "+tuned.Name)
+			Expect(err).ToNot(HaveOccurred(), "cannot find the Cluster Node Tuning Operator object %q", tuned.Name)
 
 			Eventually(func() bool {
 				err := testclient.Client.List(context.TODO(), tunedList)
@@ -118,15 +116,16 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				}
 				return true
 			}, 120*time.Second, testPollInterval*time.Second).Should(BeTrue(),
-				"tuned CR name owned by a performance profile CR should only be "+tunedExpectedName)
+				"tuned CR name owned by a performance profile CR should only be %q", tunedExpectedName)
 		})
 
 		It("[test_id:37127] Node should point to right tuned profile", func() {
 			for _, node := range workerRTNodes {
 				tuned := tunedForNode(&node)
 				activeProfile, err := pods.ExecCommandOnPod(tuned, []string{"cat", "/etc/tuned/active_profile"})
-				Expect(err).ToNot(HaveOccurred())
-				Expect(strings.TrimSpace(string(activeProfile))).To(Equal(tunedExpectedName))
+				Expect(err).ToNot(HaveOccurred(), "Error getting the tuned active profile")
+				activeProfileName := string(activeProfile)
+				Expect(strings.TrimSpace(activeProfileName)).To(Equal(tunedExpectedName), "active profile name mismatch got %q expected %q", activeProfileName, tunedExpectedName)
 			}
 		})
 	})
@@ -259,7 +258,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				hook := hooks["hook"].(map[string]interface{})
 				Expect(hook).ToNot(BeNil())
 				args := hook["args"].([]interface{})
-				Expect(len(args)).To(Equal(2))
+				Expect(len(args)).To(Equal(2), "unexpected arguments: %v", args)
 
 				rpsCPUs, err := components.CPUMaskToCPUSet(args[1].(string))
 				Expect(err).ToNot(HaveOccurred())
@@ -414,10 +413,10 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				return mcps.GetConditionStatus(testutils.RoleWorkerCNF, machineconfigv1.MachineConfigPoolUpdating)
 			}, 30, 5).Should(Equal(corev1.ConditionFalse))
 
-			Expect(testclient.Client.Get(context.TODO(), configKey, kubeletConfig)).To(HaveOccurred(), fmt.Sprintf("KubeletConfig %s should be removed", configKey.Name))
-			Expect(testclient.Client.Get(context.TODO(), configKey, machineConfig)).To(HaveOccurred(), fmt.Sprintf("MachineConfig %s should be removed", configKey.Name))
-			Expect(testclient.Client.Get(context.TODO(), configKey, runtimeClass)).To(HaveOccurred(), fmt.Sprintf("RuntimeClass %s should be removed", configKey.Name))
-			Expect(testclient.Client.Get(context.TODO(), tunedKey, tunedProfile)).To(HaveOccurred(), fmt.Sprintf("Tuned profile object %s should be removed", tunedKey.Name))
+			Expect(testclient.Client.Get(context.TODO(), configKey, kubeletConfig)).To(HaveOccurred(), "KubeletConfig %s should be removed", configKey.Name)
+			Expect(testclient.Client.Get(context.TODO(), configKey, machineConfig)).To(HaveOccurred(), "MachineConfig %s should be removed", configKey.Name)
+			Expect(testclient.Client.Get(context.TODO(), configKey, runtimeClass)).To(HaveOccurred(), "RuntimeClass %s should be removed", configKey.Name)
+			Expect(testclient.Client.Get(context.TODO(), tunedKey, tunedProfile)).To(HaveOccurred(), "Tuned profile object %s should be removed", tunedKey.Name)
 
 			By("Checking that initial KubeletConfig and MachineConfig still exist")
 			initialKey := types.NamespacedName{
@@ -425,9 +424,9 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				Namespace: components.NamespaceNodeTuningOperator,
 			}
 			err = testclient.GetWithRetry(context.TODO(), initialKey, &machineconfigv1.KubeletConfig{})
-			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("cannot find KubeletConfig object %s", initialKey.Name))
+			Expect(err).ToNot(HaveOccurred(), "cannot find KubeletConfig object %s", initialKey.Name)
 			err = testclient.GetWithRetry(context.TODO(), initialKey, &machineconfigv1.MachineConfig{})
-			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("cannot find MachineConfig object %s", initialKey.Name))
+			Expect(err).ToNot(HaveOccurred(), "cannot find MachineConfig object %s", initialKey.Name)
 		})
 	})
 
@@ -1021,7 +1020,7 @@ func execSysctlOnWorkers(workerNodes []corev1.Node, sysctlMap map[string]string)
 			By(fmt.Sprintf("executing the command \"sysctl -n %s\"", param))
 			out, err = nodes.ExecCommandOnMachineConfigDaemon(&node, []string{"sysctl", "-n", param})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(strings.TrimSpace(string(out))).Should(Equal(expected), fmt.Sprintf("parameter %s value is not %s.", param, expected))
+			Expect(strings.TrimSpace(string(out))).Should(Equal(expected), "parameter %s value is not %s.", param, expected)
 		}
 	}
 }

--- a/functests/1_performance/rt-kernel.go
+++ b/functests/1_performance/rt-kernel.go
@@ -32,7 +32,7 @@ var _ = Describe("[performance]RT Kernel", func() {
 			discoveryFailed = true
 			return
 		}
-		Expect(err).ToNot(HaveOccurred(), "failed to get a a profile using a filter for RT kernel")
+		Expect(err).ToNot(HaveOccurred(), "failed to get a profile using a filter for RT kernel")
 	})
 
 	BeforeEach(func() {
@@ -47,7 +47,7 @@ var _ = Describe("[performance]RT Kernel", func() {
 		Expect(err).ToNot(HaveOccurred())
 		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
 		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
-		Expect(workerRTNodes).ToNot(BeEmpty())
+		Expect(workerRTNodes).ToNot(BeEmpty(), "No RT worker node found!")
 
 		err = nodes.HasPreemptRTKernel(&workerRTNodes[0])
 		Expect(err).ToNot(HaveOccurred())

--- a/functests/1_performance/test_suite_performance_test.go
+++ b/functests/1_performance/test_suite_performance_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var _ = BeforeSuite(func() {
-	Expect(testclient.ClientsEnabled).To(BeTrue())
+	Expect(testclient.ClientsEnabled).To(BeTrue(), "package client not enabled")
 	// create test namespace
 	err := testclient.Client.Create(context.TODO(), namespaces.TestingNamespace)
 	if errors.IsAlreadyExists(err) {

--- a/functests/1_performance/topology_manager.go
+++ b/functests/1_performance/topology_manager.go
@@ -1,8 +1,6 @@
 package __performance
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -29,8 +27,8 @@ var _ = Describe("[rfe_id:27350][performance]Topology Manager", func() {
 		workerRTNodes, err = nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
-		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
-		Expect(workerRTNodes).ToNot(BeEmpty())
+		Expect(err).ToNot(HaveOccurred(), "Error looking for the optional selector: %v", err)
+		Expect(workerRTNodes).ToNot(BeEmpty(), "No RT worker node found!")
 		profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 	})
@@ -41,9 +39,9 @@ var _ = Describe("[rfe_id:27350][performance]Topology Manager", func() {
 
 		// verify topology manager policy
 		if profile.Spec.NUMA != nil && profile.Spec.NUMA.TopologyPolicy != nil {
-			Expect(kubeletConfig.TopologyManagerPolicy).To(Equal(*profile.Spec.NUMA.TopologyPolicy))
+			Expect(kubeletConfig.TopologyManagerPolicy).To(Equal(*profile.Spec.NUMA.TopologyPolicy), "Topology Manager policy mismatch got %q expected %q", kubeletConfig.TopologyManagerPolicy, *profile.Spec.NUMA.TopologyPolicy)
 		} else {
-			Expect(kubeletConfig.TopologyManagerPolicy).To(Equal(kubeletconfigv1beta1.BestEffortTopologyManagerPolicy))
+			Expect(kubeletConfig.TopologyManagerPolicy).To(Equal(kubeletconfigv1beta1.BestEffortTopologyManagerPolicy), "Topology Manager policy mismatch got %q expected %q", kubeletconfigv1beta1.BestEffortTopologyManagerPolicy)
 		}
 	})
 })

--- a/functests/3_performance_status/status.go
+++ b/functests/3_performance_status/status.go
@@ -3,7 +3,6 @@ package __performance_status
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	ign2types "github.com/coreos/ignition/config/v2_2/types"
 	. "github.com/onsi/ginkgo"
@@ -39,7 +38,7 @@ var _ = Describe("Status testing of performance profile", func() {
 		workerCNFNodes, err = nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 		workerCNFNodes, err = nodes.MatchingOptionalSelector(workerCNFNodes)
-		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
+		Expect(err).ToNot(HaveOccurred(), "error looking for the optional selector: %v", err)
 		Expect(workerCNFNodes).ToNot(BeEmpty())
 	})
 

--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -107,7 +107,7 @@ var _ = Describe("[performance] Latency Test", func() {
 		workerRTNodes, err := nodes.GetByLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
-		Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("error looking for the optional selector: %v", err))
+		Expect(err).ToNot(HaveOccurred(), "error looking for the optional selector: %v", err)
 		Expect(workerRTNodes).ToNot(BeEmpty())
 		workerRTNode = &workerRTNodes[0]
 	})
@@ -177,7 +177,7 @@ var _ = Describe("[performance] Latency Test", func() {
 					continue
 				}
 
-				Expect(curr < maximumLatency).To(BeTrue(), fmt.Sprintf("The current latency %d is bigger than the expected one %d", curr, maximumLatency))
+				Expect(curr < maximumLatency).To(BeTrue(), "The current latency %d is bigger than the expected one %d", curr, maximumLatency)
 			}
 		})
 	})

--- a/functests/utils/client/clients.go
+++ b/functests/utils/client/clients.go
@@ -118,6 +118,6 @@ func GetWithRetry(ctx context.Context, key client.ObjectKey, obj runtime.Object)
 			testlog.Infof("Getting %s failed, retrying: %v", key.Name, err)
 		}
 		return err
-	}, 1*time.Minute, 10*time.Second).ShouldNot(HaveOccurred(), "Max numbers of retries reached")
+	}, 1*time.Minute, 10*time.Second).ShouldNot(HaveOccurred(), "Max numbers of retries getting %v reached", key)
 	return err
 }

--- a/functests/utils/mcps/mcps.go
+++ b/functests/utils/mcps/mcps.go
@@ -143,7 +143,7 @@ func GetConditionStatus(mcpName string, conditionType machineconfigv1.MachineCon
 // GetConditionReason return the reason of the given MCP
 func GetConditionReason(mcpName string, conditionType machineconfigv1.MachineConfigPoolConditionType) string {
 	mcp, err := GetByName(mcpName)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "Failed getting MCP by name")
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "Failed getting MCP %q by name", mcpName)
 	for _, condition := range mcp.Status.Conditions {
 		if condition.Type == conditionType {
 			return condition.Reason
@@ -180,7 +180,7 @@ func WaitForCondition(mcpName string, conditionType machineconfigv1.MachineConfi
 
 		testlog.Infof("MCP %q is targeting %v node(s)", mcp.Name, len(cnfNodes))
 		return nil
-	}, 10*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
+	}, 10*time.Minute, 5*time.Second).ShouldNot(HaveOccurred(), "Failed to find CNF nodes by MCP %q", mcpName)
 
 	// timeout should be based on the number of worker-cnf nodes
 	timeout := time.Duration(len(cnfNodes)*mcpUpdateTimeoutPerNode) * time.Minute
@@ -190,7 +190,7 @@ func WaitForCondition(mcpName string, conditionType machineconfigv1.MachineConfi
 
 	EventuallyWithOffset(1, func() corev1.ConditionStatus {
 		return GetConditionStatus(mcpName, conditionType)
-	}, timeout, 30*time.Second).Should(Equal(conditionStatus))
+	}, timeout, 30*time.Second).Should(Equal(conditionStatus), "Failed to find condition status by MCP %q", mcpName)
 }
 
 // WaitForProfilePickedUp waits for the MCP with given name containing the MC created for the PerformanceProfile with the given name
@@ -209,5 +209,5 @@ func WaitForProfilePickedUp(mcpName string, profileName string) {
 			}
 		}
 		return false
-	}, 10*time.Minute, 30*time.Second).Should(BeTrue(), "PerformanceProfile's MC was not picked up by MCP in time")
+	}, 10*time.Minute, 30*time.Second).Should(BeTrue(), "PerformanceProfile's %q MC was not picked up by MCP  %qin time", profileName, mcpName)
 }

--- a/functests/utils/profiles/profiles.go
+++ b/functests/utils/profiles/profiles.go
@@ -57,7 +57,7 @@ func WaitForDeletion(profileKey types.NamespacedName, timeout time.Duration) err
 // GetCondition the performance profile condition for the given type
 func GetCondition(nodeLabels map[string]string, conditionType v1.ConditionType) *v1.Condition {
 	profile, err := GetByNodeLabels(nodeLabels)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "Failed getting profile by nodelabel")
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "Failed getting profile by nodelabels %v", nodeLabels)
 	for _, condition := range profile.Status.Conditions {
 		if condition.Type == conditionType {
 			return &condition


### PR DESCRIPTION
Add explanation for Expect() failures when the expecations is not
obvious.

Note:
in general, we not change expectations like
```
Expect(err).NotTo(HaveOccurred())
```
because the ginkgo default behaviour is expressive enough.

We can use format strings freely in the gomega annotations. See:
https://onsi.github.io/gomega/ - "Annotating assertions"

Signed-off-by: Francesco Romani <fromani@redhat.com>