### PR TITLE
Populate the additionalKernelArgs field in the performance profile

### DIFF
--- a/cmd/performance-profile-creator/README.md
+++ b/cmd/performance-profile-creator/README.md
@@ -45,10 +45,19 @@ Depending on how must-gather directory was setup run the Performance profile Cre
 1. Option 1: Using must-gather output dir (obtained after running must gather manually)
    ```bash
    podman run --entrypoint performance-profile-creator -v /path/to/must-gather-output:/must-gather:z\
-   quay.io/openshift-kni/performance-addon-operator:4.8-snapshot -M /must-gather > performance-profile.yaml
+   quay.io/openshift-kni/performance-addon-operator:4.8-snapshot --must-gather-dir-path /must-gather > performance-profile.yaml
    ```
 1. Option 2: Using an existing must-gather tarball which is decompressed to a directory.
    ```bash
    podman run --entrypoint performance-profile-creator -v /path/to/decompressed-tarball:/must-gather:z \
-   quay.io/openshift-kni/performance-addon-operator:4.8-snapshot -M /must-gather > performance-profile.yaml
+   quay.io/openshift-kni/performance-addon-operator:4.8-snapshot --must-gather-dir-path /must-gather > performance-profile.yaml
     ```
+
+## Running Performance Profile Creator using Wrapper script
+
+1. Example of how the following wrapper script can be used to create a performance profle:
+   ```bash
+   ./hack/run-perf-profile-creator.sh -t must-gather.tar.gz -- --mcp-name=worker-cnf --reserved-cpu-count=20 \
+   --rt-kernel=false --split-reserved-cpus-across-numa=true --topology-manager-policy=restricted \
+   --power-consumption-mode=low-latency > performace-profile.yaml
+   ```

--- a/cmd/performance-profile-creator/cmd/root.go
+++ b/cmd/performance-profile-creator/cmd/root.go
@@ -83,14 +83,17 @@ func getDataFromFlags(cmd *cobra.Command) (profileCreatorArgs, error) {
 	creatorArgs := profileCreatorArgs{}
 	mustGatherDirPath := cmd.Flag("must-gather-dir-path").Value.String()
 	mcpName := cmd.Flag("mcp-name").Value.String()
+	log.Infof("mcp-name: %s ", mcpName)
 	reservedCPUCount, err := strconv.Atoi(cmd.Flag("reserved-cpu-count").Value.String())
 	if err != nil {
 		return creatorArgs, fmt.Errorf("failed to parse reserved-cpu-count flag: %v", err)
 	}
+	log.Infof("reserved-cpu-count: %d ", reservedCPUCount)
 	splitReservedCPUsAcrossNUMA, err := strconv.ParseBool(cmd.Flag("split-reserved-cpus-across-numa").Value.String())
 	if err != nil {
 		return creatorArgs, fmt.Errorf("failed to parse split-reserved-cpus-across-numa flag: %v", err)
 	}
+	log.Infof("split-reserved-cpus-across-numa = %t", splitReservedCPUsAcrossNUMA)
 	profileName := cmd.Flag("profile-name").Value.String()
 	tmPolicy := cmd.Flag("topology-manager-policy").Value.String()
 	if err != nil {
@@ -103,6 +106,7 @@ func getDataFromFlags(cmd *cobra.Command) (profileCreatorArgs, error) {
 	if tmPolicy == kubeletconfig.SingleNumaNodeTopologyManager && splitReservedCPUsAcrossNUMA {
 		return creatorArgs, fmt.Errorf("not appropriate to split reserved CPUs in case of topology-manager-policy: %v", tmPolicy)
 	}
+	log.Infof("topology-manager-policy: %s ", tmPolicy)
 	powerConsumptionMode := cmd.Flag("power-consumption-mode").Value.String()
 	if err != nil {
 		return creatorArgs, fmt.Errorf("failed to parse power-consumption-mode flag: %v", err)
@@ -111,6 +115,7 @@ func getDataFromFlags(cmd *cobra.Command) (profileCreatorArgs, error) {
 	if err != nil {
 		return creatorArgs, fmt.Errorf("invalid value for power-consumption-mode flag specified: %v", err)
 	}
+	log.Infof("power-consumption-mode: %s ", powerConsumptionMode)
 	//TODO: Use the validated powerConsumptionMode above to be captured in the created performance profile
 	rtKernelEnabled, err := strconv.ParseBool(cmd.Flag("rt-kernel").Value.String())
 	if err != nil {

--- a/pkg/profilecreator/profilecreator.go
+++ b/pkg/profilecreator/profilecreator.go
@@ -290,6 +290,8 @@ func (ghwHandler GHWHandler) GetReservedAndIsolatedCPUs(reservedCPUCount int, sp
 func (ghwHandler GHWHandler) getCPUsSplitAcrossNUMA(reservedCPUCount int, htEnabled bool, topologyInfoNodes []*topology.Node) (string, string, error) {
 	reservedCPUSet := cpuset.NewBuilder()
 	numaNodeNum := len(topologyInfoNodes)
+	log.Infof("Number of NUMA nodes on the node are: %d", numaNodeNum)
+
 	max := 0
 	reservedPerNuma := reservedCPUCount / numaNodeNum
 	remainder := reservedCPUCount % numaNodeNum
@@ -316,9 +318,9 @@ func (ghwHandler GHWHandler) getCPUsSplitAcrossNUMA(reservedCPUCount int, htEnab
 	}
 	totalCPUSet := totalCPUSetFromTopology(topologyInfoNodes)
 	isolatedCPUSet := totalCPUSet.Difference(reservedCPUSet.Result())
-	log.Infof("reservedCPUs: %v len(reservedCPUs): %d\n isolatedCPUs: %v len(isolatedCPUs): %d\n", reservedCPUSet.Result().String(), reservedCPUSet.Result().Size(), isolatedCPUSet.String(), isolatedCPUSet.Size())
+	log.Infof("%d reserved CPUs allocated: %v ", reservedCPUSet.Result().Size(), reservedCPUSet.Result().String())
+	log.Infof("%d isolated CPUs allocated: %v", isolatedCPUSet.Size(), isolatedCPUSet.String())
 	return reservedCPUSet.Result().String(), isolatedCPUSet.String(), nil
-
 }
 
 // getCPUsSequentially returns Reserved and Isolated CPUs sequentially
@@ -338,10 +340,11 @@ func (ghwHandler GHWHandler) getCPUsSequentially(reservedCPUCount int, htEnabled
 	}
 	totalCPUSet := totalCPUSetFromTopology(topologyInfoNodes)
 	isolatedCPUSet := totalCPUSet.Difference(reservedCPUSet.Result())
-	log.Infof("reservedCPUs: %v len(reservedCPUs): %d\n isolatedCPUs: %v len(isolatedCPUs): %d\n", reservedCPUSet.Result().String(), reservedCPUSet.Result().Size(), isolatedCPUSet.String(), isolatedCPUSet.Size())
+	log.Infof("%d reserved CPUs allocated: %v ", reservedCPUSet.Result().Size(), reservedCPUSet.Result().String())
+	log.Infof("%d isolated CPUs allocated: %v", isolatedCPUSet.Size(), isolatedCPUSet.String())
 	return reservedCPUSet.Result().String(), isolatedCPUSet.String(), nil
-
 }
+
 func totalCPUSetFromTopology(topologyInfoNodes []*topology.Node) cpuset.CPUSet {
 	totalCPUSet := cpuset.NewBuilder()
 	for _, node := range topologyInfoNodes {
@@ -413,7 +416,7 @@ func EnsureNodesHaveTheSameHardware(mustGatherDirPath string, nodes []*v1.Node) 
 
 func ensureSameTopology(topology1, topology2 *topology.Info) error {
 	if topology1.Architecture != topology2.Architecture {
-		return fmt.Errorf("the arhitecture is different: %v vs %v", topology1.Architecture, topology2.Architecture)
+		return fmt.Errorf("the architecture is different: %v vs %v", topology1.Architecture, topology2.Architecture)
 	}
 
 	if len(topology1.Nodes) != len(topology2.Nodes) {


### PR DESCRIPTION
- based on the power mode specified by the user we populate the kernel arguments
  in the additionalKernelArgs field of the created performance profile.
- Log  values of computed fields to explain how each field in the profile is populated.
- Minor refactoring to print logs corresponding to reservedCPUs
   and isolatedCPUs just once after GetReservedAndIsolatedCPUs is
   called.
- Additional unit tests for GetAdditionalKernelArgs
- Updates to the README