### PR TITLE
Remove superfluous rbac permissions

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -51,15 +51,6 @@ metadata:
 rules:
 - apiGroups:
   - apps
-  resources:
-  - daemonsets
-  - deployments
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
   resourceNames:
   - performance-operator
   resources:

--- a/controllers/performanceprofile_controller.go
+++ b/controllers/performanceprofile_controller.go
@@ -184,7 +184,6 @@ func validateUpdateEvent(e *event.UpdateEvent) bool {
 // +kubebuilder:rbac:groups=tuned.openshift.io,resources=tuneds,verbs=*
 // +kubebuilder:rbac:groups=node.k8s.io,resources=runtimeclasses,verbs=*
 // +kubebuilder:rbac:namespace="openshift-performance-addon-operator",groups=core,resources=pods;services;services/finalizers;configmaps,verbs=*
-// +kubebuilder:rbac:namespace="openshift-performance-addon-operator",groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=*
 // +kubebuilder:rbac:namespace="openshift-performance-addon-operator",groups=apps,resourceNames=performance-operator,resources=deployments/finalizers,verbs=update
 // +kubebuilder:rbac:namespace="openshift-performance-addon-operator",groups=monitoring.coreos.com,resources=servicemonitors,verbs=*
 

--- a/deploy/olm-catalog/performance-addon-operator/4.8.0/performance-addon-operator.v4.8.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.8.0/performance-addon-operator.v4.8.0.clusterserviceversion.yaml
@@ -237,15 +237,6 @@ spec:
       - rules:
         - apiGroups:
           - apps
-          resources:
-          - daemonsets
-          - deployments
-          - replicasets
-          - statefulsets
-          verbs:
-          - '*'
-        - apiGroups:
-          - apps
           resourceNames:
           - performance-operator
           resources:


### PR DESCRIPTION
This update removes permissions that are not related to PAO

Signed-off-by: Talor Itzhak <titzhak@redhat.com>