### PR TITLE
Bug 1986410 Control CPUs amount under latency-test pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,13 +147,18 @@ deployed Performance Operator and configured MCP and nodes. It will create its o
 The latency-test container image gives the possibility to run the latency 
 test without need to install go, ginkgo or other go related modules.
 
-The test himself is running the `oslat` binary and verifies if the maximal latency returned by the `oslat`
-less than specified value under the `OSLAT_MAXIMUM_LATENCY`.
+The test itself is running the `oslat` `cyclictest` and `hwlatdetect` binaries and verifies if the maximal latency returned by each one of the tools is
+less than specified value under the `MAXIMUM_LATENCY`.
 
-To run the latency test inside of the container:
+To run the latency test inside the container:
 
 ```
-docker run --rm -v /kubeconfig:/kubeconfig -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=60 -e OSLAT_MAXIMUM_LATENCY=700 alukiano/latency-test:4.6-snapshot /usr/bin/run-tests.sh
+docker run --rm -v /kubeconfig:/kubeconfig \
+-e KUBECONFIG=/kubeconfig \
+-e LATENCY_TEST_RUN=true \
+-e LATENCY_TEST_RUNTIME=60 \
+-e MAXIMUM_LATENCY=700 \
+ quay.io/openshift-kni/cnf-tests /usr/bin/run-tests.sh
 ```
 
 You can run the container with different ENV variables, but the bare minimum is to pass
@@ -164,7 +169,11 @@ You can run the container with different ENV variables, but the bare minimum is 
 - `LATENCY_TEST_RUN` indicates if the latency test should run.
 - `LATENCY_TEST_RUNTIME` the amount of time in seconds that the latency test should run.
 - `LATENCY_TEST_IMAGE` the image that used under the latency test.
-- `OSLAT_MAXIMUM_LATENCY` the expected maximum latency for all buckets in us.
+- `LATECNY_TEST_CPUS` the amount of CPUs the pod which run the latency test should request
+- `OSLAT_MAXIMUM_LATENCY` the expected maximum latency for all buckets in us in the oslat test.
+- `CYCLICTEST_MAXIMUM_LATENCY` the expected maximum latency for the cyclictest test.
+- `HWLATDETECT_MAXIMUM_LATENCY` the expected maximum latency for the hwlatdetect test.
+- `MAXIMUM_LATENCY` a unified value for the expected maximum latency for all tests (In case both provided, the specific variables will have precedence over the unified one).
 
 # Contributing
 

--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -37,6 +37,7 @@ var (
 	latencyTestRun     = false
 	latencyTestRuntime = "300"
 	maximumLatency     = -1
+	latencyTestCpus    = -1
 )
 
 const (
@@ -45,10 +46,11 @@ const (
 	hwlatdetectTestName = "hwlatdetect"
 )
 
-// LATENCY_TEST_DELAY delay the run of the oslat binary, can be useful to give time to the CPU manager reconcile loop
+// LATENCY_TEST_DELAY delay the run of the binary, can be useful to give time to the CPU manager reconcile loop
 // to update the default CPU pool
 // LATENCY_TEST_RUN: indicates if the latency test should run
 // LATENCY_TEST_RUNTIME: the amount of time in seconds that the latency test should run
+// LATENCY_TEST_CPUS: the amount of CPUs the pod which run the latency test should request
 func init() {
 	latencyTestRunEnv := os.Getenv("LATENCY_TEST_RUN")
 	if latencyTestRunEnv != "" {
@@ -67,6 +69,14 @@ func init() {
 		var err error
 		if latencyTestDelay, err = strconv.Atoi(latencyTestDelayEnv); err != nil {
 			klog.Fatalf("the environment variable LATENCY_TEST_DELAY has incorrect value %q", latencyTestDelayEnv)
+		}
+	}
+
+	latencyTestCpusEnv := os.Getenv("LATENCY_TEST_CPUS")
+	if latencyTestCpusEnv != "" {
+		var err error
+		if latencyTestCpus, err = strconv.Atoi(latencyTestCpusEnv); err != nil {
+			klog.Fatalf("the environment variable LATENCY_TEST_CPUS has incorrect value %q", latencyTestCpusEnv)
 		}
 	}
 }
@@ -246,11 +256,18 @@ var _ = Describe("[performance] Latency Test", func() {
 })
 
 func getLatencyTestPod(profile *performancev2.PerformanceProfile, node *corev1.Node, testName string, testSpecificArgs []string) *corev1.Pod {
-	cpus := cpuset.MustParse(string(*profile.Spec.CPU.Isolated))
 	runtimeClass := components.GetComponentName(profile.Name, components.ComponentNamePrefix)
 	testNamePrefix := fmt.Sprintf("%s-", testName)
 	runnerName := fmt.Sprintf("%srunner", testNamePrefix)
 	runnerPath := path.Join("usr", "bin", runnerName)
+
+	if latencyTestCpus == -1 {
+		// we can not use all isolated CPUs, because if reserved and isolated include all node CPUs, and reserved CPUs
+		// do not calculated into the Allocated, at least part of time of one of isolated CPUs will be used to run
+		// other node containers
+		cpus := cpuset.MustParse(string(*profile.Spec.CPU.Isolated))
+		latencyTestCpus = cpus.Size() - 1
+	}
 
 	latencyTestRunnerArgs := []string{
 		"-logtostderr=false",
@@ -287,10 +304,7 @@ func getLatencyTestPod(profile *performancev2.PerformanceProfile, node *corev1.N
 					Args: latencyTestRunnerArgs,
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
-							// we can not use all isolated CPUs, because if reserved and isolated include all node CPUs, and reserved CPUs
-							// do not calculated into the Allocated, at least part of time of one of isolated CPUs will be used to run
-							// other node containers
-							corev1.ResourceCPU:    resource.MustParse(strconv.Itoa(cpus.Size() - 1)),
+							corev1.ResourceCPU:    resource.MustParse(strconv.Itoa(latencyTestCpus)),
 							corev1.ResourceMemory: resource.MustParse("1Gi"),
 						},
 					},


### PR DESCRIPTION
By having the new LATENCY_TEST_CPUS env variable, the user will be able to specify the amount of CPUs
that will be used by the pod which runs the latency tests.

The LATENCY_TEST_CPUS env variable is optional, the default value is the total amount of isolated CPUs minus one (this behavior is identical to the prior one).