### PR TITLE
Fix discovery mode tests on SNO

### DIFF
--- a/functests/utils/consts.go
+++ b/functests/utils/consts.go
@@ -59,6 +59,9 @@ func init() {
 		NodeSelectorLabels = profile.Spec.NodeSelector
 		if NodesSelector != "" {
 			keyValue := strings.Split(NodesSelector, "=")
+			if len(keyValue) == 1 {
+				keyValue = append(keyValue, "")
+			}
 			NodeSelectorLabels[keyValue[0]] = keyValue[1]
 		}
 	}


### PR DESCRIPTION
This commit fix the node selector in discovery mode

environment variables:

```
CLEAN_PERFORMANCE_PROFILE=false
NODES_SELECTOR=node-role.kubernetes.io/master
ROLE_WORKER_CNF=master
DISCOVERY_MODE=true
```

error:

```
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
github.com/openshift-kni/performance-addon-operators/functests/utils.init.0()
	/home/sscheink/Documents/GolangProjects/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/utils/consts.go:62 +0x76f

Debugger finished with the exit code 0
```

Signed-off-by: Sebastian Sch <sebassch@gmail.com>