### PR TITLE
[release-4.8] Bug 1975348: Do not create systemd update-rps service for veth devices

### DIFF
--- a/build/assets/configs/99-netdev-rps.rules
+++ b/build/assets/configs/99-netdev-rps.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="net", ACTION=="add", TAG+="systemd", ENV{SYSTEMD_WANTS}="update-rps@%k.service"
+SUBSYSTEM=="net", ACTION=="add", ENV{DEVPATH}!="/devices/virtual/net/veth*", TAG+="systemd", ENV{SYSTEMD_WANTS}="update-rps@%k.service"

--- a/build/assets/scripts/low-latency-hooks.sh
+++ b/build/assets/scripts/low-latency-hooks.sh
@@ -9,6 +9,14 @@ pid=$(jq '.pid' /dev/stdin 2>&1)
 ns=$(ip netns identify "${pid}" 2>&1)
 [[ $? -eq 0 && -n "${ns}" ]] || { logger "${0} Failed to identify the namespace: ${ns}"; exit 0; }
 
+# Updates the container veth RPS mask on the node
+netns_link_indexes=$(ip netns exec "${ns}" ip -j link | jq ".[] | select(.link_index != null) | .link_index")
+for link_index in ${netns_link_indexes}; do
+  container_veth=$(ip -j link | jq ".[] | select(.ifindex == ${link_index}) | .ifname" | tr -d '"')
+  echo ${mask} > /sys/devices/virtual/net/${container_veth}/queues/rx-0/rps_cpus
+done
+
+# Updates the RPS mask for the interface inside of the container network namespace
 mode=$(ip netns exec "${ns}" [ -w /sys ] && echo "rw" || echo "ro" 2>&1)
 [ $? -eq 0 ] || { logger "${0} Failed to determine if the /sys is writable: ${mode}"; exit 0; }
 


### PR DESCRIPTION
Bug 1967317: Do not create systemd update-rps service for veth devices

(cherry picked from commit 33b9640cf1f780fa1c9d2bc441fe5ecbf340b39a)
Signed-off-by: Artyom Lukianov <alukiano@redhat.com>