### PR TITLE
hack: Run PPC tests as part of the functional tests

### DIFF
--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GINKGO_SUITS=${GINKGO_SUITS:-functests}
+GINKGO_SUITS=${GINKGO_SUITS:-functests functests-performance-profile-creator2}
 LATENCY_TEST_RUN=${LATENCY_TEST_RUN:-"false"}
 
 which ginkgo


### PR DESCRIPTION
Use the same CI lane to test PPC regression.

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>