### PR TITLE
add the OCP label index under metadata annotations

### DIFF
--- a/deploy/metadata/performance-addon-operator/4.9.0/annotations.yaml
+++ b/deploy/metadata/performance-addon-operator/4.9.0/annotations.yaml
@@ -1,4 +1,5 @@
 annotations:
+  com.redhat.openshift.versions: "v4.9"
   operators.operatorframework.io.bundle.mediatype.v1: "registry+v1"
   operators.operatorframework.io.bundle.manifests.v1: "manifests/"
   operators.operatorframework.io.bundle.metadata.v1: "metadata/"

--- a/hack/generate-metadata.sh
+++ b/hack/generate-metadata.sh
@@ -12,6 +12,7 @@ fi
 
 cat >"${METADATA_DIR}/${CSV_VERSION}/annotations.yaml" <<EOF
 annotations:
+  com.redhat.openshift.versions: "v${CSV_CHANNEL}"
   operators.operatorframework.io.bundle.mediatype.v1: "registry+v1"
   operators.operatorframework.io.bundle.manifests.v1: "manifests/"
   operators.operatorframework.io.bundle.metadata.v1: "metadata/"


### PR DESCRIPTION
Currently, pipeline will only look for the Label in the image (label under the dockerfile of the bundle)
to know what version should be added in each OCP OLM index image,
however, note that the official olm sdk tool ensure that it is in the annotation
which means that this information might be used for any other purpose in the future and then,
the operator bundle might not be processed accordingly if the dockerfile and annotations are not keep in sync.