### PR TITLE
Render Command for PAO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,11 @@ perf-profile-creator-tests: create-performance-profile
 	@echo "Running Performance Profile Creator Tests"
 	hack/run-perf-profile-creator-functests.sh
 
+.PHONY: render-command-tests
+render-command-tests:
+	@echo "Running Render Command Tests"
+	hack/run-perf-profile-creator-functests.sh
+
 .PHONY: unittests
 unittests:
 	hack/unittests.sh

--- a/functests-render-command/1_render_command/render_suite_test.go
+++ b/functests-render-command/1_render_command/render_suite_test.go
@@ -1,0 +1,34 @@
+package __render_command
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	testDir      string
+	workspaceDir string
+	binPath      string
+)
+
+func TestRenderCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Render Command Suite")
+}
+
+var _ = BeforeSuite(func() {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		Fail("Cannot retrieve test directory")
+	}
+
+	testDir = filepath.Dir(file)
+	workspaceDir = filepath.Clean(filepath.Join(testDir, "..", ".."))
+	binPath = filepath.Clean(filepath.Join(workspaceDir, "build", "_output", "bin"))
+	fmt.Fprintf(GinkgoWriter, "using binary at %q\n", binPath)
+})

--- a/functests-render-command/1_render_command/render_test.go
+++ b/functests-render-command/1_render_command/render_test.go
@@ -1,0 +1,102 @@
+package __render_command
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	assetsOutDir string
+	assetsInDir  string
+	ppInFiles    string
+	testDataPath string
+)
+
+var _ = Describe("render command unittest", func() {
+
+	BeforeEach(func() {
+		assetsOutDir = createTempAssetsDir()
+		assetsInDir = filepath.Join(workspaceDir, "build", "assets")
+		ppInFiles = filepath.Join(workspaceDir, "cluster-setup", "manual-cluster", "performance", "performance_profile.yaml")
+		testDataPath = filepath.Join(workspaceDir, "testdata")
+	})
+
+	Context("With a single performance-profile", func() {
+		It("Gets cli args and produces the expected components to output directory", func() {
+
+			cmdline := []string{
+				filepath.Join(binPath, "performance-addon-operators"),
+				"render",
+				"--performance-profile-input-files", ppInFiles,
+				"--asset-input-dir", assetsInDir,
+				"--asset-output-dir", assetsOutDir,
+			}
+			fmt.Fprintf(GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			runAndCompare(cmd)
+
+		})
+
+		It("Gets environment variables and produces the expected components to output directory", func() {
+			cmdline := []string{
+				filepath.Join(binPath, "performance-addon-operators"),
+				"render",
+			}
+			fmt.Fprintf(GinkgoWriter, "running: %v\n", cmdline)
+
+			cmd := exec.Command(cmdline[0], cmdline[1:]...)
+			cmd.Env = append(cmd.Env,
+				fmt.Sprintf("PERFORMANCE_PROFILE_INPUT_FILES=%s", ppInFiles),
+				fmt.Sprintf("ASSET_INPUT_DIR=%s", assetsInDir),
+				fmt.Sprintf("ASSET_OUTPUT_DIR=%s", assetsOutDir),
+			)
+			runAndCompare(cmd)
+		})
+	})
+
+	AfterEach(func() {
+		cleanArtifacts()
+	})
+
+})
+
+func createTempAssetsDir() string {
+	assets, err := ioutil.TempDir("", "assets")
+	Expect(err).ToNot(HaveOccurred())
+	fmt.Printf("assets` output dir at: %q\n", assets)
+	return assets
+}
+
+func cleanArtifacts() {
+	os.RemoveAll(assetsOutDir)
+}
+
+func runAndCompare(cmd *exec.Cmd) {
+	_, err := cmd.Output()
+	Expect(err).ToNot(HaveOccurred())
+
+	outputAssetsFiles, err := ioutil.ReadDir(assetsOutDir)
+	Expect(err).ToNot(HaveOccurred())
+
+	refPath := filepath.Join(testDataPath, "render-expected-output")
+	fmt.Fprintf(GinkgoWriter, "reference data at: %q\n", refPath)
+
+	for _, f := range outputAssetsFiles {
+		refData, err := ioutil.ReadFile(filepath.Join(refPath, f.Name()))
+		Expect(err).ToNot(HaveOccurred())
+
+		data, err := ioutil.ReadFile(filepath.Join(assetsOutDir, f.Name()))
+		Expect(err).ToNot(HaveOccurred())
+
+		res := bytes.Compare(data, refData)
+		Expect(res).To(BeZero())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/cobra v1.1.1
+	github.com/spf13/pflag v1.0.5
 	go.mongodb.org/mongo-driver v1.3.2 // indirect
 	go.uber.org/zap v1.14.1 // indirect
 	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect

--- a/hack/run-render-command-functests.sh
+++ b/hack/run-render-command-functests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+GINKGO_SUITS=${GINKGO_SUITS:-functests-render-command}
+
+which ginkgo
+if [ $? -ne 0 ]; then
+	echo "Downloading ginkgo tool"
+	go install github.com/onsi/ginkgo/ginkgo
+fi
+
+NO_COLOR=""
+if ! which tput &> /dev/null 2>&1 || [[ $(tput -T$TERM colors) -lt 8 ]]; then
+  echo "Terminal does not seem to support colored output, disabling it"
+  NO_COLOR="-noColor"
+fi
+
+
+echo "Running Functional Tests: ${GINKGO_SUITS}"
+# -v: print out the text and location for each spec before running it and flush output to stdout in realtime
+# -r: run suites recursively
+# --failFast: ginkgo will stop the suite right after the first spec failure
+# --flakeAttempts: rerun the test if it fails
+# -requireSuite: fail if tests are not executed because of missing suite
+GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --failFast --flakeAttempts=2 -requireSuite ${GINKGO_SUITS} -- -junitDir /tmp/artifacts

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -1,0 +1,165 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package render
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ghodss/yaml"
+	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/manifestset"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+type renderOpts struct {
+	performanceProfileInputFiles performanceProfileFiles
+	assetsInDir                  string
+	assetsOutDir                 string
+}
+
+type performanceProfileFiles []string
+
+func (ppf *performanceProfileFiles) String() string {
+	return fmt.Sprint(*ppf)
+}
+
+func (ppf *performanceProfileFiles) Type() string {
+	return "performanceProfileFiles"
+}
+
+// Set parse performance-profile-input-files flag and store it in ppf
+func (ppf *performanceProfileFiles) Set(value string) error {
+	if len(*ppf) > 0 {
+		return errors.New("performance-profile-input-files flag already set")
+	}
+
+	for _, s := range strings.Split(value, ",") {
+		*ppf = append(*ppf, s)
+	}
+	return nil
+}
+
+//NewRenderCommand creates a render command.
+func NewRenderCommand() *cobra.Command {
+	renderOpts := renderOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "render",
+		Short: "Render performance-addon-operator manifests",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			if err := renderOpts.Validate(); err != nil {
+				klog.Fatal(err)
+			}
+
+			if err := renderOpts.Run(); err != nil {
+				klog.Fatal(err)
+			}
+		},
+	}
+
+	renderOpts.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (r *renderOpts) AddFlags(fs *pflag.FlagSet) {
+	fs.Var(&r.performanceProfileInputFiles, "performance-profile-input-files", "A comma-separated list of performance-profile manifests.")
+	fs.StringVar(&r.assetsInDir, "asset-input-dir", components.AssetsDir, "Input path for the assets directory.")
+	fs.StringVar(&r.assetsOutDir, "asset-output-dir", r.assetsOutDir, "Output path for the rendered manifests.")
+	// environment variables has precedence over standard input
+	r.readFlagsFromEnv()
+}
+
+func (r *renderOpts) readFlagsFromEnv() {
+	if ppInFiles := os.Getenv("PERFORMANCE_PROFILE_INPUT_FILES"); len(ppInFiles) > 0 {
+		r.performanceProfileInputFiles.Set(ppInFiles)
+	}
+
+	if assetInDir := os.Getenv("ASSET_INPUT_DIR"); len(assetInDir) > 0 {
+		r.assetsInDir = assetInDir
+	}
+
+	if assetsOutDir := os.Getenv("ASSET_OUTPUT_DIR"); len(assetsOutDir) > 0 {
+		r.assetsOutDir = assetsOutDir
+	}
+}
+
+func (r *renderOpts) Validate() error {
+	if len(r.performanceProfileInputFiles) == 0 {
+		return fmt.Errorf("performance-profile-input-files must be specified")
+	}
+
+	if len(r.assetsOutDir) == 0 {
+		return fmt.Errorf("asset-output-dir must be specified")
+	}
+
+	return nil
+}
+
+func (r *renderOpts) Run() error {
+	for _, pp := range r.performanceProfileInputFiles {
+		b, err := ioutil.ReadFile(pp)
+		if err != nil {
+			return err
+		}
+
+		profile := &performancev2.PerformanceProfile{}
+		err = yaml.Unmarshal(b, profile)
+		if err != nil {
+			return err
+		}
+
+		components, err := manifestset.GetNewComponents(profile, &r.assetsInDir)
+		if err != nil {
+			return err
+		}
+		or := []v1.OwnerReference{
+			{
+				Kind: profile.Kind,
+				Name: profile.Name,
+			},
+		}
+
+		for _, componentObj := range components.ToObjects() {
+			componentObj.SetOwnerReferences(or)
+		}
+
+		for kind, manifest := range components.ToManifestTable() {
+			b, err := yaml.Marshal(manifest)
+			if err != nil {
+				return err
+			}
+
+			fileName := fmt.Sprintf("%s_%s.yaml", profile.Name, strings.ToLower(kind))
+			err = ioutil.WriteFile(filepath.Join(r.assetsOutDir, fileName), b, 0644)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/performanceprofile/components/manifestset/manifestset.go
+++ b/pkg/controller/performanceprofile/components/manifestset/manifestset.go
@@ -1,0 +1,75 @@
+package manifestset
+
+import (
+	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/kubeletconfig"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/machineconfig"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/runtimeclass"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/tuned"
+	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
+	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	nodev1beta1 "k8s.io/api/node/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ManifestResultSet contains all component's instances that should be created according to performance-profile
+type ManifestResultSet struct {
+	MachineConfig *mcov1.MachineConfig
+	KubeletConfig *mcov1.KubeletConfig
+	Tuned         *tunedv1.Tuned
+	RuntimeClass  *nodev1beta1.RuntimeClass
+}
+
+// ManifestTable is map with Kind name as key and component's instance as value
+type ManifestTable map[string]interface{}
+
+// ToObjects return a list of all manifests converted to objects
+func (ms *ManifestResultSet) ToObjects() []metav1.Object {
+	objs := make([]metav1.Object, 0)
+
+	objs = append(objs,
+		ms.MachineConfig.GetObjectMeta(),
+		ms.KubeletConfig.GetObjectMeta(),
+		ms.Tuned.GetObjectMeta(),
+		ms.RuntimeClass.GetObjectMeta(),
+	)
+	return objs
+}
+
+// ToManifestTable return a map with Kind name as key and component's instance as value
+func (ms *ManifestResultSet) ToManifestTable() ManifestTable {
+	manifests := make(map[string]interface{}, 0)
+	manifests[ms.MachineConfig.Kind] = ms.MachineConfig
+	manifests[ms.KubeletConfig.Kind] = ms.KubeletConfig
+	manifests[ms.Tuned.Kind] = ms.Tuned
+	manifests[ms.RuntimeClass.Kind] = ms.RuntimeClass
+	return manifests
+}
+
+// GetNewComponents return a list of all component's instances that should be created according to profile
+func GetNewComponents(profile *performancev2.PerformanceProfile, assetDir *string) (*ManifestResultSet, error) {
+	mc, err := machineconfig.New(*assetDir, profile)
+	if err != nil {
+		return nil, err
+	}
+
+	kc, err := kubeletconfig.New(profile)
+	if err != nil {
+		return nil, err
+	}
+
+	performanceTuned, err := tuned.NewNodePerformance(*assetDir, profile)
+	if err != nil {
+		return nil, err
+	}
+
+	runtimeClass := runtimeclass.New(profile, machineconfig.HighPerformanceRuntime)
+
+	manifestResultSet := ManifestResultSet{
+		MachineConfig: mc,
+		KubeletConfig: kc,
+		Tuned:         performanceTuned,
+		RuntimeClass:  runtimeClass,
+	}
+	return &manifestResultSet, nil
+}

--- a/testdata/render-expected-output/manual_kubeletconfig.yaml
+++ b/testdata/render-expected-output/manual_kubeletconfig.yaml
@@ -1,0 +1,51 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  creationTimestamp: null
+  name: performance-manual
+  ownerReferences:
+  - apiVersion: ""
+    kind: PerformanceProfile
+    name: manual
+    uid: ""
+spec:
+  kubeletConfig:
+    apiVersion: kubelet.config.k8s.io/v1beta1
+    authentication:
+      anonymous: {}
+      webhook:
+        cacheTTL: 0s
+      x509: {}
+    authorization:
+      webhook:
+        cacheAuthorizedTTL: 0s
+        cacheUnauthorizedTTL: 0s
+    cpuManagerPolicy: static
+    cpuManagerReconcilePeriod: 5s
+    evictionPressureTransitionPeriod: 0s
+    fileCheckFrequency: 0s
+    httpCheckFrequency: 0s
+    imageMinimumGCAge: 0s
+    kind: KubeletConfiguration
+    kubeReserved:
+      cpu: 1000m
+      memory: 500Mi
+    logging: {}
+    nodeStatusReportFrequency: 0s
+    nodeStatusUpdateFrequency: 0s
+    reservedSystemCPUs: "0"
+    runtimeRequestTimeout: 0s
+    shutdownGracePeriod: 0s
+    shutdownGracePeriodCriticalPods: 0s
+    streamingConnectionIdleTimeout: 0s
+    syncFrequency: 0s
+    systemReserved:
+      cpu: 1000m
+      memory: 500Mi
+    topologyManagerPolicy: single-numa-node
+    volumeStatsAggPeriod: 0s
+  machineConfigPoolSelector:
+    matchLabels:
+      machineconfiguration.openshift.io/role: worker-cnf
+status:
+  conditions: null

--- a/testdata/render-expected-output/manual_machineconfig.yaml
+++ b/testdata/render-expected-output/manual_machineconfig.yaml
@@ -1,0 +1,99 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: worker-cnf
+  name: 50-performance-manual
+  ownerReferences:
+  - apiVersion: ""
+    kind: PerformanceProfile
+    name: manual
+    uid: ""
+spec:
+  config:
+    ignition:
+      config:
+        replace:
+          verification: {}
+      proxy: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKc2V0IC1ldW8gcGlwZWZhaWwKCm5vZGVzX3BhdGg9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vbm9kZSIKaHVnZXBhZ2VzX2ZpbGU9IiR7bm9kZXNfcGF0aH0vbm9kZSR7TlVNQV9OT0RFfS9odWdlcGFnZXMvaHVnZXBhZ2VzLSR7SFVHRVBBR0VTX1NJWkV9a0IvbnJfaHVnZXBhZ2VzIgoKaWYgWyAhIC1mICIke2h1Z2VwYWdlc19maWxlfSIgXTsgdGhlbgogIGVjaG8gIkVSUk9SOiAke2h1Z2VwYWdlc19maWxlfSBkb2VzIG5vdCBleGlzdCIKICBleGl0IDEKZmkKCnRpbWVvdXQ9NjAKc2FtcGxlPTEKY3VycmVudF90aW1lPTAKd2hpbGUgWyAiJChjYXQgIiR7aHVnZXBhZ2VzX2ZpbGV9IikiIC1uZSAiJHtIVUdFUEFHRVNfQ09VTlR9IiBdOyBkbwogIGVjaG8gIiR7SFVHRVBBR0VTX0NPVU5UfSIgPiIke2h1Z2VwYWdlc19maWxlfSIKCiAgY3VycmVudF90aW1lPSQoKGN1cnJlbnRfdGltZSArIHNhbXBsZSkpCiAgaWYgWyAkY3VycmVudF90aW1lIC1ndCAkdGltZW91dCBdOyB0aGVuCiAgICBlY2hvICJFUlJPUjogJHtodWdlcGFnZXNfZmlsZX0gZG9lcyBub3QgaGF2ZSB0aGUgZXhwZWN0ZWQgbnVtYmVyIG9mIGh1Z2VwYWdlcyAke0hVR0VQQUdFU19DT1VOVH0iCiAgICBleGl0IDEKICBmaQoKICBzbGVlcCAkc2FtcGxlCmRvbmUK
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/hugepages-allocation.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKbWFzaz0iJHsxfSIKWyAtbiAiJHttYXNrfSIgXSB8fCB7IGxvZ2dlciAiJHswfTogVGhlIHJwcy1tYXNrIHBhcmFtZXRlciBpcyBtaXNzaW5nIiA7IGV4aXQgMDsgfQoKcGlkPSQoanEgJy5waWQnIC9kZXYvc3RkaW4gMj4mMSkKW1sgJD8gLWVxIDAgJiYgLW4gIiR7cGlkfSIgXV0gfHwgeyBsb2dnZXIgIiR7MH06IEZhaWxlZCB0byBleHRyYWN0IHRoZSBwaWQ6ICR7cGlkfSI7IGV4aXQgMDsgfQoKbnM9JChpcCBuZXRucyBpZGVudGlmeSAiJHtwaWR9IiAyPiYxKQpbWyAkPyAtZXEgMCAmJiAtbiAiJHtuc30iIF1dIHx8IHsgbG9nZ2VyICIkezB9IEZhaWxlZCB0byBpZGVudGlmeSB0aGUgbmFtZXNwYWNlOiAke25zfSI7IGV4aXQgMDsgfQoKbW9kZT0kKGlwIG5ldG5zIGV4ZWMgIiR7bnN9IiBbIC13IC9zeXMgXSAmJiBlY2hvICJydyIgfHwgZWNobyAicm8iIDI+JjEpClsgJD8gLWVxIDAgXSB8fCB7IGxvZ2dlciAiJHswfSBGYWlsZWQgdG8gZGV0ZXJtaW5lIGlmIHRoZSAvc3lzIGlzIHdyaXRhYmxlOiAke21vZGV9IjsgZXhpdCAwOyB9CgppZiBbICIke21vZGV9IiA9ICJybyIgXTsgdGhlbgogICAgcmVzPSQoaXAgbmV0bnMgZXhlYyAiJHtuc30iIG1vdW50IC1vIHJlbW91bnQscncgL3N5cyAyPiYxKQogICAgWyAkPyAtZXEgMCBdIHx8IHsgbG9nZ2VyICIkezB9OiBGYWlsZWQgdG8gcmVtb3VudCAvc3lzIGFzIHJ3OiAke3Jlc30iOyBleGl0IDA7IH0KZmkKCiMgL3N5cy9jbGFzcy9uZXQgY2FuJ3QgYmUgdXNlZCByZWN1cnNpdmVseSB0byBmaW5kIHRoZSBycHNfY3B1cyBmaWxlLCB1c2UgL3N5cy9kZXZpY2VzIGluc3RlYWQKcmVzPSQoaXAgbmV0bnMgZXhlYyAiJHtuc30iIGZpbmQgL3N5cy9kZXZpY2VzIC10eXBlIGYgLW5hbWUgcnBzX2NwdXMgLWV4ZWMgc2ggLWMgImVjaG8gJHttYXNrfSB8IGNhdCA+IHt9IiBcOyAyPiYxKQpbWyAkPyAtZXEgMCAmJiAteiAiJHtyZXN9IiBdXSB8fCBsb2dnZXIgIiR7MH06IEZhaWxlZCB0byBhcHBseSB0aGUgUlBTIG1hc2s6ICR7cmVzfSIKCmlmIFsgIiR7bW9kZX0iID0gInJvIiBdOyB0aGVuCiAgICBpcCBuZXRucyBleGVjICIke25zfSIgbW91bnQgLW8gcmVtb3VudCxybyAvc3lzCiAgICBbICQ/IC1lcSAwIF0gfHwgZXhpdCAxICMgRXJyb3Igb3V0IHNvIHRoZSBwb2Qgd2lsbCBub3Qgc3RhcnQgd2l0aCBhIHdyaXRhYmxlIC9zeXMKZmkK
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/low-latency-hooks.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZGV2PSQxClsgLW4gIiR7ZGV2fSIgXSB8fCB7IGVjaG8gIlRoZSBkZXZpY2UgYXJndW1lbnQgaXMgbWlzc2luZyIgPiYyIDsgZXhpdCAxOyB9CgptYXNrPSQyClsgLW4gIiR7bWFza30iIF0gfHwgeyBlY2hvICJUaGUgbWFzayBhcmd1bWVudCBpcyBtaXNzaW5nIiA+JjIgOyBleGl0IDE7IH0KCmRldl9kaXI9Ii9zeXMvY2xhc3MvbmV0LyR7ZGV2fSIKCmZ1bmN0aW9uIGZpbmRfZGV2X2RpciB7CiAgc3lzdGVtZF9kZXZzPSQoc3lzdGVtY3RsIGxpc3QtdW5pdHMgLXQgZGV2aWNlIHwgZ3JlcCBzeXMtc3Vic3lzdGVtLW5ldC1kZXZpY2VzIHwgY3V0IC1kJyAnIC1mMSkKCiAgZm9yIHN5c3RlbWRfZGV2IGluICR7c3lzdGVtZF9kZXZzfTsgZG8KICAgIGRldl9zeXNmcz0kKHN5c3RlbWN0bCBzaG93ICIke3N5c3RlbWRfZGV2fSIgLXAgU3lzRlNQYXRoIC0tdmFsdWUpCgogICAgZGV2X29yaWdfbmFtZT0iJHtkZXZfc3lzZnMjIyovfSIKICAgIGlmIFsgIiR7ZGV2X29yaWdfbmFtZX0iID0gIiR7ZGV2fSIgXTsgdGhlbgogICAgICBkZXZfbmFtZT0iJHtzeXN0ZW1kX2RldiMjKi19IgogICAgICBkZXZfbmFtZT0iJHtkZXZfbmFtZSUlLmRldmljZX0iCiAgICAgIGlmIFsgIiR7ZGV2X25hbWV9IiA9ICIke2Rldn0iIF07IHRoZW4gIyBkaXNyZWdhcmQgdGhlIG9yaWdpbmFsIGRldmljZSB1bml0CiAgICAgICAgICAgICAgY29udGludWUKICAgICAgZmkKCiAgICAgIGVjaG8gIiR7ZGV2fSBkZXZpY2Ugd2FzIHJlbmFtZWQgdG8gJGRldl9uYW1lIgogICAgICBkZXZfZGlyPSIvc3lzL2NsYXNzL25ldC8ke2Rldl9uYW1lfSIKICAgICAgYnJlYWsKICAgIGZpCiAgZG9uZQp9CgpbIC1kICIke2Rldl9kaXJ9IiBdIHx8IGZpbmRfZGV2X2RpciAgICAgICAgICAgICAgICAjIHRoZSBuZXQgZGV2aWNlIHdhcyByZW5hbWVkLCBmaW5kIHRoZSBuZXcgbmFtZQpbIC1kICIke2Rldl9kaXJ9IiBdIHx8IHsgc2xlZXAgNTsgZmluZF9kZXZfZGlyOyB9ICAjIHNlYXJjaCBmYWlsZWQsIHdhaXQgYSBsaXR0bGUgYW5kIHRyeSBhZ2FpbgpbIC1kICIke2Rldl9kaXJ9IiBdIHx8IHsgZWNobyAiJHtkZXZfZGlyfSIgZGlyZWN0b3J5IG5vdCBmb3VuZCA+JjIgOyBleGl0IDA7IH0gIyB0aGUgaW50ZXJmYWNlIGRpc2FwcGVhcmVkLCBub3QgYW4gZXJyb3IKCmZpbmQgIiR7ZGV2X2Rpcn0iL3F1ZXVlcyAtdHlwZSBmIC1uYW1lIHJwc19jcHVzIC1leGVjIHNoIC1jICJlY2hvICR7bWFza30gfCBjYXQgPiB7fSIgXDs=
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/set-rps-mask.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWVdCmluZnJhX2N0cl9jcHVzZXQgPSAiMCIKCgojIFdlIHNob3VsZCBjb3B5IHBhc3RlIHRoZSBkZWZhdWx0IHJ1bnRpbWUgYmVjYXVzZSB0aGlzIHNuaXBwZXQgd2lsbCBvdmVycmlkZSB0aGUgd2hvbGUgcnVudGltZXMgc2VjdGlvbgpbY3Jpby5ydW50aW1lLnJ1bnRpbWVzLnJ1bmNdCnJ1bnRpbWVfcGF0aCA9ICIiCnJ1bnRpbWVfdHlwZSA9ICJvY2kiCnJ1bnRpbWVfcm9vdCA9ICIvcnVuL3J1bmMiCgojIFRoZSBDUkktTyB3aWxsIGNoZWNrIHRoZSBhbGxvd2VkX2Fubm90YXRpb25zIHVuZGVyIHRoZSBydW50aW1lIGhhbmRsZXIgYW5kIGFwcGx5IGhpZ2gtcGVyZm9ybWFuY2UgaG9va3Mgd2hlbiBvbmUgb2YKIyBoaWdoLXBlcmZvcm1hbmNlIGFubm90YXRpb25zIHByZXNlbnRzIHVuZGVyIGl0LgojIFdlIHNob3VsZCBwcm92aWRlIHRoZSBydW50aW1lX3BhdGggYmVjYXVzZSB3ZSBuZWVkIHRvIGluZm9ybSB0aGF0IHdlIHdhbnQgdG8gcmUtdXNlIHJ1bmMgYmluYXJ5IGFuZCB3ZQojIGRvIG5vdCBoYXZlIGhpZ2gtcGVyZm9ybWFuY2UgYmluYXJ5IHVuZGVyIHRoZSAkUEFUSCB0aGF0IHdpbGwgcG9pbnQgdG8gaXQuCltjcmlvLnJ1bnRpbWUucnVudGltZXMuaGlnaC1wZXJmb3JtYW5jZV0KcnVudGltZV9wYXRoID0gIi9iaW4vcnVuYyIKcnVudGltZV90eXBlID0gIm9jaSIKcnVudGltZV9yb290ID0gIi9ydW4vcnVuYyIKYWxsb3dlZF9hbm5vdGF0aW9ucyA9IFsiY3B1LWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LXF1b3RhLmNyaW8uaW8iLCAiaXJxLWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iXQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/99-runtimes.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,ewogICJ2ZXJzaW9uIjogIjEuMC4wIiwKICAiaG9vayI6IHsKICAgICJwYXRoIjogIi91c3IvbG9jYWwvYmluL2xvdy1sYXRlbmN5LWhvb2tzLnNoIiwKICAgICJhcmdzIjogWyJsb3ctbGF0ZW5jeS1ob29rcy5zaCIsICIwMDAwMDAwMSJdCiAgfSwKICAid2hlbiI6IHsKICAgICJhbHdheXMiOiB0cnVlCiAgfSwKICAic3RhZ2VzIjogWyJwcmVzdGFydCJdCn0K
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/containers/oci/hooks.d/99-low-latency-hooks.json
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,U1VCU1lTVEVNPT0ibmV0IiwgQUNUSU9OPT0iYWRkIiwgVEFHKz0ic3lzdGVtZCIsIEVOVntTWVNURU1EX1dBTlRTfT0idXBkYXRlLXJwc0Alay5zZXJ2aWNlIgo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/udev/rules.d/99-netdev-rps.rules
+        user: {}
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Hugepages-1048576kB allocation on the node 0
+          Before=kubelet.service
+
+          [Service]
+          Environment=HUGEPAGES_COUNT=1
+          Environment=HUGEPAGES_SIZE=1048576
+          Environment=NUMA_NODE=0
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/hugepages-allocation.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: hugepages-allocation-1048576kB-NUMA0.service
+      - contents: |
+          [Unit]
+          Description=Sets network devices RPS mask
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/set-rps-mask.sh %i 00000001
+        name: update-rps@.service
+  fips: false
+  kernelArguments: null
+  kernelType: realtime
+  osImageURL: ""

--- a/testdata/render-expected-output/manual_runtimeclass.yaml
+++ b/testdata/render-expected-output/manual_runtimeclass.yaml
@@ -1,0 +1,14 @@
+apiVersion: node.k8s.io/v1beta1
+handler: high-performance
+kind: RuntimeClass
+metadata:
+  creationTimestamp: null
+  name: performance-manual
+  ownerReferences:
+  - apiVersion: ""
+    kind: PerformanceProfile
+    name: manual
+    uid: ""
+scheduling:
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""

--- a/testdata/render-expected-output/manual_tuned.yaml
+++ b/testdata/render-expected-output/manual_tuned.yaml
@@ -1,0 +1,74 @@
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  creationTimestamp: null
+  name: openshift-node-performance-manual
+  namespace: openshift-cluster-node-tuning-operator
+  ownerReferences:
+  - apiVersion: ""
+    kind: PerformanceProfile
+    name: manual
+    uid: ""
+spec:
+  profile:
+  - data: "[main]\nsummary=Openshift node optimized for deterministic performance
+      at the cost of increased power consumption, focused on low latency network performance.
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
+      -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
+      All values are mapped with a comment where a parent profile contains them.\n#
+      Different values will override the original values in parent profiles.\n\n[variables]\n#
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1-3
+      \n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n[cpu]\nforce_latency=cstate.id:1|3
+      \                  #  latency-performance  (override)\ngovernor=performance
+      \                         #  latency-performance \nenergy_perf_bias=performance
+      \                 #  latency-performance \nmin_perf_pct=100                              #
+      \ latency-performance \n\n[service]\nservice.stalld=start,enable\n\n[vm]\ntransparent_hugepages=never
+      \                  #  network-latency\n\n\n[irqbalance]\n# Override the value
+      set by cpu-partitioning with an empty one\nbanned_cpus=\"\"\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\n\ndefault_irq_smp_affinity
+      = ignore\n\n\n[sysctl]\nkernel.hung_task_timeout_secs = 600           # cpu-partitioning
+      #realtime\nkernel.nmi_watchdog = 0                       # cpu-partitioning
+      #realtime\nkernel.sched_rt_runtime_us = -1               # realtime \nkernel.timer_migration
+      = 0                    # cpu-partitioning (= 1) #realtime (= 0)\nkernel.numa_balancing=0
+      \                      # network-latency\nnet.core.busy_read=50                         #
+      network-latency\nnet.core.busy_poll=50                         # network-latency\nnet.ipv4.tcp_fastopen=3
+      \                      # network-latency\nvm.stat_interval = 10                         #
+      cpu-partitioning  #realtime\n\n# ktune sysctl settings for rhel6 servers, maximizing
+      i/o throughput\n#\n# Minimal preemption granularity for CPU-bound tasks:\n#
+      (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)\nkernel.sched_min_granularity_ns=10000000
+      \     # latency-performance\n\n# If a workload mostly uses anonymous memory
+      and it hits this limit, the entire\n# working set is buffered for I/O, and any
+      more write buffering would require\n# swapping, so it's time to throttle writes
+      until I/O can catch up.  Workloads\n# that mostly use file mappings may be able
+      to use even higher values.\n#\n# The generator of dirty data starts writeback
+      at this percentage (system default\n# is 20%)\nvm.dirty_ratio=10                             #
+      latency-performance\n\n# Start background writeback (via writeback threads)
+      at this percentage (system\n# default is 10%)\nvm.dirty_background_ratio=3                   #
+      latency-performance\n\n# The swappiness parameter controls the tendency of the
+      kernel to move\n# processes out of physical memory and onto the swap disk.\n#
+      0 tells the kernel to avoid swapping processes out of physical memory\n# for
+      as long as possible\n# 100 tells the kernel to aggressively swap processes out
+      of physical memory\n# and move them to swap cache\nvm.swappiness=10                              #
+      latency-performance\n\n# The total time the scheduler will consider a migrated
+      process\n# \"cache hot\" and thus less likely to be re-migrated\n# (system default
+      is 500000, i.e. 0.5 ms)\nkernel.sched_migration_cost_ns=5000000        # latency-performance\n\n[selinux]\navc_cache_threshold=8192
+      \                     # Custom (atomic host)\n\n\n[net]\nnf_conntrack_hashsize=131072
+      \n\n\n[bootloader]\n# set empty values to disable RHEL initrd setting in cpu-partitioning
+      \ninitrd_remove_dir=     \ninitrd_dst_img=\ninitrd_add_dir=\n# overrides cpu-partitioning
+      cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask}
+      intel_pstate=disable nosoftlockup\n\ncmdline_realtime=+tsc=nowatchdog intel_iommu=on
+      iommu=pt isolcpus=managed_irq,${isolated_cores} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\ncmdline_hugepages=+
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \ncmdline_additionalArg=+
+      nmi_watchdog=0 audit=0 mce=off processor.max_cstate=1 idle=poll intel_idle.max_cstate=0
+      \n"
+    name: openshift-node-performance-manual
+  recommend:
+  - machineConfigLabels:
+      machineconfiguration.openshift.io/role: worker-cnf
+    operand:
+      debug: false
+    priority: 20
+    profile: openshift-node-performance-manual
+status: {}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -290,6 +290,7 @@ github.com/sirupsen/logrus
 ## explicit
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # github.com/vincent-petithory/dataurl v0.0.0-20191104211930-d1553a71de50
 github.com/vincent-petithory/dataurl


### PR DESCRIPTION
Render command gets performance-profile manifest as an input and based on the provided profile,
it creates manifests yaml of the corresponding CR's which should have been created by the profile.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>