### PR TITLE
Create CI lane to validate u/s targets and tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,6 +285,11 @@ verify: golint govet generate
 .PHONY: ci-job
 ci-job: verify build unittests
 
+.PHONY: ci-tools-job
+ci-tools-job:
+	@echo "Verifying tools operation"
+	hack/verify-tools.sh
+	
 .PHONY: release-note
 release-note:
 	hack/release-note.sh

--- a/hack/verify-tools.sh
+++ b/hack/verify-tools.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+set -e
+make dist-tools generate-csv dist-csv-replace-imageref generate-docs


### PR DESCRIPTION
This update intended to explicitely test our internal tools, which don't have explicit test coverage atm.
The update composed of two part:
1. Makefile's target (this PR)
2. Create a CI lane for the OpenShift CI (another PR will be issue soon)

Signed-off-by: Talor Itzhak <titzhak@redhat.com>