### PR TITLE
e2e: skip the IRQ load balancing test

### DIFF
--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -347,6 +347,8 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 		var testpod *corev1.Pod
 
 		BeforeEach(func() {
+			Skip("the test because of the Jira issue https://issues.redhat.com/browse/CNF-1834")
+
 			if profile.Spec.GloballyDisableIrqLoadBalancing != nil && *profile.Spec.GloballyDisableIrqLoadBalancing {
 				Skip("IRQ load balance should be enabled (GloballyDisableIrqLoadBalancing=false), skipping test")
 			}


### PR DESCRIPTION
The test constantly fails under d/s CI, the reason that some of the interrupts can not be moved.
It no easy way to fix it, and until we will have some solution we need to skip the test.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>