### PR TITLE
[release 4.7] Enabled stalld only from a minimum kernel version

### DIFF
--- a/build/assets/tuned/openshift-node-performance
+++ b/build/assets/tuned/openshift-node-performance
@@ -18,6 +18,9 @@ isolated_cores={{.IsolatedCpus}}
 {{end}}
 
 not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
+# minimum kernel version applicable for enabling stalld is 4.18.0-240.22.1.el8_3.x86_64 or 4.18.0-240.22.1.rt7.77.el8_3.x86_64
+# starting kernel version for oc 4.7 is 4.18.0-240.10.1.el8_3.x86_64
+stalld_minimum_kernel_version_prefix=^Linux [^ ]+ (?!4\.18\.0-240\.([0-9]|1[0-9]|2[0-1])\.)
 
 [cpu]
 force_latency=cstate.id:1|3                   #  latency-performance  (override)
@@ -27,6 +30,7 @@ min_perf_pct=100                              #  latency-performance
 
 [service]
 service.stalld=start,enable
+uname_regex=${stalld_minimum_kernel_version_prefix}
 
 [vm]
 transparent_hugepages=never                   #  network-latency


### PR DESCRIPTION
stalld will be enabled by default only if the node
has a required kernel version where https://bugzilla.redhat.com/show_bug.cgi?id=1912118
and https://bugzilla.redhat.com/show_bug.cgi?id=1903302 where fixed.

The minimum kernel versions required for stalld if in oc 4.7 are
4.18.0-240.22.1.el8_3.x86_64
4.18.0-240.22.1.rt7.77.el8_3.x86_64

The enablement is determined by using tuned uname_regex option to check
if the kernel version prefix matches the minimum requirement

oc 4.7 kernel version starts from 4.18.0-240.10.1.el8_3.x86_64

Signed-off-by: Yanir Quinn <yquinn@redhat.com>