### PR TITLE
E2E test for consume NTO's per-node Tuned profile application status

### DIFF
--- a/functests/3_performance_status/status.go
+++ b/functests/3_performance_status/status.go
@@ -125,7 +125,7 @@ var _ = Describe("Status testing of performance profile", func() {
 			ns := "openshift-cluster-node-tuning-operator"
 			tunedName := "openshift-cause-tuned-failure"
 
-			// Make sure to clean badTuned object even if the It threw an assertion
+			// Make sure to clean badTuned object even if the It threw an error
 			clean = func() error {
 				key := types.NamespacedName{
 					Name:      tunedName,

--- a/functests/utils/profiles/profiles.go
+++ b/functests/utils/profiles/profiles.go
@@ -109,3 +109,9 @@ func UpdateWithRetry(profile *performancev2.PerformanceProfile) {
 		return nil
 	}, time.Minute, 5*time.Second).Should(BeNil())
 }
+
+func WaitForCondition(nodeLabels map[string]string, conditionType v1.ConditionType, conditionStatus corev1.ConditionStatus) {
+	EventuallyWithOffset(1, func() corev1.ConditionStatus {
+		return (GetCondition(nodeLabels, conditionType)).Status
+	}, 15*time.Minute, 30*time.Second).Should(Equal(conditionStatus), "Failed to met performance profile condition %v", conditionType)
+}


### PR DESCRIPTION
The test will create a TuneD object with a TuneD profile that doesn't exist.
Tuned daemon will fail to apply it, therefore it will get into a Degraded state which eventually should be reflected in PAO status.
In the end, we remove the bad Tuned object and wait for PAO status condition to be Available again.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>