### PR TITLE
[release-4.8] Cherry picked from PR "e2e: Add stalld test and remove no longer needed skips #690" Bug 1985365: "re-activate stalld test and add new stalld priority test"

### DIFF
--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -228,7 +228,8 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				Expect(err).ToNot(HaveOccurred())
 				re := regexp.MustCompile("scheduling priority: ([0-9]+)")
 				match := re.FindStringSubmatch(sched_tasks)
-				stalld_prio, _ := strconv.Atoi(match[1])
+				stalld_prio, err := strconv.Atoi(match[1])
+				Expect(err).ToNot(HaveOccurred())
 
 				ksoftirq_pid, err := nodes.ExecCommandOnNode([]string{"pgrep", "-f", "ksoftirqd", "-n"}, &node)
 				Expect(err).ToNot(HaveOccurred())
@@ -236,7 +237,8 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				sched_tasks, err = nodes.ExecCommandOnNode([]string{"chrt", "-ap", ksoftirq_pid}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				match = re.FindStringSubmatch(sched_tasks)
-				ksoftirq_prio, _ := strconv.Atoi(match[1])
+				ksoftirq_prio, err := strconv.Atoi(match[1])
+				Expect(err).ToNot(HaveOccurred())
 
 				rcuc_pid, err := nodes.ExecCommandOnNode([]string{"pgrep", "-f", "rcuc", "-n"}, &node)
 				Expect(err).ToNot(HaveOccurred())
@@ -244,9 +246,9 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				sched_tasks, err = nodes.ExecCommandOnNode([]string{"chrt", "-ap", rcuc_pid}, &node)
 				Expect(err).ToNot(HaveOccurred())
 				match = re.FindStringSubmatch(sched_tasks)
-				rcuc_prio, _ := strconv.Atoi(match[1])
+				rcuc_prio, err := strconv.Atoi(match[1])
+				Expect(err).ToNot(HaveOccurred())
 
-				//fmt.Println("stalld , ksoft ,rcuc" , stalld_prio,ksoftirq_prio ,rcuc_prio)
 				Expect(stalld_prio).To(BeNumerically("<", ksoftirq_prio))
 				Expect(stalld_prio).To(BeNumerically("<", rcuc_prio))
 			}

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -202,7 +202,6 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 		})
 
 		It("[test_id:35363][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] stalld daemon is running on the host", func() {
-			Skip("until bugs https://bugzilla.redhat.com/show_bug.cgi?id=1912118 and https://bugzilla.redhat.com/show_bug.cgi?id=1903302 fixed")
 			for _, node := range workerRTNodes {
 				tuned := tunedForNode(&node)
 				_, err := pods.ExecCommandOnPod(tuned, []string{"pidof", "stalld"})

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -208,6 +208,50 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})
+		It("[test_id:42400][crit:medium][vendor:cnf-qe@redhat.com][level:acceptance] stalld daemon is running as sched_fifo", func() {
+			for _, node := range workerRTNodes {
+				pid, err := nodes.ExecCommandOnNode([]string{"pidof", "stalld"}, &node)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pid).ToNot(BeEmpty())
+				sched_tasks, err := nodes.ExecCommandOnNode([]string{"chrt", "-ap", pid}, &node)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sched_tasks).To(ContainSubstring("scheduling policy: SCHED_FIFO"))
+				Expect(sched_tasks).To(ContainSubstring("scheduling priority: 10"))
+			}
+		})
+		It("[test_id:42696][crit:medium][vendor:cnf-qe@redhat.com][level:acceptance] Stalld runs in higher priority than ksoftirq and rcu{c,b}", func() {
+			for _, node := range workerRTNodes {
+				stalld_pid, err := nodes.ExecCommandOnNode([]string{"pidof", "stalld"}, &node)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stalld_pid).ToNot(BeEmpty())
+				sched_tasks, err := nodes.ExecCommandOnNode([]string{"chrt", "-ap", stalld_pid}, &node)
+				Expect(err).ToNot(HaveOccurred())
+				re := regexp.MustCompile("scheduling priority: ([0-9]+)")
+				match := re.FindStringSubmatch(sched_tasks)
+				stalld_prio, _ := strconv.Atoi(match[1])
+
+				ksoftirq_pid, err := nodes.ExecCommandOnNode([]string{"pgrep", "-f", "ksoftirqd", "-n"}, &node)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ksoftirq_pid).ToNot(BeEmpty())
+				sched_tasks, err = nodes.ExecCommandOnNode([]string{"chrt", "-ap", ksoftirq_pid}, &node)
+				Expect(err).ToNot(HaveOccurred())
+				match = re.FindStringSubmatch(sched_tasks)
+				ksoftirq_prio, _ := strconv.Atoi(match[1])
+
+				rcuc_pid, err := nodes.ExecCommandOnNode([]string{"pgrep", "-f", "rcuc", "-n"}, &node)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(rcuc_pid).ToNot(BeEmpty())
+				sched_tasks, err = nodes.ExecCommandOnNode([]string{"chrt", "-ap", rcuc_pid}, &node)
+				Expect(err).ToNot(HaveOccurred())
+				match = re.FindStringSubmatch(sched_tasks)
+				rcuc_prio, _ := strconv.Atoi(match[1])
+
+				//fmt.Println("stalld , ksoft ,rcuc" , stalld_prio,ksoftirq_prio ,rcuc_prio)
+				Expect(stalld_prio).To(BeNumerically("<", ksoftirq_prio))
+				Expect(stalld_prio).To(BeNumerically("<", rcuc_prio))
+			}
+		})
+
 	})
 
 	Context("Additional kernel arguments added from perfomance profile", func() {


### PR DESCRIPTION
Back-porting PR https://github.com/openshift-kni/performance-addon-operators/pull/690 to release-4.8 branch