### PR TITLE
must-gather: rename variable for clarity

### DIFF
--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -51,7 +51,7 @@ do
     echo "Failed to collect perf-node-gather data from node ${line} due to pod scheduling failure." >> ${NODES_PATH}/skipped_nodes.txt
 done
 
-WORKER_NODES=()
+COLLECTABLE_NODES=()
 for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name --no-headers --field-selector=status.phase=Running -n perf-node-gather)
 do
     node=$(echo $line | awk -F ' ' '{print $1}')
@@ -62,7 +62,7 @@ do
     oc exec $pod -n perf-node-gather -- lspci -nvv 2>/dev/null >> $NODE_PATH/lspci
     oc exec $pod -n perf-node-gather -- lscpu -e 2>/dev/null >> $NODE_PATH/lscpu
     oc exec $pod -n perf-node-gather -- cat /proc/cmdline 2>/dev/null >> $NODE_PATH/proc_cmdline
-    WORKER_NODES+=($node)
+    COLLECTABLE_NODES+=($node)
 
     oc exec $pod -n perf-node-gather -- gather_sysinfo --debug --root=/host --output=- > $NODE_PATH/sysinfo.tgz 2> $NODE_PATH/sysinfo.log
 done
@@ -70,7 +70,7 @@ done
 # Collect journal logs for specified units for all nodes
 NODE_UNITS=(kubelet)
 ADM_PIDS=()
-for NODE in ${WORKER_NODES[@]}; do
+for NODE in ${COLLECTABLE_NODES[@]}; do
     NODE_PATH=${NODES_PATH}/$NODE
     mkdir -p ${NODE_PATH}
     for UNIT in ${NODE_UNITS[@]}; do


### PR DESCRIPTION
must-gather already depends on the perf-node-gather ds to detect
nodes on which it should collect data.
In turn, the daemonset doesn't explicitely select any node: we run, by
design, on each schedulable node, which, by default, exclude
control-plane nodes using NoSchedule taints.

On single-node deployment, the only prerequisite is that the node
must NOT have such a taint - which is a precondition to run any useful
workload anyway.

This PR hence just renames an internal variable for clarity; no changes
in logic are actually needed.

Signed-off-by: Francesco Romani <fromani@redhat.com>