### PR TITLE
must-gather: ghw: update dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/go-openapi/strfmt v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.9 // indirect
 	github.com/go-openapi/validate v0.19.8 // indirect
-	github.com/jaypipes/ghw v0.7.0
+	github.com/jaypipes/ghw v0.7.1-0.20210309000509-b593e32e58a7
 	github.com/mitchellh/mapstructure v1.2.2 // indirect
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -562,8 +562,8 @@ github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
-github.com/jaypipes/ghw v0.7.0 h1:DO0qK9hESxkOTWyd/93hjYBRL7MdVSFqaXdcR7n4pVY=
-github.com/jaypipes/ghw v0.7.0/go.mod h1:+gR9bjm3W/HnFi90liF+Fj9GpCe/Dsibl9Im8KmC7c4=
+github.com/jaypipes/ghw v0.7.1-0.20210309000509-b593e32e58a7 h1:APDKkCKIAkoVmI17TZOCDMgZx8zrOBSde1Z476vDzSc=
+github.com/jaypipes/ghw v0.7.1-0.20210309000509-b593e32e58a7/go.mod h1:+gR9bjm3W/HnFi90liF+Fj9GpCe/Dsibl9Im8KmC7c4=
 github.com/jaypipes/pcidb v0.6.0 h1:VIM7GKVaW4qba30cvB67xSCgJPTzkG8Kzw/cbs5PHWU=
 github.com/jaypipes/pcidb v0.6.0/go.mod h1:L2RGk04sfRhp5wvHO0gfRAMoLY/F3PKv/nwJeVoho0o=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/vendor/github.com/jaypipes/ghw/README.md
+++ b/vendor/github.com/jaypipes/ghw/README.md
@@ -653,6 +653,9 @@ Each `ghw.NIC` struct contains the following fields:
 * `ghw.NIC.Capabilities` is an array of pointers to `ghw.NICCapability` structs
   that can describe the things the NIC supports. These capabilities match the
   returned values from the `ethtool -k <DEVICE>` call on Linux
+* `ghw.NIC.PCIAddress` is the PCI device address of the device backing the NIC.
+  this is not-nil only if the backing device is indeed a PCI device; more backing
+  devices (e.g. USB) will be added in future versions.
 
 The `ghw.NICCapability` struct contains the following fields:
 
@@ -1274,6 +1277,18 @@ memory:
   total_physical_bytes: 25263415296
   total_usable_bytes: 25263415296
 ```
+
+## Calling external programs
+
+By default ghw may call external programs, for example `ethtool`, to learn about hardware capabilities.
+In some rare circumstances it may be useful to opt out from this behaviour and rely only on the data
+provided by pseudo-filesystems, like sysfs.
+The most common use case is when we want to consume a snapshot from ghw. In these cases the information
+provided by tools will be most likely inconsistent with the data from the snapshot - they will run on
+a different host!
+To prevent ghw from calling external tools, set the environs variable `GHW_DISABLE_TOOLS` to any value,
+or, programmatically, check the `WithDisableTools` function.
+The default behaviour of ghw is to call external tools when available.
 
 ## Developers
 

--- a/vendor/github.com/jaypipes/ghw/SNAPSHOT.md
+++ b/vendor/github.com/jaypipes/ghw/SNAPSHOT.md
@@ -22,8 +22,9 @@ expect, we recommend to check also the [project issues](https://github.com/jaypi
 
 ghw supports snapshots only on linux platforms. This restriction may be lifted in future releases.
 Snapshots must be consumable in the following supported ways:
+
 1. (way 1) from docker (or podman), mounting them as volumes. See `hack/run-against-snapshot.sh`
-2. (way 2) using the environment variables `ghw_SNAPSHOT_*`. See `README.md` for the full documentation.
+2. (way 2) using the environment variables `GHW_SNAPSHOT_*`. See `README.md` for the full documentation.
 
 Other combinations are possible, but are unsupported and may stop working any time.
 You should depend only on the supported ways to consume snapshots.
@@ -31,6 +32,7 @@ You should depend only on the supported ways to consume snapshots.
 ### Snapshot content constraints
 
 Stemming from the use cases, the snapshot content must have the following properties:
+
 0. (constraint 0) MUST contain the same information as live system (obviously). Whatever you learn from a live system, you MUST be able to learn from a snapshot.
 1. (constraint 1) MUST NOT require any post processing before it is consumable besides, obviously, unpacking the `.tar.gz` on the right directory - and pointing ghw to that directory.
 2. (constraint 2) MUST NOT require any special handling nor special code path in ghw. From ghw perspective running against a live system or against a snapshot should be completely transparent.

--- a/vendor/github.com/jaypipes/ghw/alias.go
+++ b/vendor/github.com/jaypipes/ghw/alias.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jaypipes/ghw/pkg/net"
 	"github.com/jaypipes/ghw/pkg/option"
 	"github.com/jaypipes/ghw/pkg/pci"
+	pciaddress "github.com/jaypipes/ghw/pkg/pci/address"
 	"github.com/jaypipes/ghw/pkg/product"
 	"github.com/jaypipes/ghw/pkg/topology"
 )
@@ -30,6 +31,7 @@ var (
 	WithNullAlterter = option.WithNullAlerter
 	// match the existing environ variable to minimize surprises
 	WithDisableWarnings = option.WithNullAlerter
+	WithDisableTools    = option.WithDisableTools
 )
 
 type SnapshotOptions = option.SnapshotOptions
@@ -124,12 +126,12 @@ const (
 )
 
 type PCIInfo = pci.Info
-type PCIAddress = pci.Address
+type PCIAddress = pciaddress.Address
 type PCIDevice = pci.Device
 
 var (
 	PCI                  = pci.New
-	PCIAddressFromString = pci.AddressFromString
+	PCIAddressFromString = pciaddress.FromString
 )
 
 type ProductInfo = product.Info

--- a/vendor/github.com/jaypipes/ghw/pkg/context/context.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/context/context.go
@@ -15,6 +15,7 @@ import (
 // context when calling internal discovery methods
 type Context struct {
 	Chroot            string
+	EnableTools       bool
 	SnapshotPath      string
 	SnapshotRoot      string
 	SnapshotExclusive bool
@@ -42,6 +43,10 @@ func New(opts ...*option.Option) *Context {
 		ctx.alert = merged.Alerter
 	}
 
+	if merged.EnableTools != nil {
+		ctx.EnableTools = *merged.EnableTools
+	}
+
 	return ctx
 }
 
@@ -49,11 +54,13 @@ func New(opts ...*option.Option) *Context {
 // default options values
 func FromEnv() *Context {
 	chrootVal := option.EnvOrDefaultChroot()
+	enableTools := option.EnvOrDefaultTools()
 	snapPathVal := option.EnvOrDefaultSnapshotPath()
 	snapRootVal := option.EnvOrDefaultSnapshotRoot()
 	snapExclusiveVal := option.EnvOrDefaultSnapshotExclusive()
 	return &Context{
 		Chroot:            chrootVal,
+		EnableTools:       enableTools,
 		SnapshotPath:      snapPathVal,
 		SnapshotRoot:      snapRootVal,
 		SnapshotExclusive: snapExclusiveVal,

--- a/vendor/github.com/jaypipes/ghw/pkg/net/net.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/net/net.go
@@ -25,8 +25,8 @@ type NIC struct {
 	MacAddress   string           `json:"mac_address"`
 	IsVirtual    bool             `json:"is_virtual"`
 	Capabilities []*NICCapability `json:"capabilities"`
-	// TODO(jaypipes): Add PCI field for accessing PCI device information
-	// PCI *PCIDevice `json:"pci"`
+	PCIAddress   *string          `json:"pci_address,omitempty"`
+	// TODO(fromani): add other hw addresses (USB) when we support them
 }
 
 func (n *NIC) String() string {

--- a/vendor/github.com/jaypipes/ghw/pkg/net/net_linux.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/net/net_linux.go
@@ -37,10 +37,14 @@ func nics(ctx *context.Context) []*NIC {
 		return nics
 	}
 
-	etInstalled := ethtoolInstalled()
-	if !etInstalled {
-		ctx.Warn(_WARN_ETHTOOL_NOT_INSTALLED)
+	etAvailable := ctx.EnableTools
+	if etAvailable {
+		if etInstalled := ethtoolInstalled(); !etInstalled {
+			ctx.Warn(_WARN_ETHTOOL_NOT_INSTALLED)
+			etAvailable = false
+		}
 	}
+
 	for _, file := range files {
 		filename := file.Name()
 		// Ignore loopback...
@@ -62,11 +66,14 @@ func nics(ctx *context.Context) []*NIC {
 
 		mac := netDeviceMacAddress(paths, filename)
 		nic.MacAddress = mac
-		if etInstalled {
+		if etAvailable {
 			nic.Capabilities = netDeviceCapabilities(ctx, filename)
 		} else {
 			nic.Capabilities = []*NICCapability{}
 		}
+
+		nic.PCIAddress = netDevicePCIAddress(paths.SysClassNet, filename)
+
 		nics = append(nics, nic)
 	}
 	return nics
@@ -161,4 +168,55 @@ func netParseEthtoolFeature(line string) *NICCapability {
 		IsEnabled: enabled,
 		CanEnable: !fixed,
 	}
+}
+
+func netDevicePCIAddress(netDevDir, netDevName string) *string {
+	// what we do here is not that hard in the end: we need to navigate the sysfs
+	// up to the directory belonging to the device backing the network interface.
+	// we can make few relatively safe assumptions, but the safest way is follow
+	// the right links. And so we go.
+	// First of all, knowing the network device name we need to resolve the backing
+	// device path to its full sysfs path.
+	// say we start with netDevDir="/sys/class/net" and netDevName="enp0s31f6"
+	netPath := filepath.Join(netDevDir, netDevName)
+	dest, err := os.Readlink(netPath)
+	if err != nil {
+		// bail out with empty value
+		return nil
+	}
+	// now we have something like dest="../../devices/pci0000:00/0000:00:1f.6/net/enp0s31f6"
+	// remember the path is relative to netDevDir="/sys/class/net"
+
+	netDev := filepath.Clean(filepath.Join(netDevDir, dest))
+	// so we clean "/sys/class/net/../../devices/pci0000:00/0000:00:1f.6/net/enp0s31f6"
+	// leading to "/sys/devices/pci0000:00/0000:00:1f.6/net/enp0s31f6"
+	// still not there. We need to access the data of the pci device. So we jump into the path
+	// linked to the "device" pseudofile
+	dest, err = os.Readlink(filepath.Join(netDev, "device"))
+	if err != nil {
+		// bail out with empty value
+		return nil
+	}
+	// we expect something like="../../../0000:00:1f.6"
+
+	devPath := filepath.Clean(filepath.Join(netDev, dest))
+	// so we clean "/sys/devices/pci0000:00/0000:00:1f.6/net/enp0s31f6/../../../0000:00:1f.6"
+	// leading to "/sys/devices/pci0000:00/0000:00:1f.6/"
+	// finally here!
+
+	// to which bus is this device connected to?
+	dest, err = os.Readlink(filepath.Join(devPath, "subsystem"))
+	if err != nil {
+		// bail out with empty value
+		return nil
+	}
+	// ok, this is hacky, but since we need the last *two* path components and we know we
+	// are running on linux...
+	if !strings.HasSuffix(dest, "/bus/pci") {
+		// unsupported and unexpected bus!
+		return nil
+	}
+
+	pciAddr := filepath.Base(devPath)
+	return &pciAddr
 }

--- a/vendor/github.com/jaypipes/ghw/pkg/option/option.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/option/option.go
@@ -17,6 +17,7 @@ const (
 	defaultChroot           = "/"
 	envKeyChroot            = "GHW_CHROOT"
 	envKeyDisableWarnings   = "GHW_DISABLE_WARNINGS"
+	envKeyDisableTools      = "GHW_DISABLE_TOOLS"
 	envKeySnapshotPath      = "GHW_SNAPSHOT_PATH"
 	envKeySnapshotRoot      = "GHW_SNAPSHOT_ROOT"
 	envKeySnapshotExclusive = "GHW_SNAPSHOT_EXCLUSIVE"
@@ -95,6 +96,17 @@ func EnvOrDefaultSnapshotPreserve() bool {
 	return false
 }
 
+// EnvOrDefaultTools return true if ghw should use external tools to augment the data collected
+// from sysfs. Most users want to do this most of time, so this is enabled by default.
+// Users consuming snapshots may want to opt out, thus they can set the GHW_DISABLE_TOOLS
+// environs variable to any value to make ghw skip calling external tools even if they are available.
+func EnvOrDefaultTools() bool {
+	if _, exists := os.LookupEnv(envKeyDisableTools); exists {
+		return false
+	}
+	return true
+}
+
 // Option is used to represent optionally-configured settings. Each field is a
 // pointer to some concrete value so that we can tell when something has been
 // set or left unset.
@@ -113,6 +125,10 @@ type Option struct {
 
 	// Alerter contains the target for ghw warnings
 	Alerter Alerter
+
+	// EnableTools optionally request ghw to not call any external program to learn
+	// about the hardware. The default is to use such tools if available.
+	EnableTools *bool
 }
 
 // SnapshotOptions contains options for handling of ghw snapshots
@@ -161,6 +177,12 @@ func WithNullAlerter() *Option {
 	}
 }
 
+// WithDisableTools sets enables or prohibts ghw to call external tools to discover hardware capabilities.
+func WithDisableTools() *Option {
+	false_ := false
+	return &Option{EnableTools: &false_}
+}
+
 // There is intentionally no Option related to GHW_SNAPSHOT_PRESERVE because we see that as
 // a debug/troubleshoot aid more something users wants to do regularly.
 // Hence we allow that only via the environment variable for the time being.
@@ -176,6 +198,9 @@ func Merge(opts ...*Option) *Option {
 		}
 		if opt.Alerter != nil {
 			merged.Alerter = opt.Alerter
+		}
+		if opt.EnableTools != nil {
+			merged.EnableTools = opt.EnableTools
 		}
 	}
 	// Set the default value if missing from mergeOpts
@@ -193,6 +218,10 @@ func Merge(opts ...*Option) *Option {
 			Root:      &snapRoot,
 			Exclusive: EnvOrDefaultSnapshotExclusive(),
 		}
+	}
+	if merged.EnableTools == nil {
+		enabled := EnvOrDefaultTools()
+		merged.EnableTools = &enabled
 	}
 	return merged
 }

--- a/vendor/github.com/jaypipes/ghw/pkg/pci/address/address.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/pci/address/address.go
@@ -1,0 +1,55 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package address
+
+import (
+	"regexp"
+	"strings"
+)
+
+var (
+	regexAddress *regexp.Regexp = regexp.MustCompile(
+		`^(([0-9a-f]{0,4}):)?([0-9a-f]{2}):([0-9a-f]{2})\.([0-9a-f]{1})$`,
+	)
+)
+
+type Address struct {
+	Domain   string
+	Bus      string
+	Slot     string
+	Function string
+}
+
+// String() returns the canonical [D]BSF representation of this Address
+func (addr *Address) String() string {
+	return addr.Domain + ":" + addr.Bus + ":" + addr.Slot + "." + addr.Function
+}
+
+// Given a string address, returns a complete Address struct, filled in with
+// domain, bus, slot and function components. The address string may either
+// be in $BUS:$SLOT.$FUNCTION (BSF) format or it can be a full PCI address
+// that includes the 4-digit $DOMAIN information as well:
+// $DOMAIN:$BUS:$SLOT.$FUNCTION.
+//
+// Returns "" if the address string wasn't a valid PCI address.
+func FromString(address string) *Address {
+	addrLowered := strings.ToLower(address)
+	matches := regexAddress.FindStringSubmatch(addrLowered)
+	if len(matches) == 6 {
+		dom := "0000"
+		if matches[1] != "" {
+			dom = matches[2]
+		}
+		return &Address{
+			Domain:   dom,
+			Bus:      matches[3],
+			Slot:     matches[4],
+			Function: matches[5],
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/jaypipes/ghw/pkg/pci/pci.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/pci/pci.go
@@ -10,15 +10,22 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/jaypipes/pcidb"
 
 	"github.com/jaypipes/ghw/pkg/context"
 	"github.com/jaypipes/ghw/pkg/marshal"
 	"github.com/jaypipes/ghw/pkg/option"
+	pciaddr "github.com/jaypipes/ghw/pkg/pci/address"
+	"github.com/jaypipes/ghw/pkg/topology"
 	"github.com/jaypipes/ghw/pkg/util"
 )
+
+// backward compatibility, to be removed in 1.0.0
+type Address pciaddr.Address
+
+// backward compatibility, to be removed in 1.0.0
+var AddressFromString = pciaddr.FromString
 
 var (
 	regexAddress *regexp.Regexp = regexp.MustCompile(
@@ -39,6 +46,9 @@ type Device struct {
 	Subclass *pcidb.Subclass `json:"subclass"`
 	// optional programming interface
 	ProgrammingInterface *pcidb.ProgrammingInterface `json:"programming_interface"`
+	// Topology node that the PCI device is affined to. Will be nil if the
+	// architecture is not NUMA.
+	Node *topology.Node `json:"node,omitempty"`
 }
 
 type devIdent struct {
@@ -116,7 +126,8 @@ func (d *Device) String() string {
 }
 
 type Info struct {
-	ctx *context.Context
+	arch topology.Architecture
+	ctx  *context.Context
 	// All PCI devices on the host system
 	Devices []*Device
 	// hash of class ID -> class information
@@ -137,43 +148,23 @@ func (i *Info) String() string {
 	return fmt.Sprintf("PCI (%d devices)", len(i.Devices))
 }
 
-type Address struct {
-	Domain   string
-	Bus      string
-	Slot     string
-	Function string
-}
-
-// Given a string address, returns a complete Address struct, filled in with
-// domain, bus, slot and function components. The address string may either
-// be in $BUS:$SLOT.$FUNCTION (BSF) format or it can be a full PCI address
-// that includes the 4-digit $DOMAIN information as well:
-// $DOMAIN:$BUS:$SLOT.$FUNCTION.
-//
-// Returns "" if the address string wasn't a valid PCI address.
-func AddressFromString(address string) *Address {
-	addrLowered := strings.ToLower(address)
-	matches := regexAddress.FindStringSubmatch(addrLowered)
-	if len(matches) == 6 {
-		dom := "0000"
-		if matches[1] != "" {
-			dom = matches[2]
-		}
-		return &Address{
-			Domain:   dom,
-			Bus:      matches[3],
-			Slot:     matches[4],
-			Function: matches[5],
-		}
-	}
-	return nil
-}
-
 // New returns a pointer to an Info struct that contains information about the
 // PCI devices on the host system
 func New(opts ...*option.Option) (*Info, error) {
 	ctx := context.New(opts...)
-	info := &Info{ctx: ctx}
+	// by default we don't report NUMA information;
+	// we will only if are sure we are running on NUMA architecture
+	arch := topology.ARCHITECTURE_SMP
+	topo, err := topology.NewWithContext(ctx)
+	if err == nil {
+		arch = topo.Architecture
+	} else {
+		ctx.Warn("error detecting system topology: %v", err)
+	}
+	info := &Info{
+		arch: arch,
+		ctx:  ctx,
+	}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/jaypipes/ghw/pkg/pci/pci_linux.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/pci/pci_linux.go
@@ -6,7 +6,6 @@
 package pci
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -16,6 +15,8 @@ import (
 
 	"github.com/jaypipes/ghw/pkg/context"
 	"github.com/jaypipes/ghw/pkg/linuxpath"
+	pciaddr "github.com/jaypipes/ghw/pkg/pci/address"
+	"github.com/jaypipes/ghw/pkg/topology"
 	"github.com/jaypipes/ghw/pkg/util"
 )
 
@@ -33,7 +34,7 @@ func (i *Info) load() error {
 
 func getDeviceModaliasPath(ctx *context.Context, address string) string {
 	paths := linuxpath.New(ctx)
-	pciAddr := AddressFromString(address)
+	pciAddr := pciaddr.FromString(address)
 	if pciAddr == nil {
 		return ""
 	}
@@ -46,13 +47,13 @@ func getDeviceModaliasPath(ctx *context.Context, address string) string {
 
 func getDeviceRevision(ctx *context.Context, address string) string {
 	paths := linuxpath.New(ctx)
-	pciAddr := AddressFromString(address)
+	pciAddr := pciaddr.FromString(address)
 	if pciAddr == nil {
 		return ""
 	}
 	revisionPath := filepath.Join(
 		paths.SysBusPciDevices,
-		pciAddr.Domain+":"+pciAddr.Bus+":"+pciAddr.Slot+"."+pciAddr.Function,
+		pciAddr.String(),
 		"revision",
 	)
 
@@ -63,7 +64,29 @@ func getDeviceRevision(ctx *context.Context, address string) string {
 	if err != nil {
 		return ""
 	}
-	return string(revision)
+	return strings.TrimSpace(string(revision))
+}
+
+func getDeviceNUMANode(ctx *context.Context, address string) *topology.Node {
+	paths := linuxpath.New(ctx)
+	pciAddr := AddressFromString(address)
+	if pciAddr == nil {
+		return nil
+	}
+	numaNodePath := filepath.Join(paths.SysBusPciDevices, pciAddr.String(), "numa_node")
+
+	if _, err := os.Stat(numaNodePath); err != nil {
+		return nil
+	}
+
+	nodeIdx := util.SafeIntFromFile(ctx, numaNodePath)
+	if nodeIdx == -1 {
+		return nil
+	}
+
+	return &topology.Node{
+		ID: nodeIdx,
+	}
 }
 
 type deviceModaliasInfo struct {
@@ -253,16 +276,21 @@ func findPCIProgrammingInterface(
 func (info *Info) GetDevice(address string) *Device {
 	fp := getDeviceModaliasPath(info.ctx, address)
 	if fp == "" {
+		info.ctx.Warn("error finding modalias info for device %q", address)
 		return nil
 	}
 
 	modaliasInfo := parseModaliasFile(fp)
 	if modaliasInfo == nil {
+		info.ctx.Warn("error parsing modalias info for device %q", address)
 		return nil
 	}
 
 	device := info.getDeviceFromModaliasInfo(address, modaliasInfo)
 	device.Revision = getDeviceRevision(info.ctx, address)
+	if info.arch == topology.ARCHITECTURE_NUMA {
+		device.Node = getDeviceNUMANode(info.ctx, address)
+	}
 	return device
 }
 
@@ -328,7 +356,7 @@ func (info *Info) ListDevices() []*Device {
 	// address and append to the returned array.
 	links, err := ioutil.ReadDir(paths.SysBusPciDevices)
 	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "error: failed to read /sys/bus/pci/devices")
+		info.ctx.Warn("failed to read /sys/bus/pci/devices")
 		return nil
 	}
 	var dev *Device
@@ -336,7 +364,7 @@ func (info *Info) ListDevices() []*Device {
 		addr := link.Name()
 		dev = info.GetDevice(addr)
 		if dev == nil {
-			_, _ = fmt.Fprintf(os.Stderr, "error: failed to get device information for PCI address %s\n", addr)
+			info.ctx.Warn("failed to get device information for PCI address %s", addr)
 		} else {
 			devs = append(devs, dev)
 		}

--- a/vendor/github.com/jaypipes/ghw/pkg/snapshot/clonetree.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/snapshot/clonetree.go
@@ -43,19 +43,26 @@ func CloneTreeInto(scratchDir string) error {
 }
 
 // ExpectedCloneContent return a slice of glob patterns which represent the pseudofiles
-// ghw cares about. The intended usage of this function is to validate a clone tree,
-// checking that the content matches the expectations.
+// ghw cares about.
+// The intended usage of this function is to validate a clone tree, checking that the
+// content matches the expectations.
+// Beware: the content is host-specific, because the content pertaining some subsystems,
+// most notably PCI, is host-specific and unpredictable.
 func ExpectedCloneContent() []string {
+	fileSpecs := ExpectedCloneStaticContent()
+	fileSpecs = append(fileSpecs, ExpectedCloneNetContent()...)
+	fileSpecs = append(fileSpecs, ExpectedClonePCIContent()...)
+	return fileSpecs
+}
+
+// ExpectedCloneStaticContent return a slice of glob patterns which represent the pseudofiles
+// ghw cares about, and which are independent from host specific topology or configuration,
+// thus are safely represented by a static slice - e.g. they don't need to be discovered at runtime.
+func ExpectedCloneStaticContent() []string {
 	return []string{
 		"/etc/mtab",
 		"/proc/cpuinfo",
 		"/proc/meminfo",
-		"/sys/bus/pci/devices/*",
-		"/sys/devices/pci*/*/irq",
-		"/sys/devices/pci*/*/local_cpulist",
-		"/sys/devices/pci*/*/modalias",
-		"/sys/devices/pci*/*/numa_node",
-		"/sys/devices/pci*/pci_bus/*/cpulistaffinity",
 		"/sys/devices/system/cpu/cpu*/cache/index*/*",
 		"/sys/devices/system/cpu/cpu*/topology/*",
 		"/sys/devices/system/memory/block_size_bytes",

--- a/vendor/github.com/jaypipes/ghw/pkg/snapshot/clonetree_net.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/snapshot/clonetree_net.go
@@ -1,0 +1,64 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package snapshot
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// warning: don't use the context package here, this means not even the linuxpath package.
+	// TODO(fromani) remove the path duplication
+	sysClassNet = "/sys/class/net"
+)
+
+// ExpectedCloneNetContent returns a slice of strings pertaning to the network interfaces ghw
+// cares about. We cannot use a static list because we want to filter away the virtual devices,
+// which  ghw doesn't concern itself about. So we need to do some runtime discovery.
+// Additionally, we want to make sure to clone the backing device data.
+func ExpectedCloneNetContent() []string {
+	var fileSpecs []string
+	ifaceEntries := []string{
+		"addr_assign_type",
+		// intentionally avoid to clone "address" to avoid to leak any host-idenfifiable data.
+	}
+	entries, err := ioutil.ReadDir(sysClassNet)
+	if err != nil {
+		// we should not import context, hence we can't Warn()
+		return fileSpecs
+	}
+	for _, entry := range entries {
+		netName := entry.Name()
+		netPath := filepath.Join(sysClassNet, netName)
+		dest, err := os.Readlink(netPath)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(dest, "devices/virtual/net") {
+			// there is no point in cloning data for virtual devices,
+			// because ghw concerns itself with HardWare.
+			continue
+		}
+
+		// so, first copy the symlink itself
+		fileSpecs = append(fileSpecs, netPath)
+
+		// now we have to clone the content of the actual network interface
+		// data related (and found into a subdir of) the backing hardware
+		// device
+		netIface := filepath.Clean(filepath.Join(sysClassNet, dest))
+		for _, ifaceEntry := range ifaceEntries {
+			fileSpecs = append(fileSpecs, filepath.Join(netIface, ifaceEntry))
+		}
+
+	}
+
+	return fileSpecs
+}

--- a/vendor/github.com/jaypipes/ghw/pkg/snapshot/clonetree_pci.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/snapshot/clonetree_pci.go
@@ -1,0 +1,148 @@
+//
+// Use and distribution licensed under the Apache license version 2.
+//
+// See the COPYING file in the root project directory for full text.
+//
+
+package snapshot
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	pciaddr "github.com/jaypipes/ghw/pkg/pci/address"
+)
+
+const (
+	// root directory: entry point to start scanning the PCI forest
+	// warning: don't use the context package here, this means not even the linuxpath package.
+	// TODO(fromani) remove the path duplication
+	sysBusPCIDir = "/sys/bus/pci/devices"
+)
+
+// ExpectedClonePCIContent return a slice of glob patterns which represent the pseudofiles
+// ghw cares about, pertaining to PCI devices only.
+// Beware: the content is host-specific, because the PCI topology is host-dependent and unpredictable.
+func ExpectedClonePCIContent() []string {
+	var fileSpecs []string
+	pciRoots := []string{
+		sysBusPCIDir,
+	}
+	for {
+		if len(pciRoots) == 0 {
+			break
+		}
+		pciRoot := pciRoots[0]
+		pciRoots = pciRoots[1:]
+		specs, roots := scanPCIDeviceRoot(pciRoot)
+		pciRoots = append(pciRoots, roots...)
+		fileSpecs = append(fileSpecs, specs...)
+	}
+	return fileSpecs
+}
+
+// scanPCIDeviceRoot reports a slice of glob patterns which represent the pseudofiles
+// ghw cares about pertaining to all the PCI devices connected to the bus connected from the
+// given root; usually (but not always) a CPU packages has 1+ PCI(e) roots, forming the first
+// level; more PCI bridges are (usually) attached to this level, creating deep nested trees.
+// hence we need to scan all possible roots, to make sure not to miss important devices.
+//
+// note about notifying errors. This function and its helper functions do use trace() everywhere
+// to report recoverable errors, even though it would have been appropriate to use Warn().
+// This is unfortunate, and again a byproduct of the fact we cannot use context.Context to avoid
+// circular dependencies.
+// TODO(fromani): switch to Warn() as soon as we figure out how to break this circular dep.
+func scanPCIDeviceRoot(root string) (fileSpecs []string, pciRoots []string) {
+	trace("scanning PCI device root %q\n", root)
+
+	perDevEntries := []string{
+		"class",
+		"device",
+		"irq",
+		"local_cpulist",
+		"modalias",
+		"numa_node",
+		"revision",
+		"vendor",
+	}
+	entries, err := ioutil.ReadDir(root)
+	if err != nil {
+		return []string{}, []string{}
+	}
+	for _, entry := range entries {
+		entryName := entry.Name()
+		if addr := pciaddr.FromString(entryName); addr == nil {
+			// doesn't look like a entry we care about
+			// This is by far and large the most likely path
+			// hence we should NOT trace/warn here.
+			continue
+		}
+
+		entryPath := filepath.Join(root, entryName)
+		pciEntry, err := findPCIEntryFromPath(root, entryName)
+		if err != nil {
+			trace("error scanning %q: %v", entryName, err)
+			continue
+		}
+
+		trace("PCI entry is %q\n", pciEntry)
+		fileSpecs = append(fileSpecs, entryPath)
+		for _, perNetEntry := range perDevEntries {
+			fileSpecs = append(fileSpecs, filepath.Join(pciEntry, perNetEntry))
+		}
+
+		if isPCIBridge(entryPath) {
+			trace("adding new PCI root %q\n", entryName)
+			pciRoots = append(pciRoots, pciEntry)
+		}
+	}
+	return fileSpecs, pciRoots
+}
+
+func findPCIEntryFromPath(root, entryName string) (string, error) {
+	entryPath := filepath.Join(root, entryName)
+	fi, err := os.Lstat(entryPath)
+	if err != nil {
+		return "", fmt.Errorf("stat(%s) failed: %v\n", entryPath, err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		// regular file, nothing to resolve
+		return entryPath, nil
+	}
+	// resolve symlink
+	target, err := os.Readlink(entryPath)
+	trace("entry %q is symlink resolved to %q\n", entryPath, target)
+	if err != nil {
+		return "", fmt.Errorf("readlink(%s) failed: %v - skipped\n", entryPath, err)
+	}
+	return filepath.Clean(filepath.Join(root, target)), nil
+}
+
+func isPCIBridge(entryPath string) bool {
+	subNodes, err := ioutil.ReadDir(entryPath)
+	if err != nil {
+		// this is so unlikely we don't even return error. But we trace just in case.
+		trace("error scanning device entry path %q: %v", entryPath, err)
+		return false
+	}
+	for _, subNode := range subNodes {
+		if !subNode.IsDir() {
+			continue
+		}
+		if addr := pciaddr.FromString(subNode.Name()); addr != nil {
+			// we got an entry in the directory pertaining to this device
+			// which is a directory itself and it is named like a PCI address.
+			// Hence we infer the device we are considering is a PCI bridge of sorts.
+			// This is is indeed a bit brutal, but the only possible alternative
+			// (besides blindly copying everything in /sys/bus/pci/devices) is
+			// to detect the type of the device and pick only the bridges.
+			// This approach duplicates the logic within the `pci` subkpg
+			// - or forces us into awkward dep cycles, and has poorer forward
+			// compatibility.
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/jaypipes/ghw/pkg/topology/topology.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/topology/topology.go
@@ -79,7 +79,13 @@ type Info struct {
 // New returns a pointer to an Info struct that contains information about the
 // NUMA topology on the host system
 func New(opts ...*option.Option) (*Info, error) {
-	ctx := context.New(opts...)
+	return NewWithContext(context.New(opts...))
+}
+
+// NewWithContext returns a pointer to an Info struct that contains information about
+// the NUMA topology on the host system. Use this function when you want to consume
+// the topology package from another package (e.g. pci, gpu)
+func NewWithContext(ctx *context.Context) (*Info, error) {
 	info := &Info{ctx: ctx}
 	if err := ctx.Do(info.load); err != nil {
 		return nil, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -125,7 +125,7 @@ github.com/hashicorp/golang-lru/simplelru
 github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
-# github.com/jaypipes/ghw v0.7.0
+# github.com/jaypipes/ghw v0.7.1-0.20210309000509-b593e32e58a7
 github.com/jaypipes/ghw
 github.com/jaypipes/ghw/pkg/baseboard
 github.com/jaypipes/ghw/pkg/bios
@@ -141,6 +141,7 @@ github.com/jaypipes/ghw/pkg/memory
 github.com/jaypipes/ghw/pkg/net
 github.com/jaypipes/ghw/pkg/option
 github.com/jaypipes/ghw/pkg/pci
+github.com/jaypipes/ghw/pkg/pci/address
 github.com/jaypipes/ghw/pkg/product
 github.com/jaypipes/ghw/pkg/snapshot
 github.com/jaypipes/ghw/pkg/topology


### PR DESCRIPTION
pull the last changes after 0.7.0, needed to properly capture PCI devices in snapshots and in general for better snapshot support.
SRIOV devices support still pending in the upstream project.

Signed-off-by: Francesco Romani <fromani@redhat.com>