### PR TITLE
must-gather: align builder image to 4.8

### DIFF
--- a/openshift-ci/Dockerfile.must-gather
+++ b/openshift-ci/Dockerfile.must-gather
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-must-gather:4.7.0 AS builder
+FROM quay.io/openshift/origin-must-gather:4.8.0 AS builder
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 RUN microdnf install -y pciutils util-linux hostname rsync tar


### PR DESCRIPTION
We didn't update previously only because the 4.8 stream wasn't ready
back in time. Now we should switch to 4.8.

Signed-off-by: Francesco Romani <fromani@redhat.com>