### PR TITLE
Enable workload partitioning work

### DIFF
--- a/build/assets/configs/01-workload-partitioning.conf
+++ b/build/assets/configs/01-workload-partitioning.conf
@@ -1,0 +1,4 @@
+[crio.runtime.workloads.management]
+activation_annotation = "target.workload.openshift.io/management"
+annotation_prefix = "resources.workload.openshift.io"
+resources = { "cpuset" = "{{.ReservedCpus}}" }

--- a/build/assets/configs/openshift-workload-pinning.json
+++ b/build/assets/configs/openshift-workload-pinning.json
@@ -1,0 +1,5 @@
+{
+  "management": {
+    "cpuset": "{{.ReservedCpus}}"
+  }
+}

--- a/controllers/performanceprofile_controller_test.go
+++ b/controllers/performanceprofile_controller_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/kubeletconfig"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/machineconfig"
+	pinfo "github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/profileinfo"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/runtimeclass"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/tuned"
 	testutils "github.com/openshift-kni/performance-addon-operators/pkg/utils/testing"
@@ -333,8 +334,9 @@ var _ = Describe("Controller", func() {
 
 			BeforeEach(func() {
 				var err error
-
-				mc, err = machineconfig.New(assetsDir, profile)
+				profileInfo := &pinfo.PerformanceProfileInfo{}
+				profileInfo.PerformanceProfile = *profile
+				mc, err = machineconfig.New(assetsDir, profileInfo)
 				Expect(err).ToNot(HaveOccurred())
 
 				mcpSelectorKey, mcpSelectorValue := components.GetFirstKeyAndValue(profile.Spec.MachineConfigPoolSelector)
@@ -782,7 +784,9 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should remove all components and remove the finalizer on first reconcile loop", func() {
-			mc, err := machineconfig.New(assetsDir, profile)
+			profileInfo := &pinfo.PerformanceProfileInfo{}
+			profileInfo.PerformanceProfile = *profile
+			mc, err := machineconfig.New(assetsDir, profileInfo)
 			Expect(err).ToNot(HaveOccurred())
 
 			mcpSelectorKey, mcpSelectorValue := components.GetFirstKeyAndValue(profile.Spec.MachineConfigPoolSelector)

--- a/functests-render-command/1_render_command/render_test.go
+++ b/functests-render-command/1_render_command/render_test.go
@@ -16,55 +16,109 @@ var (
 	assetsInDir  string
 	ppInFiles    string
 	testDataPath string
+	refPath      string
+	cmdLineArgs  []string
+	envVars      []string
 )
 
 var _ = Describe("render command e2e test", func() {
-
 	BeforeEach(func() {
 		assetsOutDir = createTempAssetsDir()
 		assetsInDir = filepath.Join(workspaceDir, "build", "assets")
 		ppInFiles = filepath.Join(workspaceDir, "cluster-setup", "manual-cluster", "performance", "performance_profile.yaml")
 		testDataPath = filepath.Join(workspaceDir, "testdata")
+		refPath = filepath.Join(testDataPath, "render-expected-output")
+
+		cmdLineArgs = []string{
+			filepath.Join(binPath, "performance-addon-operators"),
+			"render",
+		}
+		envVars = []string{}
 	})
 
-	Context("With a single performance-profile", func() {
-		It("Gets cli args and produces the expected components to output directory", func() {
+	JustBeforeEach(func() {
+		fmt.Fprintf(GinkgoWriter, "running: %v\n", cmdLineArgs)
+		cmd := exec.Command(cmdLineArgs[0], cmdLineArgs[1:]...)
+		cmd.Env = append(cmd.Env, envVars...)
+		_, err := cmd.Output()
+		Expect(err).ToNot(HaveOccurred())
+	})
 
-			cmdline := []string{
-				filepath.Join(binPath, "performance-addon-operators"),
-				"render",
+	Context("with a single performance-profile and command line args", func() {
+		BeforeEach(func() {
+			cmdLineArgs = append(cmdLineArgs,
 				"--performance-profile-input-files", ppInFiles,
 				"--asset-input-dir", assetsInDir,
 				"--asset-output-dir", assetsOutDir,
-			}
-			fmt.Fprintf(GinkgoWriter, "running: %v\n", cmdline)
-
-			cmd := exec.Command(cmdline[0], cmdline[1:]...)
-			runAndCompare(cmd)
-
+			)
 		})
 
-		It("Gets environment variables and produces the expected components to output directory", func() {
-			cmdline := []string{
-				filepath.Join(binPath, "performance-addon-operators"),
-				"render",
-			}
-			fmt.Fprintf(GinkgoWriter, "running: %v\n", cmdline)
+		It("should produces the expected components to output directory", func() {
+			file, diff, err := cmpRenderToRef()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(diff).To(BeEmpty(), "rendered %s file is not identical to its reference file; diff: %v", file, diff)
+		})
+	})
 
-			cmd := exec.Command(cmdline[0], cmdline[1:]...)
-			cmd.Env = append(cmd.Env,
+	Context("with a single performance-profile and environment variables", func() {
+		BeforeEach(func() {
+			envVars = append(envVars,
 				fmt.Sprintf("PERFORMANCE_PROFILE_INPUT_FILES=%s", ppInFiles),
 				fmt.Sprintf("ASSET_INPUT_DIR=%s", assetsInDir),
 				fmt.Sprintf("ASSET_OUTPUT_DIR=%s", assetsOutDir),
 			)
-			runAndCompare(cmd)
+		})
+
+		It("should produces the expected components to output directory", func() {
+			file, diff, err := cmpRenderToRef()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(diff).To(BeEmpty(), "rendered %s file is not identical to its reference file; diff: %v", file, diff)
+		})
+	})
+
+	Context("with workload-partition enabled and command line args", func() {
+		BeforeEach(func() {
+			cmdLineArgs = append(cmdLineArgs,
+				"--performance-profile-input-files", ppInFiles,
+				"--asset-input-dir", assetsInDir,
+				"--asset-output-dir", assetsOutDir,
+				"--enable-workload-partitioning",
+			)
+		})
+
+		It("should have the configuration under machineconfig file", func() {
+			renderedMachineConfig := "manual_machineconfig.yaml"
+			refMachineConfig := "manual_machineconfig_with_workload.yaml"
+
+			diff, err := cmpRenderToRefMC(renderedMachineConfig, refMachineConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(diff).To(BeEmpty(), "rendered %s file is not identical to its reference file; diff: %v", renderedMachineConfig, diff)
+		})
+	})
+
+	Context("with workload-partition enabled and environment variables", func() {
+		BeforeEach(func() {
+			envVars = append(envVars,
+				fmt.Sprintf("PERFORMANCE_PROFILE_INPUT_FILES=%s", ppInFiles),
+				fmt.Sprintf("ASSET_INPUT_DIR=%s", assetsInDir),
+				fmt.Sprintf("ASSET_OUTPUT_DIR=%s", assetsOutDir),
+				fmt.Sprintf("ENABLE_WORKLOAD_PARTITIONING=true"),
+			)
+		})
+
+		It("should have the configuration under machineconfig file", func() {
+			renderedMachineConfig := "manual_machineconfig.yaml"
+			refMachineConfig := "manual_machineconfig_with_workload.yaml"
+
+			diff, err := cmpRenderToRefMC(renderedMachineConfig, refMachineConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(diff).To(BeEmpty(), "rendered %s file is not identical to its reference file; diff: %v", renderedMachineConfig, diff)
 		})
 	})
 
 	AfterEach(func() {
 		cleanArtifacts()
 	})
-
 })
 
 func createTempAssetsDir() string {
@@ -78,27 +132,48 @@ func cleanArtifacts() {
 	os.RemoveAll(assetsOutDir)
 }
 
-func runAndCompare(cmd *exec.Cmd) {
-	_, err := cmd.Output()
-	Expect(err).ToNot(HaveOccurred())
-
+func cmpRenderToRef() (string, string, error) {
 	outputAssetsFiles, err := ioutil.ReadDir(assetsOutDir)
-	Expect(err).ToNot(HaveOccurred())
+	if err != nil {
+		return "", "", err
+	}
 
-	refPath := filepath.Join(testDataPath, "render-expected-output")
 	fmt.Fprintf(GinkgoWriter, "reference data at: %q\n", refPath)
 
 	for _, f := range outputAssetsFiles {
 		refData, err := ioutil.ReadFile(filepath.Join(refPath, f.Name()))
-		Expect(err).ToNot(HaveOccurred())
+		if err != nil {
+			return f.Name(), "", err
+		}
 
 		data, err := ioutil.ReadFile(filepath.Join(assetsOutDir, f.Name()))
-		Expect(err).ToNot(HaveOccurred())
+		if err != nil {
+			return f.Name(), "", err
+		}
 
 		diff, err := getFilesDiff(data, refData)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(diff).To(BeZero(), "rendered %s file is not identical to its reference file; diff: %v",
-			f.Name(),
-			diff)
+		if err != nil {
+			return f.Name(), "", err
+		}
+
+		if len(diff) != 0 {
+			return f.Name(), diff, nil
+		}
 	}
+	return "", "", nil
+}
+
+func cmpRenderToRefMC(render, ref string) (string, error) {
+	fmt.Fprintf(GinkgoWriter, "reference data at: %q\n", refPath)
+	refData, err := ioutil.ReadFile(filepath.Join(refPath, ref))
+	if err != nil {
+		return "", err
+	}
+
+	data, err := ioutil.ReadFile(filepath.Join(assetsOutDir, render))
+	if err != nil {
+		return "", err
+	}
+
+	return getFilesDiff(data, refData)
 }

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Machine Config", func() {
 
 	Context("machine config creation ", func() {
 		It("should create machine config with valid assests", func() {
-			profile := testutils.NewPerformanceProfile("test")
+			profile := testutils.NewPerformanceProfileInfo("test")
 			profile.Spec.HugePages.Pages[0].Node = pointer.Int32Ptr(0)
 
 			_, err := New(testAssetsDir, profile)
@@ -52,7 +52,8 @@ var _ = Describe("Machine Config", func() {
 		var manifest string
 
 		BeforeEach(func() {
-			profile := testutils.NewPerformanceProfile("test")
+			profile := testutils.NewPerformanceProfileInfo("test")
+			profile.PerformanceProfile = *testutils.NewPerformanceProfile("test")
 			profile.Spec.HugePages.Pages[0].Node = pointer.Int32Ptr(0)
 
 			labelKey, labelValue := components.GetFirstKeyAndValue(profile.Spec.MachineConfigLabel)

--- a/pkg/controller/performanceprofile/components/manifestset/manifestset.go
+++ b/pkg/controller/performanceprofile/components/manifestset/manifestset.go
@@ -1,10 +1,10 @@
 package manifestset
 
 import (
-	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/kubeletconfig"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/machineconfig"
 	profilecomponent "github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/profile"
+	pinfo "github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/profileinfo"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/runtimeclass"
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/tuned"
 	tunedv1 "github.com/openshift/cluster-node-tuning-operator/pkg/apis/tuned/v1"
@@ -49,25 +49,25 @@ func (ms *ManifestResultSet) ToManifestTable() ManifestTable {
 }
 
 // GetNewComponents return a list of all component's instances that should be created according to profile
-func GetNewComponents(profile *performancev2.PerformanceProfile, profileMCP *mcov1.MachineConfigPool, assetDir *string) (*ManifestResultSet, error) {
-	machineConfigPoolSelector := profilecomponent.GetMachineConfigPoolSelector(profile, profileMCP)
+func GetNewComponents(profileInfo *pinfo.PerformanceProfileInfo, profileMCP *mcov1.MachineConfigPool, assetDir *string) (*ManifestResultSet, error) {
+	machineConfigPoolSelector := profilecomponent.GetMachineConfigPoolSelector(&profileInfo.PerformanceProfile, profileMCP)
 
-	mc, err := machineconfig.New(*assetDir, profile)
+	mc, err := machineconfig.New(*assetDir, profileInfo)
 	if err != nil {
 		return nil, err
 	}
 
-	kc, err := kubeletconfig.New(profile, machineConfigPoolSelector)
+	kc, err := kubeletconfig.New(&profileInfo.PerformanceProfile, machineConfigPoolSelector)
 	if err != nil {
 		return nil, err
 	}
 
-	performanceTuned, err := tuned.NewNodePerformance(*assetDir, profile)
+	performanceTuned, err := tuned.NewNodePerformance(*assetDir, &profileInfo.PerformanceProfile)
 	if err != nil {
 		return nil, err
 	}
 
-	runtimeClass := runtimeclass.New(profile, machineconfig.HighPerformanceRuntime)
+	runtimeClass := runtimeclass.New(&profileInfo.PerformanceProfile, machineconfig.HighPerformanceRuntime)
 
 	manifestResultSet := ManifestResultSet{
 		MachineConfig: mc,

--- a/pkg/controller/performanceprofile/components/profileinfo/profileinfo.go
+++ b/pkg/controller/performanceprofile/components/profileinfo/profileinfo.go
@@ -1,0 +1,10 @@
+package profileinfo
+
+import performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
+
+// PerformanceProfileInfo is a wrapper for PerformanceProfile that can hold extra data and configuration
+type PerformanceProfileInfo struct {
+	performancev2.PerformanceProfile
+	// extra data the operator cares about but which is not part of the public API
+	WorkloadPartitionEnabled bool
+}

--- a/pkg/utils/testing/testing.go
+++ b/pkg/utils/testing/testing.go
@@ -2,6 +2,7 @@ package testing
 
 import (
 	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
+	pinfo "github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/profileinfo"
 	mcov1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,4 +98,12 @@ func NewProfileMCP() *mcov1.MachineConfigPool {
 			},
 		},
 	}
+}
+
+// NewPerformanceProfileInfo returns new PerformanceProfileInfo used for testing
+func NewPerformanceProfileInfo(name string) *pinfo.PerformanceProfileInfo {
+	return &pinfo.PerformanceProfileInfo{
+		PerformanceProfile: *NewPerformanceProfile(name),
+	}
+
 }

--- a/testdata/render-expected-output/manual_machineconfig_with_workload.yaml
+++ b/testdata/render-expected-output/manual_machineconfig_with_workload.yaml
@@ -1,0 +1,114 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  creationTimestamp: null
+  labels:
+    machineconfiguration.openshift.io/role: worker-cnf
+  name: 50-performance-manual
+  ownerReferences:
+  - apiVersion: ""
+    kind: PerformanceProfile
+    name: manual
+    uid: ""
+spec:
+  config:
+    ignition:
+      config:
+        replace:
+          verification: {}
+      proxy: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKc2V0IC1ldW8gcGlwZWZhaWwKCm5vZGVzX3BhdGg9Ii9zeXMvZGV2aWNlcy9zeXN0ZW0vbm9kZSIKaHVnZXBhZ2VzX2ZpbGU9IiR7bm9kZXNfcGF0aH0vbm9kZSR7TlVNQV9OT0RFfS9odWdlcGFnZXMvaHVnZXBhZ2VzLSR7SFVHRVBBR0VTX1NJWkV9a0IvbnJfaHVnZXBhZ2VzIgoKaWYgWyAhIC1mICIke2h1Z2VwYWdlc19maWxlfSIgXTsgdGhlbgogIGVjaG8gIkVSUk9SOiAke2h1Z2VwYWdlc19maWxlfSBkb2VzIG5vdCBleGlzdCIKICBleGl0IDEKZmkKCnRpbWVvdXQ9NjAKc2FtcGxlPTEKY3VycmVudF90aW1lPTAKd2hpbGUgWyAiJChjYXQgIiR7aHVnZXBhZ2VzX2ZpbGV9IikiIC1uZSAiJHtIVUdFUEFHRVNfQ09VTlR9IiBdOyBkbwogIGVjaG8gIiR7SFVHRVBBR0VTX0NPVU5UfSIgPiIke2h1Z2VwYWdlc19maWxlfSIKCiAgY3VycmVudF90aW1lPSQoKGN1cnJlbnRfdGltZSArIHNhbXBsZSkpCiAgaWYgWyAkY3VycmVudF90aW1lIC1ndCAkdGltZW91dCBdOyB0aGVuCiAgICBlY2hvICJFUlJPUjogJHtodWdlcGFnZXNfZmlsZX0gZG9lcyBub3QgaGF2ZSB0aGUgZXhwZWN0ZWQgbnVtYmVyIG9mIGh1Z2VwYWdlcyAke0hVR0VQQUdFU19DT1VOVH0iCiAgICBleGl0IDEKICBmaQoKICBzbGVlcCAkc2FtcGxlCmRvbmUK
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/hugepages-allocation.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKbWFzaz0iJHsxfSIKWyAtbiAiJHttYXNrfSIgXSB8fCB7IGxvZ2dlciAiJHswfTogVGhlIHJwcy1tYXNrIHBhcmFtZXRlciBpcyBtaXNzaW5nIiA7IGV4aXQgMDsgfQoKcGlkPSQoanEgJy5waWQnIC9kZXYvc3RkaW4gMj4mMSkKW1sgJD8gLWVxIDAgJiYgLW4gIiR7cGlkfSIgXV0gfHwgeyBsb2dnZXIgIiR7MH06IEZhaWxlZCB0byBleHRyYWN0IHRoZSBwaWQ6ICR7cGlkfSI7IGV4aXQgMDsgfQoKbnM9JChpcCBuZXRucyBpZGVudGlmeSAiJHtwaWR9IiAyPiYxKQpbWyAkPyAtZXEgMCAmJiAtbiAiJHtuc30iIF1dIHx8IHsgbG9nZ2VyICIkezB9IEZhaWxlZCB0byBpZGVudGlmeSB0aGUgbmFtZXNwYWNlOiAke25zfSI7IGV4aXQgMDsgfQoKIyBVcGRhdGVzIHRoZSBjb250YWluZXIgdmV0aCBSUFMgbWFzayBvbiB0aGUgbm9kZQpuZXRuc19saW5rX2luZGV4ZXM9JChpcCBuZXRucyBleGVjICIke25zfSIgaXAgLWogbGluayB8IGpxICIuW10gfCBzZWxlY3QoLmxpbmtfaW5kZXggIT0gbnVsbCkgfCAubGlua19pbmRleCIpCmZvciBsaW5rX2luZGV4IGluICR7bmV0bnNfbGlua19pbmRleGVzfTsgZG8KICBjb250YWluZXJfdmV0aD0kKGlwIC1qIGxpbmsgfCBqcSAiLltdIHwgc2VsZWN0KC5pZmluZGV4ID09ICR7bGlua19pbmRleH0pIHwgLmlmbmFtZSIgfCB0ciAtZCAnIicpCiAgZWNobyAke21hc2t9ID4gL3N5cy9kZXZpY2VzL3ZpcnR1YWwvbmV0LyR7Y29udGFpbmVyX3ZldGh9L3F1ZXVlcy9yeC0wL3Jwc19jcHVzCmRvbmUKCiMgVXBkYXRlcyB0aGUgUlBTIG1hc2sgZm9yIHRoZSBpbnRlcmZhY2UgaW5zaWRlIG9mIHRoZSBjb250YWluZXIgbmV0d29yayBuYW1lc3BhY2UKbW9kZT0kKGlwIG5ldG5zIGV4ZWMgIiR7bnN9IiBbIC13IC9zeXMgXSAmJiBlY2hvICJydyIgfHwgZWNobyAicm8iIDI+JjEpClsgJD8gLWVxIDAgXSB8fCB7IGxvZ2dlciAiJHswfSBGYWlsZWQgdG8gZGV0ZXJtaW5lIGlmIHRoZSAvc3lzIGlzIHdyaXRhYmxlOiAke21vZGV9IjsgZXhpdCAwOyB9CgppZiBbICIke21vZGV9IiA9ICJybyIgXTsgdGhlbgogICAgcmVzPSQoaXAgbmV0bnMgZXhlYyAiJHtuc30iIG1vdW50IC1vIHJlbW91bnQscncgL3N5cyAyPiYxKQogICAgWyAkPyAtZXEgMCBdIHx8IHsgbG9nZ2VyICIkezB9OiBGYWlsZWQgdG8gcmVtb3VudCAvc3lzIGFzIHJ3OiAke3Jlc30iOyBleGl0IDA7IH0KZmkKCiMgL3N5cy9jbGFzcy9uZXQgY2FuJ3QgYmUgdXNlZCByZWN1cnNpdmVseSB0byBmaW5kIHRoZSBycHNfY3B1cyBmaWxlLCB1c2UgL3N5cy9kZXZpY2VzIGluc3RlYWQKcmVzPSQoaXAgbmV0bnMgZXhlYyAiJHtuc30iIGZpbmQgL3N5cy9kZXZpY2VzIC10eXBlIGYgLW5hbWUgcnBzX2NwdXMgLWV4ZWMgc2ggLWMgImVjaG8gJHttYXNrfSB8IGNhdCA+IHt9IiBcOyAyPiYxKQpbWyAkPyAtZXEgMCAmJiAteiAiJHtyZXN9IiBdXSB8fCBsb2dnZXIgIiR7MH06IEZhaWxlZCB0byBhcHBseSB0aGUgUlBTIG1hc2s6ICR7cmVzfSIKCmlmIFsgIiR7bW9kZX0iID0gInJvIiBdOyB0aGVuCiAgICBpcCBuZXRucyBleGVjICIke25zfSIgbW91bnQgLW8gcmVtb3VudCxybyAvc3lzCiAgICBbICQ/IC1lcSAwIF0gfHwgZXhpdCAxICMgRXJyb3Igb3V0IHNvIHRoZSBwb2Qgd2lsbCBub3Qgc3RhcnQgd2l0aCBhIHdyaXRhYmxlIC9zeXMKZmkK
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/low-latency-hooks.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,IyEvdXNyL2Jpbi9lbnYgYmFzaAoKZGV2PSQxClsgLW4gIiR7ZGV2fSIgXSB8fCB7IGVjaG8gIlRoZSBkZXZpY2UgYXJndW1lbnQgaXMgbWlzc2luZyIgPiYyIDsgZXhpdCAxOyB9CgptYXNrPSQyClsgLW4gIiR7bWFza30iIF0gfHwgeyBlY2hvICJUaGUgbWFzayBhcmd1bWVudCBpcyBtaXNzaW5nIiA+JjIgOyBleGl0IDE7IH0KCmRldl9kaXI9Ii9zeXMvY2xhc3MvbmV0LyR7ZGV2fSIKCmZ1bmN0aW9uIGZpbmRfZGV2X2RpciB7CiAgc3lzdGVtZF9kZXZzPSQoc3lzdGVtY3RsIGxpc3QtdW5pdHMgLXQgZGV2aWNlIHwgZ3JlcCBzeXMtc3Vic3lzdGVtLW5ldC1kZXZpY2VzIHwgY3V0IC1kJyAnIC1mMSkKCiAgZm9yIHN5c3RlbWRfZGV2IGluICR7c3lzdGVtZF9kZXZzfTsgZG8KICAgIGRldl9zeXNmcz0kKHN5c3RlbWN0bCBzaG93ICIke3N5c3RlbWRfZGV2fSIgLXAgU3lzRlNQYXRoIC0tdmFsdWUpCgogICAgZGV2X29yaWdfbmFtZT0iJHtkZXZfc3lzZnMjIyovfSIKICAgIGlmIFsgIiR7ZGV2X29yaWdfbmFtZX0iID0gIiR7ZGV2fSIgXTsgdGhlbgogICAgICBkZXZfbmFtZT0iJHtzeXN0ZW1kX2RldiMjKi19IgogICAgICBkZXZfbmFtZT0iJHtkZXZfbmFtZSUlLmRldmljZX0iCiAgICAgIGlmIFsgIiR7ZGV2X25hbWV9IiA9ICIke2Rldn0iIF07IHRoZW4gIyBkaXNyZWdhcmQgdGhlIG9yaWdpbmFsIGRldmljZSB1bml0CiAgICAgICAgICAgICAgY29udGludWUKICAgICAgZmkKCiAgICAgIGVjaG8gIiR7ZGV2fSBkZXZpY2Ugd2FzIHJlbmFtZWQgdG8gJGRldl9uYW1lIgogICAgICBkZXZfZGlyPSIvc3lzL2NsYXNzL25ldC8ke2Rldl9uYW1lfSIKICAgICAgYnJlYWsKICAgIGZpCiAgZG9uZQp9CgpbIC1kICIke2Rldl9kaXJ9IiBdIHx8IGZpbmRfZGV2X2RpciAgICAgICAgICAgICAgICAjIHRoZSBuZXQgZGV2aWNlIHdhcyByZW5hbWVkLCBmaW5kIHRoZSBuZXcgbmFtZQpbIC1kICIke2Rldl9kaXJ9IiBdIHx8IHsgc2xlZXAgNTsgZmluZF9kZXZfZGlyOyB9ICAjIHNlYXJjaCBmYWlsZWQsIHdhaXQgYSBsaXR0bGUgYW5kIHRyeSBhZ2FpbgpbIC1kICIke2Rldl9kaXJ9IiBdIHx8IHsgZWNobyAiJHtkZXZfZGlyfSIgZGlyZWN0b3J5IG5vdCBmb3VuZCA+JjIgOyBleGl0IDA7IH0gIyB0aGUgaW50ZXJmYWNlIGRpc2FwcGVhcmVkLCBub3QgYW4gZXJyb3IKCmZpbmQgIiR7ZGV2X2Rpcn0iL3F1ZXVlcyAtdHlwZSBmIC1uYW1lIHJwc19jcHVzIC1leGVjIHNoIC1jICJlY2hvICR7bWFza30gfCBjYXQgPiB7fSIgXDs=
+          verification: {}
+        group: {}
+        mode: 448
+        path: /usr/local/bin/set-rps-mask.sh
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,CltjcmlvLnJ1bnRpbWVdCmluZnJhX2N0cl9jcHVzZXQgPSAiMCIKCgojIFdlIHNob3VsZCBjb3B5IHBhc3RlIHRoZSBkZWZhdWx0IHJ1bnRpbWUgYmVjYXVzZSB0aGlzIHNuaXBwZXQgd2lsbCBvdmVycmlkZSB0aGUgd2hvbGUgcnVudGltZXMgc2VjdGlvbgpbY3Jpby5ydW50aW1lLnJ1bnRpbWVzLnJ1bmNdCnJ1bnRpbWVfcGF0aCA9ICIiCnJ1bnRpbWVfdHlwZSA9ICJvY2kiCnJ1bnRpbWVfcm9vdCA9ICIvcnVuL3J1bmMiCgojIFRoZSBDUkktTyB3aWxsIGNoZWNrIHRoZSBhbGxvd2VkX2Fubm90YXRpb25zIHVuZGVyIHRoZSBydW50aW1lIGhhbmRsZXIgYW5kIGFwcGx5IGhpZ2gtcGVyZm9ybWFuY2UgaG9va3Mgd2hlbiBvbmUgb2YKIyBoaWdoLXBlcmZvcm1hbmNlIGFubm90YXRpb25zIHByZXNlbnRzIHVuZGVyIGl0LgojIFdlIHNob3VsZCBwcm92aWRlIHRoZSBydW50aW1lX3BhdGggYmVjYXVzZSB3ZSBuZWVkIHRvIGluZm9ybSB0aGF0IHdlIHdhbnQgdG8gcmUtdXNlIHJ1bmMgYmluYXJ5IGFuZCB3ZQojIGRvIG5vdCBoYXZlIGhpZ2gtcGVyZm9ybWFuY2UgYmluYXJ5IHVuZGVyIHRoZSAkUEFUSCB0aGF0IHdpbGwgcG9pbnQgdG8gaXQuCltjcmlvLnJ1bnRpbWUucnVudGltZXMuaGlnaC1wZXJmb3JtYW5jZV0KcnVudGltZV9wYXRoID0gIi9iaW4vcnVuYyIKcnVudGltZV90eXBlID0gIm9jaSIKcnVudGltZV9yb290ID0gIi9ydW4vcnVuYyIKYWxsb3dlZF9hbm5vdGF0aW9ucyA9IFsiY3B1LWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iLCAiY3B1LXF1b3RhLmNyaW8uaW8iLCAiaXJxLWxvYWQtYmFsYW5jaW5nLmNyaW8uaW8iXQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/99-runtimes.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,W2NyaW8ucnVudGltZS53b3JrbG9hZHMubWFuYWdlbWVudF0KYWN0aXZhdGlvbl9hbm5vdGF0aW9uID0gInRhcmdldC53b3JrbG9hZC5vcGVuc2hpZnQuaW8vbWFuYWdlbWVudCIKYW5ub3RhdGlvbl9wcmVmaXggPSAicmVzb3VyY2VzLndvcmtsb2FkLm9wZW5zaGlmdC5pbyIKcmVzb3VyY2VzID0geyAiY3B1c2V0IiA9ICIwIiB9Cg==
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/crio/crio.conf.d/01-workload-partitioning.conf
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,ewogICJtYW5hZ2VtZW50IjogewogICAgImNwdXNldCI6ICIwIgogIH0KfQo=
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/kubernetes/openshift-workload-pinning.json
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,ewogICJ2ZXJzaW9uIjogIjEuMC4wIiwKICAiaG9vayI6IHsKICAgICJwYXRoIjogIi91c3IvbG9jYWwvYmluL2xvdy1sYXRlbmN5LWhvb2tzLnNoIiwKICAgICJhcmdzIjogWyJsb3ctbGF0ZW5jeS1ob29rcy5zaCIsICIwMDAwMDAwMSJdCiAgfSwKICAid2hlbiI6IHsKICAgICJhbHdheXMiOiB0cnVlCiAgfSwKICAic3RhZ2VzIjogWyJwcmVzdGFydCJdCn0K
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/containers/oci/hooks.d/99-low-latency-hooks.json
+        user: {}
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,U1VCU1lTVEVNPT0ibmV0IiwgQUNUSU9OPT0iYWRkIiwgRU5We0RFVlBBVEh9IT0iL2RldmljZXMvdmlydHVhbC9uZXQvdmV0aCoiLCBUQUcrPSJzeXN0ZW1kIiwgRU5We1NZU1RFTURfV0FOVFN9PSJ1cGRhdGUtcnBzQCVrLnNlcnZpY2UiCg==
+          verification: {}
+        group: {}
+        mode: 420
+        path: /etc/udev/rules.d/99-netdev-rps.rules
+        user: {}
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Hugepages-1048576kB allocation on the node 0
+          Before=kubelet.service
+
+          [Service]
+          Environment=HUGEPAGES_COUNT=1
+          Environment=HUGEPAGES_SIZE=1048576
+          Environment=NUMA_NODE=0
+          Type=oneshot
+          RemainAfterExit=true
+          ExecStart=/usr/local/bin/hugepages-allocation.sh
+
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: hugepages-allocation-1048576kB-NUMA0.service
+      - contents: |
+          [Unit]
+          Description=Sets network devices RPS mask
+
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/set-rps-mask.sh %i 00000001
+        name: update-rps@.service
+  extensions: null
+  fips: false
+  kernelArguments: null
+  kernelType: realtime
+  osImageURL: ""


### PR DESCRIPTION
This PR contains 2 main parts:
1. PerformanceProfileInfo struct which is purpose is to allow the operator to handle extra data which it cares about, but it's not part of the public API.
2. Allow render command to add the necessary bits and bytes to ```MachineConfig``` object in order to enable the workload partitioning feature.

The API for the ```WorkloadPartition```  is still missing, hence only the logic for the render command was implemented.

Once the ```WorkloadPartition``` will be available through the API, I'll post additional PR with the logic for watching the object inside the reconciliation loop and update the ```MachineConfig``` accordingly.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>