### PR TITLE
Bug 1986399: Latency tests: disable irq and cpu load balancing

### DIFF
--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -269,7 +269,8 @@ func getLatencyTestPod(profile *performancev2.PerformanceProfile, node *corev1.N
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: testNamePrefix,
 			Annotations: map[string]string{
-				"cpu-load-balancing.crio.io": "true",
+				"irq-load-balancing.crio.io": "disable",
+				"cpu-load-balancing.crio.io": "disable",
 			},
 			Namespace: testutils.NamespaceTesting,
 		},


### PR DESCRIPTION
This update will disable irq load-balancing and cpu load-balancing for the latency test pod.
Disabling the load-balancing is required for eliminating additional workload on the pods` CPUs.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>