### PR TITLE
[release-4.6] Bug 1949027: Re-enable stalld

### DIFF
--- a/build/assets/tuned/openshift-node-performance
+++ b/build/assets/tuned/openshift-node-performance
@@ -25,10 +25,8 @@ governor=performance                          #  latency-performance
 energy_perf_bias=performance                  #  latency-performance 
 min_perf_pct=100                              #  latency-performance 
 
-# Disable the stalld service until bugs https://bugzilla.redhat.com/show_bug.cgi?id=1912118 and
-# https://bugzilla.redhat.com/show_bug.cgi?id=1903302 will be fixed
-# [service]
-# service.stalld=start,enable
+[service]
+service.stalld=start,enable
 
 [vm]
 transparent_hugepages=never                   #  network-latency


### PR DESCRIPTION
This is a downport of #600   : fix allows to re-enable stalld in PAO deafult tuned profile