### PR TITLE
profile-creator: do not consider MCPs targeting unschedulable nodes

### DIFF
--- a/cmd/performance-profile-creator/cmd/root.go
+++ b/cmd/performance-profile-creator/cmd/root.go
@@ -184,7 +184,7 @@ func getProfileData(args ProfileCreatorArgs) (*ProfileData, error) {
 		return nil, fmt.Errorf("failed to find MCP %s's nodes: %v", args.MCPName, err)
 	}
 	if len(matchedNodes) == 0 {
-		return nil, fmt.Errorf("no nodes are associated with '%s' MCP", args.MCPName)
+		return nil, fmt.Errorf("no schedulable nodes are associated with '%s' MCP", args.MCPName)
 	}
 
 	var matchedNodeNames []string


### PR DESCRIPTION
Refuse to create the profile if all the nodes targeted by the input MCP
are not schedulable. This is the case for the master MCPs in "normal" clusters.

Signed-off-by: Marcel Apfelbaum <marcel@redhat.com>