### PR TITLE
Performance Profile creator tests

### DIFF
--- a/testdata/ppc-expected-profiles/profile3.json
+++ b/testdata/ppc-expected-profiles/profile3.json
@@ -1,0 +1,11 @@
+{
+    "must-gather-dir-path": "must-gather.bare-metal",
+    "mcp-name": "worker-cnf",
+    "reserved-cpu-count": 5,
+    "disable-ht": true,
+    "rt-kernel": true,
+    "split-reserved-cpus-across-numa": true,
+    "user-level-networking": false
+}
+    
+    

--- a/testdata/ppc-expected-profiles/profile3.yaml
+++ b/testdata/ppc-expected-profiles/profile3.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  additionalKernelArgs:
+  - nosmt
+  cpu:
+    isolated: 5-39
+    reserved: 0-4
+  machineConfigPoolSelector:
+    machineconfiguration.openshift.io/role: worker-cnf
+  net:
+    userLevelNetworking: false
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true

--- a/testdata/ppc-expected-profiles/profile4.json
+++ b/testdata/ppc-expected-profiles/profile4.json
@@ -1,0 +1,10 @@
+{
+    "must-gather-dir-path": "must-gather.bare-metal",
+    "mcp-name": "worker-cnf",
+    "reserved-cpu-count": 12,
+    "rt-kernel": true,
+    "disable-ht": true, 
+    "user-level-networking": false
+}
+    
+    

--- a/testdata/ppc-expected-profiles/profile4.yaml
+++ b/testdata/ppc-expected-profiles/profile4.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  additionalKernelArgs:
+  - nosmt
+  cpu:
+    isolated: 1,3,5,7,9,11,13,15,17,19,21,23-39
+    reserved: 0,2,4,6,8,10,12,14,16,18,20,22
+  machineConfigPoolSelector:
+    machineconfiguration.openshift.io/role: worker-cnf
+  net:
+    userLevelNetworking: false
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true

--- a/testdata/ppc-expected-profiles/profile5.json
+++ b/testdata/ppc-expected-profiles/profile5.json
@@ -1,0 +1,9 @@
+{
+    "must-gather-dir-path": "must-gather.bare-metal",
+    "mcp-name": "worker-cnf",
+    "reserved-cpu-count": 4,
+    "disable-ht": false,
+    "rt-kernel": true,
+    "split-reserved-cpus-across-numa": true,
+    "user-level-networking": false
+}

--- a/testdata/ppc-expected-profiles/profile5.yaml
+++ b/testdata/ppc-expected-profiles/profile5.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    isolated: 2-39,42-79
+    reserved: 0-1,40-41
+  machineConfigPoolSelector:
+    machineconfiguration.openshift.io/role: worker-cnf
+  net:
+    userLevelNetworking: false
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+  numa:
+    topologyPolicy: restricted
+  realTimeKernel:
+    enabled: true


### PR DESCRIPTION
Add tests related Performance Profile creator scripts. 
1. Negative scenarios:  Add tests cases where wrong arguments are passed to ppc script
2.  Expand regression tests to include HT disabled. 
Code in these test cases has been written in collaboration with [Tinashe Chipomho](https://github.com/CloudGrimm)