### PR TITLE
Add management workload annotations

### DIFF
--- a/cluster-setup/base/performance/operator_namespace.yaml
+++ b/cluster-setup/base/performance/operator_namespace.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-performance-addon-operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -9,6 +9,8 @@ spec:
       name: performance-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: performance-operator
     spec:

--- a/deploy/olm-catalog/performance-addon-operator/4.4.0/performance-addon-operator.v4.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.4.0/performance-addon-operator.v4.4.0.clusterserviceversion.yaml
@@ -109,6 +109,8 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: performance-operator
             spec:

--- a/deploy/olm-catalog/performance-addon-operator/4.5.0/performance-addon-operator.v4.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.5.0/performance-addon-operator.v4.5.0.clusterserviceversion.yaml
@@ -109,6 +109,8 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: performance-operator
             spec:

--- a/deploy/olm-catalog/performance-addon-operator/4.5.1/performance-addon-operator.v4.5.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.5.1/performance-addon-operator.v4.5.1.clusterserviceversion.yaml
@@ -115,6 +115,8 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: performance-operator
             spec:

--- a/deploy/olm-catalog/performance-addon-operator/4.6.0/performance-addon-operator.v4.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.6.0/performance-addon-operator.v4.6.0.clusterserviceversion.yaml
@@ -115,6 +115,8 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: performance-operator
             spec:

--- a/deploy/olm-catalog/performance-addon-operator/4.7.0/performance-addon-operator.v4.7.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.7.0/performance-addon-operator.v4.7.0.clusterserviceversion.yaml
@@ -161,6 +161,8 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: performance-operator
             spec:

--- a/deploy/olm-catalog/performance-addon-operator/4.8.0/performance-addon-operator.v4.8.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.8.0/performance-addon-operator.v4.8.0.clusterserviceversion.yaml
@@ -210,6 +210,8 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: performance-operator
             spec:

--- a/must-gather/node-gather/daemonset.yaml
+++ b/must-gather/node-gather/daemonset.yaml
@@ -11,6 +11,8 @@ spec:
       name: perf-node-gather-daemonset
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: perf-node-gather-daemonset
     spec:

--- a/must-gather/node-gather/namespace.yaml
+++ b/must-gather/node-gather/namespace.yaml
@@ -2,4 +2,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    workload.openshift.io/allowed: "management"
   name: perf-node-gather


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.