### PR TITLE
Enable the memory manager

### DIFF
--- a/pkg/controller/performanceprofile/components/kubeletconfig/kubeletconfig_test.go
+++ b/pkg/controller/performanceprofile/components/kubeletconfig/kubeletconfig_test.go
@@ -9,7 +9,14 @@ import (
 
 	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
 	testutils "github.com/openshift-kni/performance-addon-operators/pkg/utils/testing"
+	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+	"k8s.io/utils/pointer"
 )
+
+const testReservedMemory = `reservedMemory:
+    - limits:
+        memory: 1100Mi
+      numaNode: 0`
 
 var _ = Describe("Kubelet Config", func() {
 	It("should generate yaml with expected parameters", func() {
@@ -27,5 +34,39 @@ var _ = Describe("Kubelet Config", func() {
 		Expect(manifest).To(ContainSubstring("reservedSystemCPUs: 0-3"))
 		Expect(manifest).To(ContainSubstring("topologyManagerPolicy: single-numa-node"))
 		Expect(manifest).To(ContainSubstring("cpuManagerPolicy: static"))
+		Expect(manifest).To(ContainSubstring("memoryManagerPolicy: Static"))
+		Expect(manifest).To(ContainSubstring(testReservedMemory))
+	})
+
+	Context("with topology manager restricted policy", func() {
+		It("should have the memory manager related parameters", func() {
+			profile := testutils.NewPerformanceProfile("test")
+			profile.Spec.NUMA.TopologyPolicy = pointer.String(kubeletconfigv1beta1.RestrictedTopologyManagerPolicy)
+			kc, err := New(profile)
+			Expect(err).ToNot(HaveOccurred())
+
+			y, err := yaml.Marshal(kc)
+			Expect(err).ToNot(HaveOccurred())
+
+			manifest := string(y)
+			Expect(manifest).To(ContainSubstring("memoryManagerPolicy: Static"))
+			Expect(manifest).To(ContainSubstring(testReservedMemory))
+		})
+	})
+
+	Context("with topology manager best-effort policy", func() {
+		It("should not have the memory manager related parameters", func() {
+			profile := testutils.NewPerformanceProfile("test")
+			profile.Spec.NUMA.TopologyPolicy = pointer.String(kubeletconfigv1beta1.BestEffortTopologyManagerPolicy)
+			kc, err := New(profile)
+			Expect(err).ToNot(HaveOccurred())
+
+			y, err := yaml.Marshal(kc)
+			Expect(err).ToNot(HaveOccurred())
+
+			manifest := string(y)
+			Expect(manifest).ToNot(ContainSubstring("memoryManagerPolicy: Static"))
+			Expect(manifest).ToNot(ContainSubstring(testReservedMemory))
+		})
 	})
 })

--- a/testdata/render-expected-output/manual_kubeletconfig.yaml
+++ b/testdata/render-expected-output/manual_kubeletconfig.yaml
@@ -22,6 +22,8 @@ spec:
         cacheUnauthorizedTTL: 0s
     cpuManagerPolicy: static
     cpuManagerReconcilePeriod: 5s
+    evictionHard:
+      memory.available: 100Mi
     evictionPressureTransitionPeriod: 0s
     fileCheckFrequency: 0s
     httpCheckFrequency: 0s
@@ -31,8 +33,13 @@ spec:
       cpu: 1000m
       memory: 500Mi
     logging: {}
+    memoryManagerPolicy: Static
     nodeStatusReportFrequency: 0s
     nodeStatusUpdateFrequency: 0s
+    reservedMemory:
+      - limits:
+          memory: 1100Mi
+        numaNode: 0
     reservedSystemCPUs: "0"
     runtimeRequestTimeout: 0s
     shutdownGracePeriod: 0s


### PR DESCRIPTION
Set the memory manager policy to `Static` and reserve
the memory on the NUMA node 0. The amount of reserved memory
equals `kube-reserved + system-reserved + hard eviction threshold`.

**Note to reviewers:**
I will provide e2e tests under the separate PR once the rebase on top of k8s 1.22 done.


Signed-off-by: Artyom Lukianov <alukiano@redhat.com>