### PR TITLE
build: add helper and rule to build the latency test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,10 @@ dist-docs-generator: build-output-dir
 dist-functests:
 	./hack/build-test-bin.sh
 
+.PHONY: dist-latency-tests
+dist-latency-tests:
+	./hack/build-latency-test-bin.sh
+
 .PHONY: new-zversion
 new-zversion: bump-zversion generate
 

--- a/hack/build-latency-test-bin.sh
+++ b/hack/build-latency-test-bin.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+if ! which go &>/dev/null; then
+  echo "No go command available"
+  exit 1
+fi
+
+go test -v -c -o build/_output/bin/latency-e2e.test ./functests/4_latency


### PR DESCRIPTION
To test the testsuite, it's useful to have the e2e latency
test suite compiled as standalone binary.

Signed-off-by: Francesco Romani <fromani@redhat.com>