### PR TITLE
update the contributor groups

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,25 +2,20 @@
 
 aliases:
   performance-reviewers:
-    - karmab
     - MarSik
-    - simon3z
     - fedepaol
     - SchSeba
     - fromanirh
     - cynepco3hahue
     - yanirq
-    - marcel-apf
     - swatisehgal
     - Tal-or
   performance-approvers:
-    - karmab
     - MarSik
-    - simon3z
     - fedepaol
     - SchSeba
     - fromanirh
     - cynepco3hahue
     - yanirq
-    - marcel-apf
     - swatisehgal
+    - Tal-or


### PR DESCRIPTION
Reflect the active contributors in the OWNERS_ALIASES.

Signed-off-by: Francesco Romani <fromani@redhat.com>