### PR TITLE
[release 4.6] Enabled stalld only from a minimum kernel version

### DIFF
--- a/build/assets/tuned/openshift-node-performance
+++ b/build/assets/tuned/openshift-node-performance
@@ -18,6 +18,8 @@ isolated_cores={{.IsolatedCpus}}
 {{end}}
 
 not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
+# minimum kernel version applicable for enabling stalld is 4.18.0-193.49.1.el8_2.x86_64
+stalld_minimum_kernel_version_prefix=^Linux [^ ]+ (?!4\.18\.0-193\.([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-8])\.)
 
 [cpu]
 force_latency=cstate.id:1|3                   #  latency-performance  (override)
@@ -27,6 +29,7 @@ min_perf_pct=100                              #  latency-performance
 
 [service]
 service.stalld=start,enable
+uname_regex=${stalld_minimum_kernel_version_prefix}
 
 [vm]
 transparent_hugepages=never                   #  network-latency

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -3,8 +3,10 @@ package __performance
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -177,12 +179,56 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 		})
 
 		It("[test_id:35363][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] stalld daemon is running on the host", func() {
-			Skip("until bugs https://bugzilla.redhat.com/show_bug.cgi?id=1912118 and https://bugzilla.redhat.com/show_bug.cgi?id=1903302 fixed")
+			stalldMinimumKernelVersionPrefix := "4.18.0-193.49"
+			minKernelPrefix := strings.Split(stalldMinimumKernelVersionPrefix, ".")
+			minSubVersion, err := strconv.Atoi(minKernelPrefix[3])
+			Expect(err).ToNot(HaveOccurred())
 			for _, node := range workerRTNodes {
-				tuned := tunedForNode(&node)
-				_, err := pods.ExecCommandOnPod(tuned, []string{"pidof", "stalld"})
-				Expect(err).ToNot(HaveOccurred())
+				cmd := []string{"uname", "-r"}
+				kernel, err := nodes.ExecCommandOnNode(cmd, &node)
+				Expect(err).ToNot(HaveOccurred(), "failed to execute uname")
+				currentKernelPrefix := strings.Split(kernel, ".")
+				currentSubVersion, err := strconv.Atoi(currentKernelPrefix[3])
+				// check if current kernel is a new rt batch stream (higher than 0-193)
+				if err != nil && strings.Contains(currentKernelPrefix[3], "rt") {
+					batchVersionStr := strings.Split(currentKernelPrefix[2], "-")
+					batchVersion, err := strconv.Atoi(batchVersionStr[1])
+					Expect(err).ToNot(HaveOccurred())
+					Expect(batchVersion > 193).Should(BeTrue(), fmt.Sprintf("Current kernel version %s is incompatible to the current oc release", kernel))
+					tuned := tunedForNode(&node)
+					_, err = pods.ExecCommandOnPod(tuned, []string{"pidof", "stalld"})
+					Expect(err).ToNot(HaveOccurred())
+				} else if currentSubVersion >= minSubVersion {
+					tuned := tunedForNode(&node)
+					_, err := pods.ExecCommandOnPod(tuned, []string{"pidof", "stalld"})
+					Expect(err).ToNot(HaveOccurred())
+				}
 			}
+		})
+
+		It("[test_id:41768][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] stalld daemon is not running on the host", func() {
+			By("Running on a kernel version lower than 4.18.0-193.49.*")
+			randomWorkerNode := workerRTNodes[rand.Intn(len(workerRTNodes))]
+			tuned := tunedForNode(&randomWorkerNode)
+			customUnameCmd := []string{"sed", "-i", "$ a uname_string = 4\\.18\\.0-193\\.48\\.1\\.el8_2\\.x86_64", "/etc/tuned/tuned-main.conf"}
+			_, err := pods.ExecCommandOnPod(tuned, customUnameCmd)
+			Expect(err).ToNot(HaveOccurred())
+			// kill tuned process will cause it to spin up again and reload the profile
+			// (tuned service restart cannot be done via pod command execution)
+			killTunedCmd := []string{"pkill", "^tuned"}
+			_, err = pods.ExecCommandOnPod(tuned, killTunedCmd)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() error {
+				_, err := pods.ExecCommandOnPod(tuned, []string{"pidof", "stalld"})
+				return err
+			}, 5*time.Minute, 10*time.Second).Should(HaveOccurred(),
+				"stalld should not be enabled for kernel version lower than 4.18.0-193.49.1.el8_2.x86_64")
+			revertCustomUnameCmd := []string{"sed", "-i", "/uname_string = 4\\.18\\.0-193\\.48\\.1\\.el8_2\\.x86_64/d", "/etc/tuned/tuned-main.conf"}
+			_, err = pods.ExecCommandOnPod(tuned, revertCustomUnameCmd)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = pods.ExecCommandOnPod(tuned, killTunedCmd)
+			Expect(err).ToNot(HaveOccurred())
+			validatTunedActiveProfile(workerRTNodes)
 		})
 	})
 


### PR DESCRIPTION
stalld will be enabled by default only if the node
has a required kernel version where https://bugzilla.redhat.com/show_bug.cgi?id=1912118
and https://bugzilla.redhat.com/show_bug.cgi?id=1903302 where fixed.

RHEL 8.2.z released with the fixed kernel: **kernel-4.18.0-193.49.1.el8_2** 

The enablement is determined by using tuned uname_regex option to check
if the kernel version prefix matches the minimum requirement
