### PR TITLE
e2e: Reactivate stalld test

### DIFF
--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -201,7 +201,6 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 		})
 
 		It("[test_id:32375][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] initramfs should not have injected configuration", func() {
-			Skip("Skipping test until BZ#1858347 is resolved")
 			for _, node := range workerRTNodes {
 				rhcosId, err := nodes.ExecCommandOnMachineConfigDaemon(&node, []string{"awk", "-F", "/", "{printf $3}", "/rootfs/proc/cmdline"})
 				Expect(err).ToNot(HaveOccurred())

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -214,7 +214,6 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 		})
 
 		It("[test_id:35363][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] stalld daemon is running on the host", func() {
-			Skip("until bugs https://bugzilla.redhat.com/show_bug.cgi?id=1912118 and https://bugzilla.redhat.com/show_bug.cgi?id=1903302 fixed")
 			for _, node := range workerRTNodes {
 				tuned := tunedForNode(&node)
 				_, err := pods.ExecCommandOnPod(tuned, []string{"pidof", "stalld"})


### PR DESCRIPTION
Now that bugzillas 1912118 and 1903302 got resolved, we can remove the
skip from the stalld test again.