### PR TITLE
Ensure PPC binary is created before running PPC functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,7 @@ operator-upgrade-tests:
 	hack/run-upgrade-tests.sh
 
 .PHONY: perf-profile-creator-tests
-perf-profile-creator-tests:
+perf-profile-creator-tests: create-performance-profile
 	@echo "Running Performance Profile Creator Tests"
 	hack/run-perf-profile-creator-functests.sh
 


### PR DESCRIPTION
In case the Performance Profile Creator functional tests are executed
without creating PPC binary, the PPC functional tests would fail. In
order to avoid that, we make it a prerequisite to create the binary
prior to executing the functional tests.

Signed-off-by: Swati Sehgal <swsehgal@redhat.com>