### PR TITLE
Increase tests timeout for single node test environments

### DIFF
--- a/functests/0_config/config.go
+++ b/functests/0_config/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/cluster"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
 	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/mcps"
@@ -33,7 +34,15 @@ import (
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/profile"
 )
 
+var RunningOnSingleNode bool
+
 var _ = Describe("[performance][config] Performance configuration", func() {
+
+	testutils.BeforeAll(func() {
+		isSNO, err := cluster.IsSingleNode()
+		Expect(err).ToNot(HaveOccurred())
+		RunningOnSingleNode = isSNO
+	})
 
 	It("Should successfully deploy the performance profile", func() {
 
@@ -73,7 +82,7 @@ var _ = Describe("[performance][config] Performance configuration", func() {
 					return nil
 				}
 				return err
-			}, 15*time.Minute, 15*time.Second).ShouldNot(HaveOccurred(), "Failed creating the performance profile")
+			}, cluster.ComputeTestTimeout(15*time.Minute, RunningOnSingleNode), 15*time.Second).ShouldNot(HaveOccurred(), "Failed creating the performance profile")
 		}
 
 		if !performanceMCP.Spec.Paused {

--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -23,6 +23,7 @@ import (
 	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/cluster"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/images"
 	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
@@ -40,6 +41,12 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 	var reservedCPU, isolatedCPU string
 	var listReservedCPU []int
 	var reservedCPUSet cpuset.CPUSet
+
+	testutils.BeforeAll(func() {
+		isSNO, err := cluster.IsSingleNode()
+		Expect(err).ToNot(HaveOccurred())
+		RunningOnSingleNode = isSNO
+	})
 
 	BeforeEach(func() {
 		if discovery.Enabled() && testutils.ProfileNotFound {
@@ -389,7 +396,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 					}
 				}
 				return true
-			}, 30*time.Second, 5*time.Second).Should(BeTrue(),
+			}, (cluster.ComputeTestTimeout(30*time.Second, RunningOnSingleNode)), 5*time.Second).Should(BeTrue(),
 				fmt.Sprintf("IRQ still active on CPU%s", psr))
 
 			By("Checking that after removing POD default smp affinity is returned back to all active CPUs")

--- a/functests/1_performance/hugepages.go
+++ b/functests/1_performance/hugepages.go
@@ -17,6 +17,7 @@ import (
 	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/cluster"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/discovery"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/images"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
@@ -28,6 +29,12 @@ import (
 var _ = Describe("[performance]Hugepages", func() {
 	var workerRTNode *corev1.Node
 	var profile *performancev2.PerformanceProfile
+
+	testutils.BeforeAll(func() {
+		isSNO, err := cluster.IsSingleNode()
+		Expect(err).ToNot(HaveOccurred())
+		RunningOnSingleNode = isSNO
+	})
 
 	BeforeEach(func() {
 		if discovery.Enabled() && testutils.ProfileNotFound {
@@ -150,7 +157,7 @@ var _ = Describe("[performance]Hugepages", func() {
 			Eventually(func() int {
 				freeHugepages := checkHugepagesStatus(freeHugepagesFile, workerRTNode)
 				return availableHugepages - freeHugepages
-			}, 30*time.Second, time.Second).Should(Equal(1))
+			}, cluster.ComputeTestTimeout(30*time.Second, RunningOnSingleNode), time.Second).Should(Equal(1))
 
 			By("checking hugepages usage in bytes")
 			usageHugepages = checkHugepagesStatus(usageHugepagesFile, workerRTNode)

--- a/functests/utils/cluster/cluster.go
+++ b/functests/utils/cluster/cluster.go
@@ -1,0 +1,31 @@
+package cluster
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+)
+
+// IsSingleNode validates if the environment is single node cluster
+func IsSingleNode() (bool, error) {
+	nodes := &corev1.NodeList{}
+	if err := testclient.Client.List(context.TODO(), nodes, &client.ListOptions{}); err != nil {
+		return false, err
+	}
+	return len(nodes.Items) == 1, nil
+}
+
+// ComputeTestTimeout returns the desired timeout for a test based on a given base timeout.
+// If the tested cluster is Single-Node it needs more time to react (due to being highly loaded) so we double the given timeout.
+func ComputeTestTimeout(baseTimeout time.Duration, isSno bool) time.Duration {
+	testTimeout := baseTimeout
+	if isSno {
+		testTimeout += baseTimeout
+	}
+
+	return testTimeout
+}


### PR DESCRIPTION
should provide similar functionality as https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/59 , giving SNO clusters longer timeouts