### PR TITLE
Rename workload annotations

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -10,7 +10,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: performance-operator
     spec:

--- a/deploy/olm-catalog/performance-addon-operator/4.4.0/performance-addon-operator.v4.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.4.0/performance-addon-operator.v4.4.0.clusterserviceversion.yaml
@@ -110,7 +110,7 @@ spec:
           template:
             metadata:
               annotations:
-                workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: performance-operator
             spec:

--- a/deploy/olm-catalog/performance-addon-operator/4.5.0/performance-addon-operator.v4.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.5.0/performance-addon-operator.v4.5.0.clusterserviceversion.yaml
@@ -110,7 +110,7 @@ spec:
           template:
             metadata:
               annotations:
-                workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: performance-operator
             spec:

--- a/deploy/olm-catalog/performance-addon-operator/4.5.1/performance-addon-operator.v4.5.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.5.1/performance-addon-operator.v4.5.1.clusterserviceversion.yaml
@@ -116,7 +116,7 @@ spec:
           template:
             metadata:
               annotations:
-                workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: performance-operator
             spec:

--- a/deploy/olm-catalog/performance-addon-operator/4.6.0/performance-addon-operator.v4.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.6.0/performance-addon-operator.v4.6.0.clusterserviceversion.yaml
@@ -116,7 +116,7 @@ spec:
           template:
             metadata:
               annotations:
-                workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: performance-operator
             spec:

--- a/deploy/olm-catalog/performance-addon-operator/4.7.0/performance-addon-operator.v4.7.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.7.0/performance-addon-operator.v4.7.0.clusterserviceversion.yaml
@@ -162,7 +162,7 @@ spec:
           template:
             metadata:
               annotations:
-                workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: performance-operator
             spec:

--- a/deploy/olm-catalog/performance-addon-operator/4.8.0/performance-addon-operator.v4.8.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.8.0/performance-addon-operator.v4.8.0.clusterserviceversion.yaml
@@ -211,7 +211,7 @@ spec:
           template:
             metadata:
               annotations:
-                workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+                target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: performance-operator
             spec:

--- a/must-gather/node-gather/daemonset.yaml
+++ b/must-gather/node-gather/daemonset.yaml
@@ -12,7 +12,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: perf-node-gather-daemonset
     spec:


### PR DESCRIPTION
As per https://github.com/openshift/enhancements/pull/739, the workload
annotations names are changing.

Signed-off-by: Jim Ramsay <jramsay@redhat.com>

/hold
Hold until after openshift/kubernetes#632 is merged please