### PR TITLE
gather_sysinfo: collect sched_domain flags

### DIFF
--- a/tools/gather-sysinfo/gather-sysinfo.go
+++ b/tools/gather-sysinfo/gather-sysinfo.go
@@ -142,6 +142,7 @@ func kniExpectedCloneContent() []string {
 		"/proc/softirqs",
 		// KNI-specific CPU infos:
 		"/sys/devices/system/cpu/smt/active",
+		"/proc/sys/kernel/sched_domain/cpu*/domain*/flags",
 		// BIOS/firmware versions
 		"/sys/class/dmi/id/bios*",
 		"/sys/class/dmi/id/product_family",


### PR DESCRIPTION
This is helpful to check the load balancing state of the cpus.

Signed-off-by: Francesco Romani <fromani@redhat.com>