### PR TITLE
[WIP] profile-creator: Add --info arg to PPC

### DIFF
--- a/pkg/profilecreator/profilecreator.go
+++ b/pkg/profilecreator/profilecreator.go
@@ -314,7 +314,7 @@ func (ghwHandler GHWHandler) GetReservedAndIsolatedCPUs(reservedCPUCount int, sp
 	if err != nil {
 		return cpuset.CPUSet{}, cpuset.CPUSet{}, fmt.Errorf("can't obtain Topology Info from GHW snapshot: %v", err)
 	}
-	htEnabled, err := ghwHandler.isHyperthreadingEnabled()
+	htEnabled, err := ghwHandler.IsHyperthreadingEnabled()
 	if err != nil {
 		return cpuset.CPUSet{}, cpuset.CPUSet{}, fmt.Errorf("can't determine if Hyperthreading is enabled or not: %v", err)
 	}
@@ -417,8 +417,8 @@ func addCoresToCPUSet(reservedCPUSet cpuset.Builder, max int, cores []*cpu.Proce
 	}
 }
 
-// isHyperthreadingEnabled checks if hyperthreading is enabled on the system or not
-func (ghwHandler GHWHandler) isHyperthreadingEnabled() (bool, error) {
+// IsHyperthreadingEnabled checks if hyperthreading is enabled on the system or not
+func (ghwHandler GHWHandler) IsHyperthreadingEnabled() (bool, error) {
 	cpuInfo, err := ghwHandler.CPU()
 	if err != nil {
 		return false, fmt.Errorf("can't obtain CPU Info from GHW snapshot: %v", err)

--- a/pkg/profilecreator/profilecreator_test.go
+++ b/pkg/profilecreator/profilecreator_test.go
@@ -625,12 +625,16 @@ var _ = Describe("PerformanceProfileCreator: Ensuring Nodes hardware equality", 
 
 			node1, err := getNode(mustGatherDirAbsolutePath, "worker1.yaml")
 			Expect(err).ToNot(HaveOccurred())
+			node1Handle, err := NewGHWHandler(mustGatherDirAbsolutePath, node1)
+			Expect(err).ToNot(HaveOccurred())
 
 			node2, err := getNode(mustGatherDirAbsolutePath, "worker1.yaml")
 			Expect(err).ToNot(HaveOccurred())
+			node2Handle, err := NewGHWHandler(mustGatherDirAbsolutePath, node2)
+			Expect(err).ToNot(HaveOccurred())
 
-			nodes := []*v1.Node{node1, node2}
-			err = EnsureNodesHaveTheSameHardware(mustGatherDirAbsolutePath, nodes)
+			nodeHandles := []*GHWHandler{node1Handle, node2Handle}
+			err = EnsureNodesHaveTheSameHardware(nodeHandles)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -642,12 +646,16 @@ var _ = Describe("PerformanceProfileCreator: Ensuring Nodes hardware equality", 
 
 			node1, err := getNode(mustGatherDirAbsolutePath, "worker1.yaml")
 			Expect(err).ToNot(HaveOccurred())
+			node1Handle, err := NewGHWHandler(mustGatherDirAbsolutePath, node1)
+			Expect(err).ToNot(HaveOccurred())
 
 			node2, err := getNode(mustGatherDirAbsolutePath, "worker2.yaml")
 			Expect(err).ToNot(HaveOccurred())
+			node2Handle, err := NewGHWHandler(mustGatherDirAbsolutePath, node2)
+			Expect(err).ToNot(HaveOccurred())
 
-			nodes := []*v1.Node{node1, node2}
-			err = EnsureNodesHaveTheSameHardware(mustGatherDirAbsolutePath, nodes)
+			nodeHandles := []*GHWHandler{node1Handle, node2Handle}
+			err = EnsureNodesHaveTheSameHardware(nodeHandles)
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
When the flag is set, only the must-gather argument is expected, all the other arguments are optional.
Show the cluster information and exit in this case.