### PR TITLE
Make the allocation logic more readable with helper functions

### DIFF
--- a/pkg/profilecreator/profilecreator.go
+++ b/pkg/profilecreator/profilecreator.go
@@ -260,15 +260,26 @@ func (ghwHandler GHWHandler) GetReservedAndIsolatedCPUs(reservedCPUCount int, sp
 	if err != nil {
 		return "", "", fmt.Errorf("Error obtaining Topology Info from GHW snapshot: %v", err)
 	}
-	if splitReservedCPUsAcrossNUMA {
-		return ghwHandler.getCPUsSplitAcrossNUMA(reservedCPUCount, topologyInfo.Nodes)
+	htEnabled, err := ghwHandler.isHyperthreadingEnabled()
+	if err != nil {
+		return "", "", fmt.Errorf("Error determining if Hyperthreading is enabled or not: %v", err)
 	}
-	return ghwHandler.getCPUsSequentially(reservedCPUCount, topologyInfo.Nodes)
+	if splitReservedCPUsAcrossNUMA {
+		return ghwHandler.getCPUsSplitAcrossNUMA(reservedCPUCount, htEnabled, topologyInfo.Nodes)
+	}
+	return ghwHandler.getCPUsSequentially(reservedCPUCount, htEnabled, topologyInfo.Nodes)
 }
 
 // getCPUsSplitAcrossNUMA returns Reserved and Isolated CPUs split across NUMA nodes
-func (ghwHandler GHWHandler) getCPUsSplitAcrossNUMA(reservedCPUCount int, topologyInfoNodes []*topology.Node) (string, string, error) {
-	totalCPUSet := cpuset.NewBuilder()
+// We identify the right number of CPUs that need to be allocated per NUMA node, meaning reservedPerNuma + (the additional number based on the remainder and the NUMA node)
+// E.g. If the user requests 15 reserved cpus and we have 4 numa nodes, we find reservedPerNuma in this case is 3 and remainder = 3.
+// For each numa node we find a max which keeps track of the cumulative resources that should be allocated for each NUMA node:
+// max = (numaID+1)*reservedPerNuma + (numaNodeNum - remainder)
+// For NUMA node 0 max = (0+1)*3 + 4-3 = 4 remainder is decremented => remainder is 2
+// For NUMA node 1 max = (1+1)*3 + 4-2 = 8 remainder is decremented => remainder is 1
+// For NUMA node 2 max = (2+1)*3 + 4-2 = 12 remainder is decremented => remainder is 0
+// For NUMA Node 3 remainder = 0 so max = 12 + 3 = 15.
+func (ghwHandler GHWHandler) getCPUsSplitAcrossNUMA(reservedCPUCount int, htEnabled bool, topologyInfoNodes []*topology.Node) (string, string, error) {
 	reservedCPUSet := cpuset.NewBuilder()
 	numaNodeNum := len(topologyInfoNodes)
 	max := 0
@@ -277,11 +288,6 @@ func (ghwHandler GHWHandler) getCPUsSplitAcrossNUMA(reservedCPUCount int, topolo
 	if remainder != 0 {
 		log.Warnf("The reserved CPUs cannot be split equally across NUMA Nodes")
 	}
-	htEnabled, err := ghwHandler.isHyperthreadingEnabled()
-	if err != nil {
-		return "", "", fmt.Errorf("Error determining if Hyperthreading is enabled or not: %v", err)
-	}
-
 	for numaID, node := range topologyInfoNodes {
 		if remainder != 0 {
 			max = (numaID+1)*reservedPerNuma + (numaNodeNum - remainder)
@@ -294,45 +300,50 @@ func (ghwHandler GHWHandler) getCPUsSplitAcrossNUMA(reservedCPUCount int, topolo
 		}
 		for _, processorCores := range node.Cores {
 			for _, core := range processorCores.LogicalProcessors {
-				totalCPUSet.Add(core)
 				if reservedCPUSet.Result().Size() < max {
 					reservedCPUSet.Add(core)
 				}
 			}
 		}
 	}
-	isolatedCPUSet := totalCPUSet.Result().Difference(reservedCPUSet.Result())
+	totalCPUSet := totalCPUSetFromTopology(topologyInfoNodes)
+	isolatedCPUSet := totalCPUSet.Difference(reservedCPUSet.Result())
 	log.Infof("reservedCPUs: %v len(reservedCPUs): %d\n isolatedCPUs: %v len(isolatedCPUs): %d\n", reservedCPUSet.Result().String(), reservedCPUSet.Result().Size(), isolatedCPUSet.String(), isolatedCPUSet.Size())
 	return reservedCPUSet.Result().String(), isolatedCPUSet.String(), nil
 
 }
 
 // getCPUsSequentially returns Reserved and Isolated CPUs sequentially
-func (ghwHandler GHWHandler) getCPUsSequentially(reservedCPUCount int, topologyInfoNodes []*topology.Node) (string, string, error) {
-	totalCPUSet := cpuset.NewBuilder()
+func (ghwHandler GHWHandler) getCPUsSequentially(reservedCPUCount int, htEnabled bool, topologyInfoNodes []*topology.Node) (string, string, error) {
 	reservedCPUSet := cpuset.NewBuilder()
-	max := reservedCPUCount
-	htEnabled, err := ghwHandler.isHyperthreadingEnabled()
-	if err != nil {
-		return "", "", fmt.Errorf("Error determining if Hyperthreading is enabled or not: %v", err)
-	}
-	if max%2 != 0 && htEnabled {
+	if reservedCPUCount%2 != 0 && htEnabled {
 		return "", "", fmt.Errorf("Can't allocatable odd number of CPUs from a NUMA Node")
 	}
 	for _, node := range topologyInfoNodes {
 		for _, processorCores := range node.Cores {
 			for _, core := range processorCores.LogicalProcessors {
-				totalCPUSet.Add(core)
-				if reservedCPUSet.Result().Size() < max {
+				if reservedCPUSet.Result().Size() < reservedCPUCount {
 					reservedCPUSet.Add(core)
 				}
 			}
 		}
 	}
-	isolatedCPUSet := totalCPUSet.Result().Difference(reservedCPUSet.Result())
+	totalCPUSet := totalCPUSetFromTopology(topologyInfoNodes)
+	isolatedCPUSet := totalCPUSet.Difference(reservedCPUSet.Result())
 	log.Infof("reservedCPUs: %v len(reservedCPUs): %d\n isolatedCPUs: %v len(isolatedCPUs): %d\n", reservedCPUSet.Result().String(), reservedCPUSet.Result().Size(), isolatedCPUSet.String(), isolatedCPUSet.Size())
 	return reservedCPUSet.Result().String(), isolatedCPUSet.String(), nil
 
+}
+func totalCPUSetFromTopology(topologyInfoNodes []*topology.Node) cpuset.CPUSet {
+	totalCPUSet := cpuset.NewBuilder()
+	for _, node := range topologyInfoNodes {
+		for _, processorCores := range node.Cores {
+			for _, core := range processorCores.LogicalProcessors {
+				totalCPUSet.Add(core)
+			}
+		}
+	}
+	return totalCPUSet.Result()
 }
 
 // isHyperthreadingEnabled checks if hyperthreading is enabled on the system or not

--- a/pkg/profilecreator/profilecreator_test.go
+++ b/pkg/profilecreator/profilecreator_test.go
@@ -3,6 +3,8 @@ package profilecreator
 import (
 	"path/filepath"
 
+	"github.com/jaypipes/ghw/pkg/cpu"
+	"github.com/jaypipes/ghw/pkg/topology"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
@@ -241,6 +243,115 @@ var _ = Describe("PerformanceProfileCreator: Check if Hyperthreading enabled/dis
 			htEnabled, err := handle.isHyperthreadingEnabled()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(htEnabled).To(Equal(false))
+		})
+	})
+})
+
+var _ = Describe("PerformanceProfileCreator: Test Helper Functions getCPUsSplitAcrossNUMA and getCPUsSequentially", func() {
+	var mustGatherDirPath, mustGatherDirAbsolutePath string
+	var node *v1.Node
+	var handle *GHWHandler
+	var reservedCPUCount int
+	var topologyInfoNodes []*topology.Node
+	var err error
+
+	BeforeEach(func() {
+		mustGatherDirPath = "../../testdata/must-gather/must-gather.local.directory"
+		node = newTestNode("cnfd1-worker-0.fci1.kni.lab.eng.bos.redhat.com")
+		topologyInfoNodes = []*topology.Node{
+			{
+				ID: 0,
+				Cores: []*cpu.ProcessorCore{
+					{ID: 0, Index: 0, NumThreads: 2, LogicalProcessors: []int{0, 40}},
+					{ID: 0, Index: 0, NumThreads: 2, LogicalProcessors: []int{0, 40}},
+					{ID: 4, Index: 6, NumThreads: 2, LogicalProcessors: []int{2, 42}},
+					{ID: 1, Index: 17, NumThreads: 2, LogicalProcessors: []int{4, 44}},
+					{ID: 3, Index: 18, NumThreads: 2, LogicalProcessors: []int{6, 46}},
+					{ID: 2, Index: 19, NumThreads: 2, LogicalProcessors: []int{8, 48}},
+					{ID: 12, Index: 1, NumThreads: 2, LogicalProcessors: []int{10, 50}},
+					{ID: 8, Index: 2, NumThreads: 2, LogicalProcessors: []int{12, 52}},
+					{ID: 11, Index: 3, NumThreads: 2, LogicalProcessors: []int{14, 54}},
+					{ID: 9, Index: 4, NumThreads: 2, LogicalProcessors: []int{16, 56}},
+					{ID: 10, Index: 5, NumThreads: 2, LogicalProcessors: []int{18, 58}},
+					{ID: 16, Index: 7, NumThreads: 2, LogicalProcessors: []int{20, 60}},
+					{ID: 20, Index: 8, NumThreads: 2, LogicalProcessors: []int{22, 62}},
+					{ID: 17, Index: 9, NumThreads: 2, LogicalProcessors: []int{24, 64}},
+					{ID: 19, Index: 10, NumThreads: 2, LogicalProcessors: []int{26, 66}},
+					{ID: 18, Index: 11, NumThreads: 2, LogicalProcessors: []int{28, 68}},
+					{ID: 28, Index: 12, NumThreads: 2, LogicalProcessors: []int{30, 70}},
+					{ID: 24, Index: 13, NumThreads: 2, LogicalProcessors: []int{32, 72}},
+					{ID: 27, Index: 14, NumThreads: 2, LogicalProcessors: []int{34, 74}},
+					{ID: 25, Index: 15, NumThreads: 2, LogicalProcessors: []int{36, 76}},
+					{ID: 26, Index: 16, NumThreads: 2, LogicalProcessors: []int{38, 78}},
+				},
+			},
+			{
+				ID: 1,
+				Cores: []*cpu.ProcessorCore{
+					{ID: 0, Index: 0, NumThreads: 2, LogicalProcessors: []int{1, 41}},
+					{ID: 4, Index: 11, NumThreads: 2, LogicalProcessors: []int{3, 43}},
+					{ID: 1, Index: 17, NumThreads: 2, LogicalProcessors: []int{5, 45}},
+					{ID: 3, Index: 18, NumThreads: 2, LogicalProcessors: []int{7, 47}},
+					{ID: 2, Index: 19, NumThreads: 2, LogicalProcessors: []int{9, 49}},
+					{ID: 12, Index: 1, NumThreads: 2, LogicalProcessors: []int{11, 51}},
+					{ID: 8, Index: 2, NumThreads: 2, LogicalProcessors: []int{13, 53}},
+					{ID: 11, Index: 3, NumThreads: 2, LogicalProcessors: []int{15, 55}},
+					{ID: 9, Index: 4, NumThreads: 2, LogicalProcessors: []int{17, 57}},
+					{ID: 10, Index: 5, NumThreads: 2, LogicalProcessors: []int{19, 59}},
+					{ID: 16, Index: 6, NumThreads: 2, LogicalProcessors: []int{21, 61}},
+					{ID: 20, Index: 7, NumThreads: 2, LogicalProcessors: []int{23, 63}},
+					{ID: 17, Index: 8, NumThreads: 2, LogicalProcessors: []int{25, 65}},
+					{ID: 19, Index: 9, NumThreads: 2, LogicalProcessors: []int{27, 67}},
+					{ID: 18, Index: 10, NumThreads: 2, LogicalProcessors: []int{29, 69}},
+					{ID: 28, Index: 12, NumThreads: 2, LogicalProcessors: []int{31, 71}},
+					{ID: 24, Index: 13, NumThreads: 2, LogicalProcessors: []int{33, 73}},
+					{ID: 27, Index: 14, NumThreads: 2, LogicalProcessors: []int{35, 75}},
+					{ID: 25, Index: 15, NumThreads: 2, LogicalProcessors: []int{37, 77}},
+					{ID: 26, Index: 16, NumThreads: 2, LogicalProcessors: []int{39, 79}},
+				},
+			},
+		}
+	})
+	Context("Check if getCPUsSplitAcrossNUMA and getCPUsSequentially are working correctly and reserved and isolated CPUs are properly populated in the performance profile", func() {
+		It("Ensure reserved and isolated CPUs populated are correctly by getCPUsSplitAcrossNUMAwhen when splitReservedCPUsAcrossNUMA is enabled", func() {
+			reservedCPUCount = 20 // random number, no special meaning
+			mustGatherDirAbsolutePath, err = filepath.Abs(mustGatherDirPath)
+			Expect(err).ToNot(HaveOccurred())
+			handle, err = NewGHWHandler(mustGatherDirAbsolutePath, node)
+			Expect(err).ToNot(HaveOccurred())
+			reservedCPUs, isolatedCPUs, err := handle.getCPUsSplitAcrossNUMA(reservedCPUCount, topologyInfoNodes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(reservedCPUs).To(Equal("0-9,40-49"))
+			Expect(isolatedCPUs).To(Equal("10-39,50-79"))
+		})
+		It("Errors out in case hyperthreading is enabled, splitReservedCPUsAcrossNUMA is enabled and number of reserved CPUs per number of NUMA nodes are odd", func() {
+			reservedCPUCount = 21 // random number which results in a CPU split per NUMA node (11 + 10 in this case) such that odd number of reserved CPUs (11) have to be allocated from a NUMA node
+			mustGatherDirAbsolutePath, err = filepath.Abs(mustGatherDirPath)
+			Expect(err).ToNot(HaveOccurred())
+			handle, err = NewGHWHandler(mustGatherDirAbsolutePath, node)
+			Expect(err).ToNot(HaveOccurred())
+			_, _, err := handle.getCPUsSplitAcrossNUMA(reservedCPUCount, topologyInfoNodes)
+			Expect(err).To(HaveOccurred())
+		})
+		It("Ensure reserved and isolated CPUs populated are correctly by getCPUsSequentially when splitReservedCPUsAcrossNUMA is disabled", func() {
+			reservedCPUCount = 20 // random number, no special meaning
+			mustGatherDirAbsolutePath, err = filepath.Abs(mustGatherDirPath)
+			Expect(err).ToNot(HaveOccurred())
+			handle, err = NewGHWHandler(mustGatherDirAbsolutePath, node)
+			Expect(err).ToNot(HaveOccurred())
+			reservedCPUs, isolatedCPUs, err := handle.getCPUsSequentially(reservedCPUCount, topologyInfoNodes)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(reservedCPUs).To(Equal("0,2,4,6,8,10,12,14,16,18,40,42,44,46,48,50,52,54,56,58"))
+			Expect(isolatedCPUs).To(Equal("1,3,5,7,9,11,13,15,17,19-39,41,43,45,47,49,51,53,55,57,59-79"))
+		})
+		It("Errors out in case hyperthreading is enabled, splitReservedCPUsAcrossNUMA is disabled and number of reserved CPUs are odd", func() {
+			reservedCPUCount = 21 // random number which results in odd number (21) of CPUs to be allocated from a NUMA node
+			mustGatherDirAbsolutePath, err = filepath.Abs(mustGatherDirPath)
+			Expect(err).ToNot(HaveOccurred())
+			handle, err = NewGHWHandler(mustGatherDirAbsolutePath, node)
+			Expect(err).ToNot(HaveOccurred())
+			_, _, err := handle.getCPUsSequentially(reservedCPUCount, topologyInfoNodes)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
As per the suggestions in the review of https://github.com/openshift-kni/performance-addon-operators/pull/566
we are refactoring the allocation logic to make it more readable by using
separate helper functions, one per allocation strategy
corresponding to splitReservedCPUsAcrossNUMA=false/true

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>