### PR TITLE
must-gather: bump up gather pod memory limit

### DIFF
--- a/must-gather/node-gather/daemonset.yaml
+++ b/must-gather/node-gather/daemonset.yaml
@@ -25,10 +25,10 @@ spec:
         resources:
           requests:
             cpu: "100m"
-            memory: "50Mi"
+            memory: "256Mi"
           limits:
             cpu: "100m"
-            memory: "50Mi"
+            memory: "256Mi"
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
Up until now, the per-node daemonset pods had a memory limit of 50 megs.
This was pretty much a "low enough" guesstimate we did back in time as
initial assessment and we stuck to it.

Now we have `gather_sysinfo`, which needs to access quite a lot small
files, and on mid-sized multi-numa boxes (feb 2021) can easily eat 60
megs alone. Hence, we get the container OOM killed, like:

```bash
[3539462.598151] [ pid ]   uid  tgid total_vm      rss pgtables_bytes swapents oom_score_adj name
[3539462.607760] [3852242]     0 3852242    35869      679   172032        0         -1000 conmon
[3539462.617012] [3852256]     0 3852256   175834     1086    81920        0          -998 pod
[3539462.625977] [3852769]     0 3852769    35869      679   172032        0         -1000 conmon
[3539462.635178] [3852830]     0 3852830     5756      348    94208        0          -998 sleep
[3539462.644291] [3853529]     0 3853529   177085     1580   114688        0          -998 gather_sysinfo
[3539462.654260] [3858753]     0 3858753   291507     3473   180224        0          -998 runc:[2:INIT]
```

Hence, we now try to find a better memory value applying this reasoning:
on a mid-size multi-numa (2 numa zones, 104 logical cores total)
the gather_sysinfo *container* routinely eat 60-65 megs.
First, we double this value to gain some buffer space (120-130 megs),
Then we double again to both account for the infra processes and to
get more buffer space (240-260), rounding to 256.

Signed-off-by: Francesco Romani <fromani@redhat.com>