### PR TITLE
Netqueues support for vendor and model

### DIFF
--- a/pkg/controller/performanceprofile/components/tuned/tuned.go
+++ b/pkg/controller/performanceprofile/components/tuned/tuned.go
@@ -140,6 +140,14 @@ func NewNodePerformance(assetsDir string, profile *performancev2.PerformanceProf
 					devices = append(devices, "^INTERFACE_NAME="+deviceNameAmendedRegex)
 				}
 			}
+			// Final regex format can be one of the following formats:
+			// devicesUdevRegex = r'^INTERFACE_NAME=InterfaceName'        (InterfaceName can also hold .* representing * wildcard)
+			// devicesUdevRegex = r'^INTERFACE_NAME=(?!InterfaceName)'    (InterfaceName can starting with ?! represents ! wildcard)
+			// devicesUdevRegex = r'^ID_VENDOR_ID=VendorID'
+			// devicesUdevRegex = r'^ID_MODEL_ID=DeviceID[\s\S]*^ID_VENDOR_ID=VendorID'
+			// devicesUdevRegex = r'^ID_MODEL_ID=DeviceID[\s\S]*^ID_VENDOR_ID=VendorID[\s\S]*^INTERFACE_NAME=InterfaceName'
+			// devicesUdevRegex = r'^ID_MODEL_ID=DeviceID[\s\S]*^ID_VENDOR_ID=VendorID[\s\S]*^INTERFACE_NAME=(?!InterfaceName)'
+			// Important note: The order of the key must be preserved - INTERFACE_NAME, ID_MODEL_ID, ID_VENDOR_ID (in that order)
 			devicesUdevRegex := "r'" + strings.Join(devices, `[\s\S]*`) + "'"
 			netPluginSequence++
 			tunedNetDevicesOutput = append(tunedNetDevicesOutput, fmt.Sprintf("\n[net_%d]\ntype=net\ndevices_udev_regex=%s\nchannels=combined %d", netPluginSequence, devicesUdevRegex, reserveCPUcount))

--- a/pkg/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/controller/performanceprofile/components/tuned/tuned_test.go
@@ -178,6 +178,9 @@ var _ = Describe("Tuned", func() {
 				})
 				It("should set by interface name with reserved CPUs count", func() {
 					netDeviceName := "eth*"
+					//regex field should be: devices_udev_regex=r'^INTERFACE_NAME=eth.*''
+					devicesUdevRegex := "r'\\^INTERFACE_NAME=" + strings.Replace(netDeviceName, "*", "\\.\\*", -1) + "'"
+
 					profile.Spec.Net = &performancev2.Net{
 						UserLevelNetworking: pointer.BoolPtr(true),
 						Devices: []performancev2.Device{
@@ -189,13 +192,14 @@ var _ = Describe("Tuned", func() {
 					reservedSet, err := cpuset.Parse(string(*profile.Spec.CPU.Reserved))
 					Expect(err).ToNot(HaveOccurred())
 					reserveCPUcount := reservedSet.Size()
-					//regex field should be: devices_udev_regex=r'^INTERFACE_NAME=eth.*''
-					devicesUdevRegex := "r'\\^INTERFACE_NAME=" + strings.Replace(netDeviceName, "*", "\\.\\*", -1) + "'"
 					channelsRegex := regexp.MustCompile(`\s*\[net_1\]\\ntype=net\\ndevices_udev_regex=` + devicesUdevRegex + `\\nchannels=combined ` + strconv.Itoa(reserveCPUcount) + `\s*`)
 					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
 				})
 				It("should set by negative interface name with reserved CPUs count", func() {
 					netDeviceName := "!ens5"
+					//regex field should be: devices_udev_regex=r'^INTERFACE_NAME=(?!ens5)'
+					devicesUdevRegex := "r'\\^INTERFACE_NAME=\\(\\?!" + strings.Replace(netDeviceName, "*", "\\.\\*", -1) + "\\)'"
+
 					profile.Spec.Net = &performancev2.Net{
 						UserLevelNetworking: pointer.BoolPtr(true),
 						Devices: []performancev2.Device{
@@ -207,13 +211,14 @@ var _ = Describe("Tuned", func() {
 					reservedSet, err := cpuset.Parse(string(*profile.Spec.CPU.Reserved))
 					Expect(err).ToNot(HaveOccurred())
 					reserveCPUcount := reservedSet.Size()
-					//regex field should be: devices_udev_regex=r'^INTERFACE_NAME=(?!ens5)'
-					devicesUdevRegex := "r'\\^INTERFACE_NAME=\\(\\?!" + strings.Replace(netDeviceName, "*", "\\.\\*", -1) + "\\)'"
 					channelsRegex := regexp.MustCompile(`\s*\[net_1\]\\ntype=net\\ndevices_udev_regex=` + devicesUdevRegex + `\\nchannels=combined ` + strconv.Itoa(reserveCPUcount) + `\s*`)
 					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
 				})
 				It("should set by specific vendor with reserved CPUs count", func() {
 					netDeviceVendorID := "0x1af4"
+					//regex field should be: devices_udev_regex=r'^ID_VENDOR_ID=0x1af4'
+					devicesUdevRegex := "r'\\^ID_VENDOR_ID=" + netDeviceVendorID + "'"
+
 					profile.Spec.Net = &performancev2.Net{
 						UserLevelNetworking: pointer.BoolPtr(true),
 						Devices: []performancev2.Device{
@@ -225,14 +230,14 @@ var _ = Describe("Tuned", func() {
 					reservedSet, err := cpuset.Parse(string(*profile.Spec.CPU.Reserved))
 					Expect(err).ToNot(HaveOccurred())
 					reserveCPUcount := reservedSet.Size()
-					//regex field should be: devices_udev_regex=r'^ID_VENDOR_ID=0x1af4'
-					devicesUdevRegex := "r'\\^ID_VENDOR_ID=" + netDeviceVendorID + "'"
 					channelsRegex := regexp.MustCompile(`\s*\[net_1\]\\ntype=net\\ndevices_udev_regex=` + devicesUdevRegex + `\\nchannels=combined ` + strconv.Itoa(reserveCPUcount) + `\s*`)
 					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
 				})
 				It("should set by specific vendor and model with reserved CPUs count", func() {
 					netDeviceVendorID := "0x1af4"
 					netDeviceModelID := "0x1000"
+					//regex field should be: devices_udev_regex=r'^ID_MODEL_ID=0x1000[\s\S]*^ID_VENDOR_ID=0x1af4'
+					devicesUdevRegex := `r'\^ID_MODEL_ID=` + netDeviceModelID + `\[\\\\s\\\\S]\*\^ID_VENDOR_ID=` + netDeviceVendorID + `'`
 
 					profile.Spec.Net = &performancev2.Net{
 						UserLevelNetworking: pointer.BoolPtr(true),
@@ -246,8 +251,6 @@ var _ = Describe("Tuned", func() {
 					reservedSet, err := cpuset.Parse(string(*profile.Spec.CPU.Reserved))
 					Expect(err).ToNot(HaveOccurred())
 					reserveCPUcount := reservedSet.Size()
-					//regex field should be: devices_udev_regex=r'^ID_MODEL_ID=0x1000[\s\S]*^ID_VENDOR_ID=0x1af4'
-					devicesUdevRegex := `r'\^ID_MODEL_ID=` + netDeviceModelID + `\[\\\\s\\\\S]\*\^ID_VENDOR_ID=` + netDeviceVendorID + `'`
 					channelsRegex := regexp.MustCompile(`\s*\[net_1\]\\ntype=net\\ndevices_udev_regex=` + devicesUdevRegex + `\\nchannels=combined ` + strconv.Itoa(reserveCPUcount) + `\s*`)
 					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
 				})
@@ -255,6 +258,8 @@ var _ = Describe("Tuned", func() {
 					netDeviceName := "ens5"
 					netDeviceVendorID := "0x1af4"
 					netDeviceModelID := "0x1000"
+					//regex field should be: devices_udev_regex=r'^ID_MODEL_ID=0x1000[\s\S]*^ID_VENDOR_ID=0x1af4[\s\S]*^INTERFACE_NAME=ens5'
+					devicesUdevRegex := `r'\^ID_MODEL_ID=` + netDeviceModelID + `\[\\\\s\\\\S]\*\^ID_VENDOR_ID=` + netDeviceVendorID + `\[\\\\s\\\\S]\*\^INTERFACE_NAME=` + netDeviceName + `'`
 
 					profile.Spec.Net = &performancev2.Net{
 						UserLevelNetworking: pointer.BoolPtr(true),
@@ -269,8 +274,6 @@ var _ = Describe("Tuned", func() {
 					reservedSet, err := cpuset.Parse(string(*profile.Spec.CPU.Reserved))
 					Expect(err).ToNot(HaveOccurred())
 					reserveCPUcount := reservedSet.Size()
-					//regex field should be: devices_udev_regex=r'^ID_MODEL_ID=0x1000[\s\S]*^ID_VENDOR_ID=0x1af4[\s\S]*^INTERFACE_NAME=ens5'
-					devicesUdevRegex := `r'\^ID_MODEL_ID=` + netDeviceModelID + `\[\\\\s\\\\S]\*\^ID_VENDOR_ID=` + netDeviceVendorID + `\[\\\\s\\\\S]\*\^INTERFACE_NAME=` + netDeviceName + `'`
 					channelsRegex := regexp.MustCompile(`\s*\[net_1\]\\ntype=net\\ndevices_udev_regex=` + devicesUdevRegex + `\\nchannels=combined ` + strconv.Itoa(reserveCPUcount) + `\s*`)
 					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
 				})
@@ -278,6 +281,8 @@ var _ = Describe("Tuned", func() {
 					netDeviceName := "!ens5"
 					netDeviceVendorID := "0x1af4"
 					netDeviceModelID := "0x1000"
+					//regex field should be: devices_udev_regex=r'^ID_MODEL_ID=0x1000[\\s\\S]*^ID_VENDOR_ID=0x1af4[\\s\\S]*^INTERFACE_NAME=(?!ens5)'
+					devicesUdevRegex := `r'\^ID_MODEL_ID=` + netDeviceModelID + `\[\\\\s\\\\S]\*\^ID_VENDOR_ID=` + netDeviceVendorID + `\[\\\\s\\\\S]\*\^INTERFACE_NAME=\(\?!` + netDeviceName + `\)'`
 
 					profile.Spec.Net = &performancev2.Net{
 						UserLevelNetworking: pointer.BoolPtr(true),
@@ -292,8 +297,6 @@ var _ = Describe("Tuned", func() {
 					reservedSet, err := cpuset.Parse(string(*profile.Spec.CPU.Reserved))
 					Expect(err).ToNot(HaveOccurred())
 					reserveCPUcount := reservedSet.Size()
-					//regex field should be: devices_udev_regex=r'^ID_MODEL_ID=0x1000[\\s\\S]*^ID_VENDOR_ID=0x1af4[\\s\\S]*^INTERFACE_NAME=(?!ens5)'
-					devicesUdevRegex := `r'\^ID_MODEL_ID=` + netDeviceModelID + `\[\\\\s\\\\S]\*\^ID_VENDOR_ID=` + netDeviceVendorID + `\[\\\\s\\\\S]\*\^INTERFACE_NAME=\(\?!` + netDeviceName + `\)'`
 					channelsRegex := regexp.MustCompile(`\s*\[net_1\]\\ntype=net\\ndevices_udev_regex=` + devicesUdevRegex + `\\nchannels=combined ` + strconv.Itoa(reserveCPUcount) + `\s*`)
 					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
 				})

--- a/pkg/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/controller/performanceprofile/components/tuned/tuned_test.go
@@ -176,8 +176,83 @@ var _ = Describe("Tuned", func() {
 					channelsRegex := regexp.MustCompile(`\s*channels=combined ` + strconv.Itoa(reserveCPUcount) + `\s*`)
 					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
 				})
-				It("should set specific devices with reserved CPUs count", func() {
-					netDeviceName := "enp0s4"
+				It("should set by interface name with reserved CPUs count", func() {
+					netDeviceName := "eth*"
+					profile.Spec.Net = &performancev2.Net{
+						UserLevelNetworking: pointer.BoolPtr(true),
+						Devices: []performancev2.Device{
+							{
+								InterfaceName: &netDeviceName,
+							},
+						}}
+					manifest := getTunedManifest(profile)
+					reservedSet, err := cpuset.Parse(string(*profile.Spec.CPU.Reserved))
+					Expect(err).ToNot(HaveOccurred())
+					reserveCPUcount := reservedSet.Size()
+					//regex field should be: devices_udev_regex=r'^INTERFACE_NAME=eth.*''
+					devicesUdevRegex := "r'\\^INTERFACE_NAME=" + strings.Replace(netDeviceName, "*", "\\.\\*", -1) + "'"
+					channelsRegex := regexp.MustCompile(`\s*\[net_1\]\\ntype=net\\ndevices_udev_regex=` + devicesUdevRegex + `\\nchannels=combined ` + strconv.Itoa(reserveCPUcount) + `\s*`)
+					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
+				})
+				It("should set by negative interface name with reserved CPUs count", func() {
+					netDeviceName := "!ens5"
+					profile.Spec.Net = &performancev2.Net{
+						UserLevelNetworking: pointer.BoolPtr(true),
+						Devices: []performancev2.Device{
+							{
+								InterfaceName: &netDeviceName,
+							},
+						}}
+					manifest := getTunedManifest(profile)
+					reservedSet, err := cpuset.Parse(string(*profile.Spec.CPU.Reserved))
+					Expect(err).ToNot(HaveOccurred())
+					reserveCPUcount := reservedSet.Size()
+					//regex field should be: devices_udev_regex=r'^INTERFACE_NAME=(?!ens5)'
+					devicesUdevRegex := "r'\\^INTERFACE_NAME=\\(\\?!" + strings.Replace(netDeviceName, "*", "\\.\\*", -1) + "\\)'"
+					channelsRegex := regexp.MustCompile(`\s*\[net_1\]\\ntype=net\\ndevices_udev_regex=` + devicesUdevRegex + `\\nchannels=combined ` + strconv.Itoa(reserveCPUcount) + `\s*`)
+					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
+				})
+				It("should set by specific vendor with reserved CPUs count", func() {
+					netDeviceVendorID := "0x1af4"
+					profile.Spec.Net = &performancev2.Net{
+						UserLevelNetworking: pointer.BoolPtr(true),
+						Devices: []performancev2.Device{
+							{
+								VendorID: &netDeviceVendorID,
+							},
+						}}
+					manifest := getTunedManifest(profile)
+					reservedSet, err := cpuset.Parse(string(*profile.Spec.CPU.Reserved))
+					Expect(err).ToNot(HaveOccurred())
+					reserveCPUcount := reservedSet.Size()
+					//regex field should be: devices_udev_regex=r'^ID_VENDOR_ID=0x1af4'
+					devicesUdevRegex := "r'\\^ID_VENDOR_ID=" + netDeviceVendorID + "'"
+					channelsRegex := regexp.MustCompile(`\s*\[net_1\]\\ntype=net\\ndevices_udev_regex=` + devicesUdevRegex + `\\nchannels=combined ` + strconv.Itoa(reserveCPUcount) + `\s*`)
+					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
+				})
+				It("should set by specific vendor and model with reserved CPUs count", func() {
+					netDeviceVendorID := "0x1af4"
+					netDeviceModelID := "0x1000"
+
+					profile.Spec.Net = &performancev2.Net{
+						UserLevelNetworking: pointer.BoolPtr(true),
+						Devices: []performancev2.Device{
+							{
+								DeviceID: &netDeviceModelID,
+								VendorID: &netDeviceVendorID,
+							},
+						}}
+					manifest := getTunedManifest(profile)
+					reservedSet, err := cpuset.Parse(string(*profile.Spec.CPU.Reserved))
+					Expect(err).ToNot(HaveOccurred())
+					reserveCPUcount := reservedSet.Size()
+					//regex field should be: devices_udev_regex=r'^ID_MODEL_ID=0x1000[\s\S]*^ID_VENDOR_ID=0x1af4'
+					devicesUdevRegex := `r'\^ID_MODEL_ID=` + netDeviceModelID + `\[\\\\s\\\\S]\*\^ID_VENDOR_ID=` + netDeviceVendorID + `'`
+					channelsRegex := regexp.MustCompile(`\s*\[net_1\]\\ntype=net\\ndevices_udev_regex=` + devicesUdevRegex + `\\nchannels=combined ` + strconv.Itoa(reserveCPUcount) + `\s*`)
+					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
+				})
+				It("should set by specific vendor,model and interface name with reserved CPUs count", func() {
+					netDeviceName := "ens5"
 					netDeviceVendorID := "0x1af4"
 					netDeviceModelID := "0x1000"
 
@@ -186,15 +261,40 @@ var _ = Describe("Tuned", func() {
 						Devices: []performancev2.Device{
 							{
 								InterfaceName: &netDeviceName,
-								VendorID:      &netDeviceVendorID,
 								DeviceID:      &netDeviceModelID,
+								VendorID:      &netDeviceVendorID,
 							},
 						}}
 					manifest := getTunedManifest(profile)
 					reservedSet, err := cpuset.Parse(string(*profile.Spec.CPU.Reserved))
 					Expect(err).ToNot(HaveOccurred())
 					reserveCPUcount := reservedSet.Size()
-					channelsRegex := regexp.MustCompile(`\s*\[net_1\]\\ntype=net\\ndevices=` + netDeviceName + `,` + netDeviceVendorID + `,` + netDeviceModelID + `\\nchannels=combined ` + strconv.Itoa(reserveCPUcount) + `\s*`)
+					//regex field should be: devices_udev_regex=r'^ID_MODEL_ID=0x1000[\s\S]*^ID_VENDOR_ID=0x1af4[\s\S]*^INTERFACE_NAME=ens5'
+					devicesUdevRegex := `r'\^ID_MODEL_ID=` + netDeviceModelID + `\[\\\\s\\\\S]\*\^ID_VENDOR_ID=` + netDeviceVendorID + `\[\\\\s\\\\S]\*\^INTERFACE_NAME=` + netDeviceName + `'`
+					channelsRegex := regexp.MustCompile(`\s*\[net_1\]\\ntype=net\\ndevices_udev_regex=` + devicesUdevRegex + `\\nchannels=combined ` + strconv.Itoa(reserveCPUcount) + `\s*`)
+					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
+				})
+				It("should set by specific vendor,model and negative interface name with reserved CPUs count", func() {
+					netDeviceName := "!ens5"
+					netDeviceVendorID := "0x1af4"
+					netDeviceModelID := "0x1000"
+
+					profile.Spec.Net = &performancev2.Net{
+						UserLevelNetworking: pointer.BoolPtr(true),
+						Devices: []performancev2.Device{
+							{
+								InterfaceName: &netDeviceName,
+								DeviceID:      &netDeviceModelID,
+								VendorID:      &netDeviceVendorID,
+							},
+						}}
+					manifest := getTunedManifest(profile)
+					reservedSet, err := cpuset.Parse(string(*profile.Spec.CPU.Reserved))
+					Expect(err).ToNot(HaveOccurred())
+					reserveCPUcount := reservedSet.Size()
+					//regex field should be: devices_udev_regex=r'^ID_MODEL_ID=0x1000[\\s\\S]*^ID_VENDOR_ID=0x1af4[\\s\\S]*^INTERFACE_NAME=(?!ens5)'
+					devicesUdevRegex := `r'\^ID_MODEL_ID=` + netDeviceModelID + `\[\\\\s\\\\S]\*\^ID_VENDOR_ID=` + netDeviceVendorID + `\[\\\\s\\\\S]\*\^INTERFACE_NAME=\(\?!` + netDeviceName + `\)'`
+					channelsRegex := regexp.MustCompile(`\s*\[net_1\]\\ntype=net\\ndevices_udev_regex=` + devicesUdevRegex + `\\nchannels=combined ` + strconv.Itoa(reserveCPUcount) + `\s*`)
 					Expect(channelsRegex.MatchString(manifest)).To(BeTrue())
 				})
 			})


### PR DESCRIPTION
The net field under a profile can now pass to tuned specific net devices according to  interfaceName,device and vendor IDs.
Internal change - pass values as a udev regex that tuned supports.