### PR TITLE
Dockerfile: use modern ENV syntax

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,10 +1,10 @@
 FROM registry.access.redhat.com/ubi8/ubi
 
 ENV HOME=/home/ci
-ENV GOROOT /usr/local/go
-ENV GOVERSION 1.13.5
-ENV GOPATH /go
-ENV GOBIN ${GOPATH}/bin
+ENV GOROOT=/usr/local/go
+ENV GOVERSION=1.13.5
+ENV GOPATH=/go
+ENV GOBIN=${GOPATH}/bin
 ENV PATH=${PATH}:${GOROOT}/bin:${GOBIN}
 
 ARG GO_PACKAGE_PATH=github.com/openshift-kni/performance-addon-operators


### PR DESCRIPTION
See https://docs.docker.com/engine/reference/builder/#env for details
no intended changes on behaviour

Spawned-from: https://github.com/openshift-kni/debug-tools/pull/22
Signed-off-by: Francesco Romani <fromani@redhat.com>