### PR TITLE
Change net api fields to more logical names

### DIFF
--- a/api/v2/performanceprofile_types.go
+++ b/api/v2/performanceprofile_types.go
@@ -144,10 +144,10 @@ type Device struct {
 	InterfaceName *string `json:"interfaceName,omitempty"`
 	// Network device vendor ID represnted as a 16 bit Hexmadecimal number.
 	// +optional
-	VendorID *string `json:"vendor,omitempty"`
+	VendorID *string `json:"vendorId,omitempty"`
 	// Network device ID (model) represnted as a 16 bit hexmadecimal number.
 	// +optional
-	DeviceID *string `json:"device,omitempty"`
+	DeviceID *string `json:"deviceId,omitempty"`
 }
 
 // RealTimeKernel defines the set of parameters relevant for the real time kernel.

--- a/api/v2/performanceprofile_types.go
+++ b/api/v2/performanceprofile_types.go
@@ -144,10 +144,10 @@ type Device struct {
 	InterfaceName *string `json:"interfaceName,omitempty"`
 	// Network device vendor ID represnted as a 16 bit Hexmadecimal number.
 	// +optional
-	VendorID *string `json:"vendorId,omitempty"`
+	VendorID *string `json:"vendorID,omitempty"`
 	// Network device ID (model) represnted as a 16 bit hexmadecimal number.
 	// +optional
-	DeviceID *string `json:"deviceId,omitempty"`
+	DeviceID *string `json:"deviceID,omitempty"`
 }
 
 // RealTimeKernel defines the set of parameters relevant for the real time kernel.

--- a/config/crd/bases/performance.openshift.io_performanceprofiles.yaml
+++ b/config/crd/bases/performance.openshift.io_performanceprofiles.yaml
@@ -356,13 +356,13 @@ spec:
                     items:
                       description: 'Device defines a way to represent a network device in several options: device name, vendor ID, model ID, PCI path and MAC address'
                       properties:
-                        deviceId:
+                        deviceID:
                           description: Network device ID (model) represnted as a 16 bit hexmadecimal number.
                           type: string
                         interfaceName:
                           description: Network device name to be matched. It uses a syntax of shell-style wildcards which are either positive or negative.
                           type: string
-                        vendorId:
+                        vendorID:
                           description: Network device vendor ID represnted as a 16 bit Hexmadecimal number.
                           type: string
                       type: object

--- a/config/crd/bases/performance.openshift.io_performanceprofiles.yaml
+++ b/config/crd/bases/performance.openshift.io_performanceprofiles.yaml
@@ -356,13 +356,13 @@ spec:
                     items:
                       description: 'Device defines a way to represent a network device in several options: device name, vendor ID, model ID, PCI path and MAC address'
                       properties:
-                        device:
+                        deviceId:
                           description: Network device ID (model) represnted as a 16 bit hexmadecimal number.
                           type: string
                         interfaceName:
                           description: Network device name to be matched. It uses a syntax of shell-style wildcards which are either positive or negative.
                           type: string
-                        vendor:
+                        vendorId:
                           description: Network device vendor ID represnted as a 16 bit Hexmadecimal number.
                           type: string
                       type: object

--- a/deploy/olm-catalog/performance-addon-operator/4.8.0/performance.openshift.io_performanceprofiles_crd.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.8.0/performance.openshift.io_performanceprofiles_crd.yaml
@@ -354,13 +354,13 @@ spec:
                     items:
                       description: 'Device defines a way to represent a network device in several options: device name, vendor ID, model ID, PCI path and MAC address'
                       properties:
-                        device:
+                        deviceId:
                           description: Network device ID (model) represnted as a 16 bit hexmadecimal number.
                           type: string
                         interfaceName:
                           description: Network device name to be matched. It uses a syntax of shell-style wildcards which are either positive or negative.
                           type: string
-                        vendor:
+                        vendorId:
                           description: Network device vendor ID represnted as a 16 bit Hexmadecimal number.
                           type: string
                       type: object

--- a/deploy/olm-catalog/performance-addon-operator/4.8.0/performance.openshift.io_performanceprofiles_crd.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.8.0/performance.openshift.io_performanceprofiles_crd.yaml
@@ -354,13 +354,13 @@ spec:
                     items:
                       description: 'Device defines a way to represent a network device in several options: device name, vendor ID, model ID, PCI path and MAC address'
                       properties:
-                        deviceId:
+                        deviceID:
                           description: Network device ID (model) represnted as a 16 bit hexmadecimal number.
                           type: string
                         interfaceName:
                           description: Network device name to be matched. It uses a syntax of shell-style wildcards which are either positive or negative.
                           type: string
-                        vendorId:
+                        vendorID:
                           description: Network device vendor ID represnted as a 16 bit Hexmadecimal number.
                           type: string
                       type: object

--- a/docs/performance_profile.md
+++ b/docs/performance_profile.md
@@ -48,8 +48,8 @@ Device defines a way to represent a network device in several options: device na
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | interfaceName | Network device name to be matched. It uses a syntax of shell-style wildcards which are either positive or negative. | *string | false |
-| vendor | Network device vendor ID represnted as a 16 bit Hexmadecimal number. | *string | false |
-| device | Network device ID (model) represnted as a 16 bit hexmadecimal number. | *string | false |
+| vendorId | Network device vendor ID represnted as a 16 bit Hexmadecimal number. | *string | false |
+| deviceId | Network device ID (model) represnted as a 16 bit hexmadecimal number. | *string | false |
 
 [Back to TOC](#table-of-contents)
 

--- a/docs/performance_profile.md
+++ b/docs/performance_profile.md
@@ -48,8 +48,8 @@ Device defines a way to represent a network device in several options: device na
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
 | interfaceName | Network device name to be matched. It uses a syntax of shell-style wildcards which are either positive or negative. | *string | false |
-| vendorId | Network device vendor ID represnted as a 16 bit Hexmadecimal number. | *string | false |
-| deviceId | Network device ID (model) represnted as a 16 bit hexmadecimal number. | *string | false |
+| vendorID | Network device vendor ID represnted as a 16 bit Hexmadecimal number. | *string | false |
+| deviceID | Network device ID (model) represnted as a 16 bit hexmadecimal number. | *string | false |
 
 [Back to TOC](#table-of-contents)
 


### PR DESCRIPTION
Spec.net field names changes:
vendor => vendorId
device => deviceId
