### PR TITLE
Improve error output for render E2E test

### DIFF
--- a/functests-render-command/1_render_command/render_suite_test.go
+++ b/functests-render-command/1_render_command/render_suite_test.go
@@ -1,16 +1,17 @@
 package __render_command_test
 
 import (
-	"github.com/openshift-kni/performance-addon-operators/functests/utils/junit"
-	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
-
 	"fmt"
 	"path/filepath"
 	"runtime"
 	"testing"
 
+	"github.com/ghodss/yaml"
+	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/junit"
+	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
 
 var (
@@ -41,3 +42,18 @@ var _ = BeforeSuite(func() {
 	binPath = filepath.Clean(filepath.Join(workspaceDir, "build", "_output", "bin"))
 	fmt.Fprintf(GinkgoWriter, "using binary at %q\n", binPath)
 })
+
+func getFilesDiff(wantFile, gotFile []byte) (string, error) {
+	var wantObj interface{}
+	var gotObj interface{}
+
+	if err := yaml.Unmarshal(wantFile, &wantObj); err != nil {
+		return "", fmt.Errorf("failed to unmarshal data for 'want':%s", err)
+	}
+
+	if err := yaml.Unmarshal(gotFile, &gotObj); err != nil {
+		return "", fmt.Errorf("failed to unmarshal data for 'got':%s", err)
+	}
+
+	return cmp.Diff(wantObj, gotObj), nil
+}

--- a/functests-render-command/1_render_command/render_test.go
+++ b/functests-render-command/1_render_command/render_test.go
@@ -1,7 +1,6 @@
 package __render_command_test
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -96,12 +95,10 @@ func runAndCompare(cmd *exec.Cmd) {
 		data, err := ioutil.ReadFile(filepath.Join(assetsOutDir, f.Name()))
 		Expect(err).ToNot(HaveOccurred())
 
-		res := bytes.Compare(data, refData)
-		if res != 0 {
-			fmt.Fprintf(GinkgoWriter, "files: %q and %q are not identical\n",
-				filepath.Join(refPath, f.Name()),
-				filepath.Join(assetsOutDir, f.Name()))
-		}
-		Expect(res).To(BeZero())
+		diff, err := getFilesDiff(data, refData)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(diff).To(BeZero(), "rendered %s file is not identical to its reference file; diff: %v",
+			f.Name(),
+			diff)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/go-openapi/strfmt v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.9 // indirect
 	github.com/go-openapi/validate v0.19.8 // indirect
+	github.com/google/go-cmp v0.5.2
 	github.com/jaypipes/ghw v0.7.1-0.20210419135914-b8b1e31b27f5
 	github.com/mitchellh/mapstructure v1.2.2 // indirect
 	github.com/onsi/ginkgo v1.12.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -125,6 +125,7 @@ github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
 # github.com/google/go-cmp v0.5.2
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags


### PR DESCRIPTION
Error output will reflect the exact difference between the files.
Inspired by https://github.com/openshift-kni/debug-tools/pull/34/commits/5e264aafde413f0f247ac16155c52dad4888b1f7

Signed-off-by: Talor Itzhak <titzhak@redhat.com>