### PR TITLE
Turn off Tuned scheduler plugin dynamic tuning.

### DIFF
--- a/build/assets/tuned/openshift-node-performance
+++ b/build/assets/tuned/openshift-node-performance
@@ -41,6 +41,7 @@ banned_cpus=""
 {{end}}
 
 [scheduler]
+runtime=0
 group.ksoftirqd=0:f:11:*:ksoftirqd.*
 group.rcuc=0:f:11:*:rcuc.*
 {{if not .GloballyDisableIrqLoadBalancing}}


### PR DESCRIPTION
The cost of using dynamic tuning (runtime=1) by the Tuned daemon is
currenty very high, and especially so in the OCP environment (see
rhbz#1921738).  PAO uses the Tuned scheduler plugin to set scheduling
policy and priority of ksoftirqd and rcuc kernel threads.  These are
per-CPU kernel threads which start very early during system boot and
exist with a unique PID regardless of CPUs being logically shutdown via
the sysfs interface.

It seems that the only reason for the dynamic scheduler configuration
(runtime=1) would be situations to pick up newly added NUMA
hot-pluggable hardware modules.  This unique case, however, very likely
does not justify the increased CPU utilization incurred by using dynamic
tuning by the Tuned scheduler plugin.