### PR TITLE
[release-4.7] remove the psr check from the rcu_nocbs test

### DIFF
--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -39,8 +39,8 @@ var profile *performancev2.PerformanceProfile
 var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 	var balanceIsolated bool
 	var reservedCPU, isolatedCPU string
-	var listReservedCPU, listIsolatedCPU []int
-	var reservedCPUSet, isolatedCPUSet cpuset.CPUSet
+	var listReservedCPU []int
+	var reservedCPUSet cpuset.CPUSet
 
 	BeforeEach(func() {
 		if discovery.Enabled() && testutils.ProfileNotFound {
@@ -64,9 +64,6 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 
 		Expect(profile.Spec.CPU.Isolated).NotTo(BeNil())
 		isolatedCPU = string(*profile.Spec.CPU.Isolated)
-		isolatedCPUSet, err = cpuset.Parse(isolatedCPU)
-		Expect(err).ToNot(HaveOccurred())
-		listIsolatedCPU = isolatedCPUSet.ToSlice()
 
 		Expect(profile.Spec.CPU.Reserved).NotTo(BeNil())
 		reservedCPU = string(*profile.Spec.CPU.Reserved)
@@ -135,15 +132,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 				mask := strings.SplitAfter(taskset, " ")
 				maskSet, err := cpuset.Parse(mask[len(mask)-1])
 				Expect(err).ToNot(HaveOccurred())
-				Expect(reservedCPUSet.IsSubsetOf(maskSet)).To(Equal(true), fmt.Sprintf("The process should have cpu affinity: %s", reservedCPU))
-
-				// check which cpu is used
-				cmd = []string{"/bin/bash", "-c", fmt.Sprintf("ps -o psr %s | tail -1", rcuo)}
-				psr, err := nodes.ExecCommandOnNode(cmd, workerRTNode)
-				Expect(err).ToNot(HaveOccurred())
-				cpu, err := strconv.Atoi(strings.Trim(psr, " "))
-				Expect(err).ToNot(HaveOccurred())
-				Expect(cpu).NotTo(BeElementOf(listIsolatedCPU))
+				Expect(reservedCPUSet.IsSubsetOf(maskSet)).To(Equal(true), "The process should have cpu affinity: %s", reservedCPU)
 			}
 		})
 	})
@@ -158,11 +147,6 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 				profile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 				Expect(err).ToNot(HaveOccurred())
 				isolatedCPU = string(*profile.Spec.CPU.Isolated)
-				isolatedCPUSet, err := cpuset.Parse(isolatedCPU)
-				Expect(err).ToNot(HaveOccurred())
-				if isolatedCPUSet.Size() <= 1 {
-					discoveryFailed = true
-				}
 			}
 		})
 


### PR DESCRIPTION
Merge pull request #573 from cynepco3hahue/remove_psr_check_from_rcu_nocbs_test

Bug 1936953: remove the psr check from the rcu_nocbs test

(cherry picked from commit ea64a9f8f4716e27db08fcca3e2c38725569f695)
Signed-off-by: Artyom Lukianov <alukiano@redhat.com>