### PR TITLE
ghw: consume latest fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/go-openapi/strfmt v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.9 // indirect
 	github.com/go-openapi/validate v0.19.8 // indirect
-	github.com/jaypipes/ghw v0.7.1-0.20210309000509-b593e32e58a7
+	github.com/jaypipes/ghw v0.7.1-0.20210419135914-b8b1e31b27f5
 	github.com/mitchellh/mapstructure v1.2.2 // indirect
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.1

--- a/go.sum
+++ b/go.sum
@@ -560,8 +560,8 @@ github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
-github.com/jaypipes/ghw v0.7.1-0.20210309000509-b593e32e58a7 h1:APDKkCKIAkoVmI17TZOCDMgZx8zrOBSde1Z476vDzSc=
-github.com/jaypipes/ghw v0.7.1-0.20210309000509-b593e32e58a7/go.mod h1:+gR9bjm3W/HnFi90liF+Fj9GpCe/Dsibl9Im8KmC7c4=
+github.com/jaypipes/ghw v0.7.1-0.20210419135914-b8b1e31b27f5 h1:TMJHaBhIHcOmBmMYU8QyhnxSyNcbNnpgvtuZIoAhGi4=
+github.com/jaypipes/ghw v0.7.1-0.20210419135914-b8b1e31b27f5/go.mod h1:+gR9bjm3W/HnFi90liF+Fj9GpCe/Dsibl9Im8KmC7c4=
 github.com/jaypipes/pcidb v0.6.0 h1:VIM7GKVaW4qba30cvB67xSCgJPTzkG8Kzw/cbs5PHWU=
 github.com/jaypipes/pcidb v0.6.0/go.mod h1:L2RGk04sfRhp5wvHO0gfRAMoLY/F3PKv/nwJeVoho0o=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/vendor/github.com/jaypipes/ghw/README.md
+++ b/vendor/github.com/jaypipes/ghw/README.md
@@ -97,8 +97,8 @@ leftovers.
 The rest of the environment variables are relevant iff `GHW_SNAPSHOT_PATH` is given.
 `GHW_SNAPSHOT_ROOT` let users specify the directory
 on which the snapshot should be unpacked. This moves the ownership of that
-directory from `ghw` to users. `ghw` will still clean up the unpacked snapshot
-when no longer needed.
+directory from `ghw` to users. For this reason, `ghw` will *not* clean up automatically
+the content unpacked in `GHW_SNAPSHOT_ROOT`.
 
 `GHW_SNAPSHOT_EXCLUSIVE` is relevant iff `GHW_SNAPSHOT_ROOT` is given.
 Set it to any value to toggle it on. This tells `ghw` that the directory is meant

--- a/vendor/github.com/jaypipes/ghw/pkg/context/context.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/context/context.go
@@ -14,12 +14,13 @@ import (
 // Concrete merged set of configuration switches that act as an execution
 // context when calling internal discovery methods
 type Context struct {
-	Chroot            string
-	EnableTools       bool
-	SnapshotPath      string
-	SnapshotRoot      string
-	SnapshotExclusive bool
-	alert             option.Alerter
+	Chroot               string
+	EnableTools          bool
+	SnapshotPath         string
+	SnapshotRoot         string
+	SnapshotExclusive    bool
+	snapshotUnpackedPath string
+	alert                option.Alerter
 }
 
 // New returns a Context struct pointer that has had various options set on it
@@ -92,6 +93,9 @@ func (ctx *Context) Setup() error {
 	root := ctx.SnapshotRoot
 	if root == "" {
 		root, err = snapshot.Unpack(ctx.SnapshotPath)
+		if err == nil {
+			ctx.snapshotUnpackedPath = root
+		}
 	} else {
 		var flags uint
 		if ctx.SnapshotExclusive {
@@ -111,12 +115,12 @@ func (ctx *Context) Setup() error {
 // You should always call `Teardown` if you called `Setup` to free any resources
 // acquired by `Setup`. Check `Do` for more automated management.
 func (ctx *Context) Teardown() error {
-	if ctx.SnapshotRoot != "" {
+	if ctx.snapshotUnpackedPath == "" {
 		// if the client code provided the unpack directory,
 		// then it is also in charge of the cleanup.
 		return nil
 	}
-	return snapshot.Cleanup(ctx.SnapshotRoot)
+	return snapshot.Cleanup(ctx.snapshotUnpackedPath)
 }
 
 func (ctx *Context) Warn(msg string, args ...interface{}) {

--- a/vendor/github.com/jaypipes/ghw/pkg/memory/memory_cache_linux.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/memory/memory_cache_linux.go
@@ -6,6 +6,7 @@
 package memory
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -62,7 +63,7 @@ func CachesForNode(ctx *context.Context, nodeID int) ([]*Cache, error) {
 		// directories contains information about the size of that level of
 		// cache and the processors mapped to it.
 		cachePath := filepath.Join(cpuPath, "cache")
-		if _, err = os.Stat(cachePath); os.IsNotExist(err) {
+		if _, err = os.Stat(cachePath); errors.Is(err, os.ErrNotExist) {
 			continue
 		}
 		cacheDirFiles, err := ioutil.ReadDir(cachePath)

--- a/vendor/github.com/jaypipes/ghw/pkg/pci/pci.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/pci/pci.go
@@ -171,6 +171,16 @@ func New(opts ...*option.Option) (*Info, error) {
 	return info, nil
 }
 
+// lookupDevice gets a device from cached data
+func (info *Info) lookupDevice(address string) *Device {
+	for _, dev := range info.Devices {
+		if dev.Address == address {
+			return dev
+		}
+	}
+	return nil
+}
+
 // simple private struct used to encapsulate PCI information in a top-level
 // "pci" YAML/JSON map/object key
 type pciPrinter struct {

--- a/vendor/github.com/jaypipes/ghw/pkg/pci/pci_linux.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/pci/pci_linux.go
@@ -271,9 +271,14 @@ func findPCIProgrammingInterface(
 }
 
 // GetDevice returns a pointer to a Device struct that describes the PCI
-// device at the requested address. If no such device could be found, returns
-// nil
+// device at the requested address. If no such device could be found, returns nil.
 func (info *Info) GetDevice(address string) *Device {
+	// check cached data first
+	if dev := info.lookupDevice(address); dev != nil {
+		return dev
+	}
+
+	// no cached data, let's get the information from system.
 	fp := getDeviceModaliasPath(info.ctx, address)
 	if fp == "" {
 		info.ctx.Warn("error finding modalias info for device %q", address)

--- a/vendor/github.com/jaypipes/ghw/pkg/snapshot/clonetree_block.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/snapshot/clonetree_block.go
@@ -7,6 +7,7 @@
 package snapshot
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -120,7 +121,7 @@ func createBlockDeviceDir(buildDeviceDir string, srcDeviceDir string) error {
 			// and whether the device is read-only
 			buf, err := ioutil.ReadFile(fp)
 			if err != nil {
-				if os.IsPermission(err) {
+				if errors.Is(err, os.ErrPermission) {
 					// example: /sys/devices/virtual/block/zram0/compact is 0400
 					trace("permission denied reading %q - skipped\n", fp)
 					continue

--- a/vendor/github.com/jaypipes/ghw/pkg/snapshot/pack.go
+++ b/vendor/github.com/jaypipes/ghw/pkg/snapshot/pack.go
@@ -9,6 +9,7 @@ package snapshot
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -35,7 +36,7 @@ func OpenDestination(snapshotName string) (*os.File, error) {
 	var f *os.File
 	var err error
 
-	if _, err = os.Stat(snapshotName); os.IsNotExist(err) {
+	if _, err = os.Stat(snapshotName); errors.Is(err, os.ErrNotExist) {
 		if f, err = os.Create(snapshotName); err != nil {
 			return nil, err
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -145,7 +145,7 @@ github.com/hashicorp/golang-lru/simplelru
 github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
-# github.com/jaypipes/ghw v0.7.1-0.20210309000509-b593e32e58a7
+# github.com/jaypipes/ghw v0.7.1-0.20210419135914-b8b1e31b27f5
 ## explicit
 github.com/jaypipes/ghw
 github.com/jaypipes/ghw/pkg/baseboard


### PR DESCRIPTION
update to the tip of ghw main branch to pull in the latest fixes,
most notably to avoid to leak temporary directories when consuming
snapshots:
https://github.com/jaypipes/ghw/pull/236
https://github.com/jaypipes/ghw/pull/240

Signed-off-by: Francesco Romani <fromani@redhat.com>