### PR TITLE
Bug 1957291: add resource request and toleration's to the operator

### DIFF
--- a/deploy/olm-catalog/performance-addon-operator/4.8.0/performance-addon-operator.v4.8.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.8.0/performance-addon-operator.v4.8.0.clusterserviceversion.yaml
@@ -239,11 +239,23 @@ spec:
                 image: REPLACE_IMAGE
                 imagePullPolicy: Always
                 name: performance-operator
-                resources: {}
+                resources:
+                  requests:
+                    cpu: 10m
+                    memory: 25Mi
               serviceAccountName: performance-operator
               tolerations:
               - effect: NoSchedule
                 key: node-role.kubernetes.io/master
+                operator: Exists
+              - effect: NoExecute
+                key: node.kubernetes.io/unreachable
+                operator: Exists
+                tolerationSeconds: 120
+              - effect: NoExecute
+                key: node.kubernetes.io/not-ready
+                operator: Exists
+                tolerationSeconds: 120
       permissions:
       - rules:
         - apiGroups:


### PR DESCRIPTION
Add resource request to be sure that our operator pod will have buarstable QoS.
Add tolerations to be sure that our operator will not evict because of CPU or
memory consumptions peaks.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>