### PR TITLE
 Bug 1960386: [release 4.6] Update the tuned profile to set higher scheduler priority

### DIFF
--- a/build/assets/tuned/openshift-node-performance
+++ b/build/assets/tuned/openshift-node-performance
@@ -31,6 +31,10 @@ service.stalld=start,enable
 [vm]
 transparent_hugepages=never                   #  network-latency
 
+[scheduler]
+group.ksoftirqd=0:f:11:*:ksoftirqd.*
+group.rcuc=0:f:11:*:rcuc.*
+
 [sysctl]
 kernel.hung_task_timeout_secs = 600           # cpu-partitioning #realtime
 kernel.nmi_watchdog = 0                       # cpu-partitioning #realtime


### PR DESCRIPTION
The stalld service has higher priority than ksoftirqd, rcub and rcuc that
can lead to the system freeze under the load pressure. To avoid it we should
raise the scheduler priority of these threads to be higher than the stalld service.

Cherry picked partially from https://github.com/openshift-kni/performance-addon-operators/pull/462 