### PR TITLE
kubelet: enable podresources feature gate

### DIFF
--- a/functests/1_performance/kubelet_config.go
+++ b/functests/1_performance/kubelet_config.go
@@ -1,0 +1,37 @@
+package __performance
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	kubefeatures "k8s.io/kubernetes/pkg/features"
+
+	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
+)
+
+var _ = Describe("Kubelet configuration", func() {
+	var workerRTNodes []corev1.Node
+
+	BeforeEach(func() {
+		var err error
+		workerRTNodes, err = nodes.GetByLabels(testutils.NodeSelectorLabels)
+		Expect(err).ToNot(HaveOccurred())
+		workerRTNodes, err = nodes.MatchingOptionalSelector(workerRTNodes)
+		Expect(err).ToNot(HaveOccurred(), "Error looking for the optional selector: %v", err)
+		Expect(workerRTNodes).ToNot(BeEmpty(), "No RT worker node found!")
+	})
+
+	It("should have enabled the podresources GetAllocatable API", func() {
+		kubeletConfig, err := nodes.GetKubeletConfig(&workerRTNodes[0])
+		Expect(err).ToNot(HaveOccurred())
+
+		testlog.Infof("kubelet config for %q: %#v", workerRTNodes[0].Name, kubeletConfig)
+
+		Expect(kubeletConfig.FeatureGates).ToNot(BeNil(), "no feature gates enabled at all!")
+		podresourcesEnabled := kubeletConfig.FeatureGates[string(kubefeatures.KubeletPodResourcesGetAllocatable)]
+		Expect(podresourcesEnabled).To(BeTrue(), "podresources feature gate not enabled on node %q", workerRTNodes[0].Name)
+	})
+})

--- a/pkg/controller/performanceprofile/components/kubeletconfig/kubeletconfig.go
+++ b/pkg/controller/performanceprofile/components/kubeletconfig/kubeletconfig.go
@@ -12,6 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
+	kubefeatures "k8s.io/kubernetes/pkg/features"
 )
 
 const (
@@ -40,6 +41,9 @@ func New(profile *performancev2.PerformanceProfile) (*machineconfigv1.KubeletCon
 		SystemReserved: map[string]string{
 			"cpu":    defaultSystemReservedCPU,
 			"memory": defaultSystemReservedMemory,
+		},
+		FeatureGates: map[string]bool{
+			string(kubefeatures.KubeletPodResourcesGetAllocatable): true,
 		},
 	}
 


### PR DESCRIPTION
We will need this feature to enable TAS.
It's pretty safe to enable - noone is actually consuming
the API at the moment, so we do it early.

Signed-off-by: Francesco Romani <fromani@redhat.com>