### PR TITLE
must-gather: sysinfo: make sure we copy ghw files

### DIFF
--- a/tools/gather-sysinfo/gather-sysinfo.go
+++ b/tools/gather-sysinfo/gather-sysinfo.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -14,7 +15,18 @@ func main() {
 	debug := flag.Bool("debug", false, "enable debug output")
 	output := flag.String("output", "", "path to clone system information into")
 	rootDir := flag.String("root", "", "pseudofs root - use this if running inside a container")
+	dumpList := flag.Bool("dump", false, "just dump the glob list of expected content and exit")
 	flag.Parse()
+
+	// ghw can't handle duplicates in CopyFilesInto, the operation will fail.
+	// Hence we need to make sure we just don't feed duplicates.
+	fileSpecs := dedupExpectedContent(kniExpectedCloneContent(), snapshot.ExpectedCloneContent())
+	if *dumpList {
+		for _, fileSpec := range fileSpecs {
+			fmt.Printf("%s\n", fileSpec)
+		}
+		os.Exit(0)
+	}
 
 	if *output == "" {
 		log.Fatal("--output is required")
@@ -31,44 +43,6 @@ func main() {
 		log.Fatalf("error creating temporary directory: %v", err)
 	}
 	defer os.RemoveAll(scratchDir)
-
-	// collect only KNI-specific entries
-	fileSpecs := []string{
-		// generic information
-		"/proc/cmdline",
-		// IRQ affinities
-		"/proc/interrupts",
-		"/proc/irq/default_smp_affinity",
-		"/proc/irq/*/*affinity_list",
-		"/proc/irq/*/node",
-		// BIOS/firmware versions
-		"/sys/class/dmi/id/bios*",
-		"/sys/class/dmi/id/product_family",
-		"/sys/class/dmi/id/product_name",
-		"/sys/class/dmi/id/product_sku",
-		"/sys/class/dmi/id/product_version",
-		// basic memory infos
-		"/proc/meminfo",
-		// PCI device data
-		"/sys/bus/pci/devices/*",
-		"/sys/devices/pci*/*/irq",
-		"/sys/devices/pci*/*/local_cpulist",
-		"/sys/devices/pci*/*/modalias",
-		"/sys/devices/pci*/*/numa_node",
-		"/sys/devices/pci*/pci_bus/*/cpulistaffinity",
-		// CPU topology
-		"/sys/devices/system/cpu/cpu*/cache/index*/*",
-		"/sys/devices/system/cpu/cpu*/topology/*",
-		"/sys/devices/system/memory/block_size_bytes",
-		"/sys/devices/system/memory/memory*/online",
-		"/sys/devices/system/memory/memory*/state",
-		// NUMA topology
-		"/sys/devices/system/node/has_*",
-		"/sys/devices/system/node/online",
-		"/sys/devices/system/node/possible",
-		"/sys/devices/system/node/node*/cpu*",
-		"/sys/devices/system/node/node*/distance",
-	}
 
 	if *rootDir != "" {
 		fileSpecs = chrootFileSpecs(fileSpecs, *rootDir)
@@ -100,4 +74,38 @@ func chrootFileSpecs(fileSpecs []string, root string) []string {
 		entries = append(entries, filepath.Join(root, fileSpec))
 	}
 	return entries
+}
+
+func dedupExpectedContent(fileSpecs, extraFileSpecs []string) []string {
+	specSet := make(map[string]int)
+	for _, fileSpec := range fileSpecs {
+		specSet[fileSpec]++
+	}
+	for _, extraFileSpec := range extraFileSpecs {
+		specSet[extraFileSpec]++
+	}
+
+	var retSpecs []string
+	for retSpec := range specSet {
+		retSpecs = append(retSpecs, retSpec)
+	}
+	return retSpecs
+}
+
+func kniExpectedCloneContent() []string {
+	return []string{
+		// generic information
+		"/proc/cmdline",
+		// IRQ affinities
+		"/proc/interrupts",
+		"/proc/irq/default_smp_affinity",
+		"/proc/irq/*/*affinity_list",
+		"/proc/irq/*/node",
+		// BIOS/firmware versions
+		"/sys/class/dmi/id/bios*",
+		"/sys/class/dmi/id/product_family",
+		"/sys/class/dmi/id/product_name",
+		"/sys/class/dmi/id/product_sku",
+		"/sys/class/dmi/id/product_version",
+	}
 }


### PR DESCRIPTION
Make sure we clone all the files ghw (not just gather_sysinfo) cares
about.

Signed-off-by: Francesco Romani <fromani@redhat.com>