### PR TITLE
performance-creator: Don't add the 'userLevelNetworking' field by default

### DIFF
--- a/functests-performance-profile-creator/1_performance-profile_creator/ppc.go
+++ b/functests-performance-profile-creator/1_performance-profile_creator/ppc.go
@@ -41,7 +41,10 @@ var _ = Describe("[rfe_id:OCP-38968][ppc] Performance Profile Creator", func() {
 				fmt.Sprintf("--reserved-cpu-count=%d", args.ReservedCPUCount),
 				fmt.Sprintf("--rt-kernel=%v", args.RTKernel),
 				fmt.Sprintf("--split-reserved-cpus-across-numa=%v", args.SplitReservedCPUsAcrossNUMA),
-				fmt.Sprintf("--user-level-networking=%v", args.UserLevelNetworking),
+			}
+
+			if args.UserLevelNetworking != nil {
+				cmdArgs = append(cmdArgs, fmt.Sprintf("--user-level-networking=%v", *args.UserLevelNetworking))
 			}
 
 			// do not pass empty strings for optional args

--- a/testdata/ppc-expected-profiles/profile1.yaml
+++ b/testdata/ppc-expected-profiles/profile1.yaml
@@ -8,8 +8,6 @@ spec:
     reserved: 0,2,40,42
   machineConfigPoolSelector:
     machineconfiguration.openshift.io/role: worker-cnf
-  net:
-    userLevelNetworking: false
   nodeSelector:
     node-role.kubernetes.io/worker-cnf: ""
   numa:

--- a/testdata/ppc-expected-profiles/profile2.json
+++ b/testdata/ppc-expected-profiles/profile2.json
@@ -2,6 +2,6 @@
   "must-gather-dir-path": "must-gather.sno",
   "mcp-name": "master",
   "reserved-cpu-count": 1,
-  "rt-kernel": false
+  "rt-kernel": false,
+  "user-level-networking": false
 }
-


### PR DESCRIPTION
Do not automatically add the net.userLevelNetworking field to the performance profile output
if the user does not specify the corresponding user-level-networking param.

Update the regression tests to check for both scenarios (param specified or not).

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>