### PR TITLE
Mitigate the OLM problem to pass annotations to the deployment

### DIFF
--- a/deploy/olm-catalog/performance-addon-operator/4.8.0/performance-addon-operator.v4.8.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.8.0/performance-addon-operator.v4.8.0.clusterserviceversion.yaml
@@ -124,6 +124,7 @@ metadata:
     operators.operatorframework.io/builder: operator-sdk-v1.0.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
     repository: https://github.com/openshift-kni/performance-addon-operators
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
   name: performance-addon-operator.v4.8.0
   namespace: placeholder
 spec:

--- a/hack/annotations.json
+++ b/hack/annotations.json
@@ -1,5 +1,6 @@
 {
     "description": "Operator to optimize OpenShift clusters for applications sensitive to CPU and network latency.",
-    "repository": "https://github.com/openshift-kni/performance-addon-operators"
+    "repository": "https://github.com/openshift-kni/performance-addon-operators",
+    "target.workload.openshift.io/management": "{\"effect\": \"PreferredDuringScheduling\"}"
 }
 


### PR DESCRIPTION
Currently, the OLM propagates to the deployment annotations specified under CSV metadata and not the one specified under the install deployment.

See BZ https://bugzilla.redhat.com/show_bug.cgi?id=1950047 for more details.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>