### PR TITLE
Change upgrade test installPlanApproval to Automatic

### DIFF
--- a/functests-extended/1_performance_operator_upgrade/upgrade_operator.go
+++ b/functests-extended/1_performance_operator_upgrade/upgrade_operator.go
@@ -52,6 +52,14 @@ var _ = Describe("[rfe_id:28567][performance] Performance Addon Operator Upgrade
 		csv := getCSV(subscription.Status.CurrentCSV, namespaces.PerformanceOperator)
 		fromImage := csv.ObjectMeta.Annotations["containerImage"]
 
+		By(fmt.Sprintf("Change subscription installPlanApproval to Automatic"))
+		Expect(testclient.Client.Patch(context.TODO(), subscription,
+			client.RawPatch(
+				types.JSONPatchType,
+				[]byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec/installPlanApproval", "value": "%s" }]`, olmv1alpha1.ApprovalAutomatic)),
+			),
+		)).ToNot(HaveOccurred())
+
 		By(fmt.Sprintf("Switch subscription channel to %s version", toVersion))
 		Expect(testclient.Client.Patch(context.TODO(), subscription,
 			client.RawPatch(


### PR DESCRIPTION
Change the subscription installPlanApproval to Automatic before performing the upgrade in upgrade tests 

This is aligned according to: 
https://github.com/openshift/release/pull/17180/files#diff-2097e214d414ba4929d4246083e57002c2a97267650c44db7807ce425e8a289cR103 