### PR TITLE
gather_sysinfo: collect SMT state from sysfs

### DIFF
--- a/tools/gather-sysinfo/gather-sysinfo.go
+++ b/tools/gather-sysinfo/gather-sysinfo.go
@@ -109,6 +109,8 @@ func kniExpectedCloneContent() []string {
 		"/proc/irq/default_smp_affinity",
 		"/proc/irq/*/*affinity_list",
 		"/proc/irq/*/node",
+		// KNI-specific CPU infos:
+		"/sys/devices/system/cpu/smt/active",
 		// BIOS/firmware versions
 		"/sys/class/dmi/id/bios*",
 		"/sys/class/dmi/id/product_family",


### PR DESCRIPTION
Explicitely collect this information from sysfs.
Another option is to check the processor flags: if "ht" is in there,
then SMT is enabled.

Signed-off-by: Francesco Romani <fromani@redhat.com>