### PR TITLE
Latency tests: remove a condition which is always false

### DIFF
--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -359,12 +359,6 @@ func extractLatencyValues(testName string, exp string, node *corev1.Node) string
 // HWLATDETECT_MAXIMUM_LATENCY: the expected maximum latency for all buckets in us
 // MAXIMUM_LATENCY: unified expected maximum latency for all tests
 func setMaximumLatencyValue(testName string) error {
-	if testName != strings.ToUpper(oslatTestName) &&
-		testName != strings.ToUpper(cyclictestTestName) &&
-		testName != strings.ToUpper(hwlatdetectTestName) {
-		return fmt.Errorf("testName variable has incorrect value %q", testName)
-	}
-
 	var err error
 	unifiedMaxLatencyEnv := os.Getenv("MAXIMUM_LATENCY")
 	if unifiedMaxLatencyEnv != "" {


### PR DESCRIPTION
**Why this fix is needed:**
An issue was discovered during a local build of the cnf-test image that @shajmakh did.
She built the image from https://github.com/Tal-or/cnf-features-deploy/tree/ship_hwlatdetect_cyclictest and ran the latency test which failed with ```"testName variable has incorrect value..."```
a careful examination of the code shows that this check will always fail, IOW the condition will always be false and it will throw this message and exit the test. 

**How do we fix it**
Removing the faulty check. In the first place, this check was intended to verify some flow which eventually was not written at all.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>