### PR TITLE
Replace -M flag to --must-gather-dir-path in wrapper script

### DIFF
--- a/hack/run-perf-profile-creator.sh
+++ b/hack/run-perf-profile-creator.sh
@@ -74,7 +74,7 @@ main() {
 
   check_requirements || exit 1
 
-  ${CMD} -v "${DATA_DIR}:${MUST_GATHER_VOL}:z" "${PAO_IMG}" "$@" -M "${MUST_GATHER_VOL}"
+  ${CMD} -v "${DATA_DIR}:${MUST_GATHER_VOL}:z" "${PAO_IMG}" "$@" --must-gather-dir-path "${MUST_GATHER_VOL}"
   echo "" 1>&2
 }
 


### PR DESCRIPTION
As we are no longer using shorthand in the PPC, this update in the
wrapper script ensures that it works without returning an error

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>