### PR TITLE
 Fix code to test number of Hugepages per numa node(4.6)

### DIFF
--- a/functests/2_performance_update/updating_profile.go
+++ b/functests/2_performance_update/updating_profile.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,6 +26,8 @@ import (
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
 )
 
+type checkFunction func(*corev1.Node) (string, error)
+
 var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance profile", func() {
 	var workerRTNodes []corev1.Node
 	var profile, initialProfile *performancev1.PerformanceProfile
@@ -34,8 +37,29 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 	chkCmdLine := []string{"cat", "/proc/cmdline"}
 	chkKubeletConfig := []string{"cat", "/rootfs/etc/kubernetes/kubelet.conf"}
 	chkIrqbalance := []string{"cat", "/rootfs/etc/sysconfig/irqbalance"}
-	chkHp2M := []string{"cat", "/sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages"}
-	chkHp1G := []string{"cat", "/sys/devices/system/node/node0/hugepages/hugepages-1048576kB/nr_hugepages"}
+
+	chkCmdLineFn := func(node *corev1.Node) (string, error) {
+		return nodes.ExecCommandOnNode(chkCmdLine, node)
+	}
+	chkKubeletConfigFn := func(node *corev1.Node) (string, error) {
+		return nodes.ExecCommandOnNode(chkKubeletConfig, node)
+	}
+
+	chkHugepages2MFn := func(node *corev1.Node) (string, error) {
+		count, err := countHugepagesOnNode(node, 2)
+		if err != nil {
+			return "", err
+		}
+		return strconv.Itoa(count), nil
+	}
+
+	chkHugepages1GFn := func(node *corev1.Node) (string, error) {
+		count, err := countHugepagesOnNode(node, 1024)
+		if err != nil {
+			return "", err
+		}
+		return strconv.Itoa(count), nil
+	}
 
 	nodeLabel := testutils.NodeSelectorLabels
 
@@ -114,12 +138,11 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
 		})
 
-		table.DescribeTable("Verify that profile parameters were updated", func(cmd, parameter []string, shouldContain bool, useRegex bool) {
+		table.DescribeTable("Verify that profile parameters were updated", func(cmdFn checkFunction, parameter []string, shouldContain bool, useRegex bool) {
 			for _, node := range workerRTNodes {
 				for _, param := range parameter {
-					result, err := nodes.ExecCommandOnNode(cmd, &node)
-					Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to execute %s", cmd))
-
+					result, err := cmdFn(&node)
+					Expect(err).ToNot(HaveOccurred())
 					matcher := ContainSubstring(param)
 					if useRegex {
 						matcher = MatchRegexp(param)
@@ -133,16 +156,16 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 				}
 			}
 		},
-			table.Entry("[test_id:34081] verify that hugepages size and count updated", chkCmdLine, []string{"default_hugepagesz=2M", "hugepagesz=1G", "hugepages=3"}, true, false),
-			table.Entry("[test_id:28070] verify that hugepages updated (NUMA node unspecified)", chkCmdLine, []string{"hugepagesz=2M"}, true, false),
-			table.Entry("verify that the right number of hugepages 1G is available on the system", chkHp1G, []string{"3"}, true, false),
-			table.Entry("verify that the right number of hugepages 2M is available on the system", chkHp2M, []string{"256"}, true, false),
-			table.Entry("[test_id:28025] verify that cpu affinity mask was updated", chkCmdLine, []string{"tuned.non_isolcpus=.*9"}, true, true),
-			table.Entry("[test_id:28071] verify that cpu balancer disabled", chkCmdLine, []string{"isolcpus=domain,managed_irq,1-2"}, true, false),
-			table.Entry("[test_id:28071] verify that cpu balancer disabled", chkCmdLine, []string{"systemd.cpu_affinity=0,3"}, true, false),
+			table.Entry("[test_id:34081] verify that hugepages size and count updated", chkCmdLineFn, []string{"default_hugepagesz=2M", "hugepagesz=1G", "hugepages=3"}, true, false),
+			table.Entry("[test_id:28070] verify that hugepages updated (NUMA node unspecified)", chkCmdLineFn, []string{"hugepagesz=2M"}, true, false),
+			table.Entry("verify that the right number of hugepages 1G is available on the system", chkHugepages1GFn, []string{"3"}, true, false),
+			table.Entry("verify that the right number of hugepages 2M is available on the system", chkHugepages2MFn, []string{"256"}, true, false),
+			table.Entry("[test_id:28025] verify that cpu affinity mask was updated", chkCmdLineFn, []string{"tuned.non_isolcpus=.*9"}, true, true),
+			table.Entry("[test_id:28071] verify that cpu balancer disabled", chkCmdLineFn, []string{"isolcpus=domain,managed_irq,1-2"}, true, false),
+			table.Entry("[test_id:28071] verify that cpu balancer disabled", chkCmdLineFn, []string{"systemd.cpu_affinity=0,3"}, true, false),
 			// kubelet.conf changed formatting, there is a space after colons atm. Let's deal with both cases with a regex
-			table.Entry("[test_id:28935] verify that reservedSystemCPUs was updated", chkKubeletConfig, []string{`"reservedSystemCPUs": ?"0,3"`}, true, true),
-			table.Entry("[test_id:28760] verify that topologyManager was updated", chkKubeletConfig, []string{`"topologyManagerPolicy": ?"best-effort"`}, true, true),
+			table.Entry("[test_id:28935] verify that reservedSystemCPUs was updated", chkKubeletConfigFn, []string{`"reservedSystemCPUs": ?"0,3"`}, true, true),
+			table.Entry("[test_id:28760] verify that topologyManager was updated", chkKubeletConfigFn, []string{`"topologyManagerPolicy": ?"best-effort"`}, true, true),
 		)
 
 		It("[test_id:27738] should succeed to disable the RT kernel", func() {
@@ -335,3 +358,28 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		})
 	})
 })
+
+func hugepagesPathForNode(nodeID, sizeINMb int) string {
+	return fmt.Sprintf("/sys/devices/system/node/node%d/hugepages/hugepages-%dkB/nr_hugepages", nodeID, sizeINMb*1024)
+}
+
+func countHugepagesOnNode(node *corev1.Node, sizeInMb int) (int, error) {
+	numaInfo, err := nodes.GetNumaNodes(node)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for i := 0; i < len(numaInfo); i++ {
+		nodeCmd := []string{"cat", hugepagesPathForNode(i, sizeInMb)}
+		result, err := nodes.ExecCommandOnNode(nodeCmd, node)
+		if err != nil {
+			return 0, err
+		}
+		t, err := strconv.Atoi(result)
+		if err != nil {
+			return 0, err
+		}
+		count += t
+	}
+	return count, nil
+}

--- a/functests/utils/nodes/nodes.go
+++ b/functests/utils/nodes/nodes.go
@@ -2,8 +2,10 @@ package nodes
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -18,6 +20,17 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// NumaNodes defines cpus in each numa node
+type NumaNodes struct {
+	Cpus []NodeCPU `json:"cpus"`
+}
+
+// NodeCPU Structure
+type NodeCPU struct {
+	CPU  string `json:"cpu"`
+	Node string `json:"node"`
+}
 
 // GetByRole returns all nodes with the specified role
 func GetByRole(role string) ([]corev1.Node, error) {
@@ -183,4 +196,30 @@ func HasPreemptRTKernel(node *corev1.Node) error {
 	}
 
 	return nil
+}
+
+// GetNumaNodes returns the number of numa nodes and the associated cpus as list on the node
+func GetNumaNodes(node *corev1.Node) (map[int][]int, error) {
+	lscpuCmd := []string{"lscpu", "-e=cpu,node", "-J"}
+	cmdout, err := ExecCommandOnNode(lscpuCmd, node)
+	var numaNode, cpu int
+	if err != nil {
+		return nil, err
+	}
+	numaCpus := make(map[int][]int)
+	var result NumaNodes
+	err = json.Unmarshal([]byte(cmdout), &result)
+	if err != nil {
+		return nil, err
+	}
+	for _, value := range result.Cpus {
+		if numaNode, err = strconv.Atoi(value.Node); err != nil {
+			break
+		}
+		if cpu, err = strconv.Atoi(value.CPU); err != nil {
+			break
+		}
+		numaCpus[numaNode] = append(numaCpus[numaNode], cpu)
+	}
+	return numaCpus, err
 }


### PR DESCRIPTION
Backporting to 4.6

    functests/nodes: Add function to return numa nodes and associated cpus of the node Add shared function GetNumaNodes which returns the number of numa nodes and the associated cpus

    Fix functests/2_performance/updating_profile: fix test to get number of hugepages. Modify the test code to get the numa nodes and then fetch fetch 1G and 2M hugepages per numa node..
