### PR TITLE
e2e: wait for the pod output

### DIFF
--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -384,7 +384,7 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			getPsr := []string{"/bin/bash", "-c", "grep Cpus_allowed_list /proc/self/status | awk '{print $2}'"}
-			psr, err := pods.ExecCommandOnPod(testclient.K8sClient, testpod, getPsr)
+			psr, err := pods.WaitForPodOutput(testclient.K8sClient, testpod, getPsr)
 			Expect(err).ToNot(HaveOccurred())
 			psrSet, err := cpuset.Parse(strings.Trim(string(psr), "\n"))
 			Expect(err).ToNot(HaveOccurred())

--- a/functests/1_performance/netqueues.go
+++ b/functests/1_performance/netqueues.go
@@ -108,7 +108,7 @@ var _ = Describe("[ref_id: 40307][pao]Resizing Network Queues", func() {
 			tunedCmd := []string{"tuned-adm", "profile_info", "openshift-node-performance-performance"}
 			for _, node := range workerRTNodes {
 				tunedPod := nodes.TunedForNode(&node, RunningOnSingleNode)
-				_, err := pods.ExecCommandOnPod(testclient.K8sClient, tunedPod, tunedCmd)
+				_, err := pods.WaitForPodOutput(testclient.K8sClient, tunedPod, tunedCmd)
 				Expect(err).ToNot(HaveOccurred())
 			}
 			for _, sizes := range devices {
@@ -157,7 +157,7 @@ var _ = Describe("[ref_id: 40307][pao]Resizing Network Queues", func() {
 
 			for _, node := range workerRTNodes {
 				tunedPod := nodes.TunedForNode(&node, RunningOnSingleNode)
-				out, err := pods.ExecCommandOnPod(testclient.K8sClient, tunedPod, tunedCmd)
+				out, err := pods.WaitForPodOutput(testclient.K8sClient, tunedPod, tunedCmd)
 				deviceExists := strings.ContainsAny(string(out), device)
 				Expect(deviceExists).To(BeTrue())
 				Expect(err).ToNot(HaveOccurred())
@@ -208,7 +208,7 @@ var _ = Describe("[ref_id: 40307][pao]Resizing Network Queues", func() {
 
 			for _, node := range workerRTNodes {
 				tunedPod := nodes.TunedForNode(&node, RunningOnSingleNode)
-				out, err := pods.ExecCommandOnPod(testclient.K8sClient, tunedPod, tunedCmd)
+				out, err := pods.WaitForPodOutput(testclient.K8sClient, tunedPod, tunedCmd)
 				deviceExists := strings.ContainsAny(string(out), device)
 				Expect(deviceExists).To(BeTrue())
 				Expect(err).ToNot(HaveOccurred())
@@ -264,7 +264,7 @@ var _ = Describe("[ref_id: 40307][pao]Resizing Network Queues", func() {
 				fmt.Sprintf("cat /etc/tuned/openshift-node-performance-performance/tuned.conf | grep devices_udev_regex")}
 			for _, node := range workerRTNodes {
 				tunedPod := nodes.TunedForNode(&node, RunningOnSingleNode)
-				out, err := pods.ExecCommandOnPod(testclient.K8sClient, tunedPod, tunedCmd)
+				out, err := pods.WaitForPodOutput(testclient.K8sClient, tunedPod, tunedCmd)
 				deviceExists := strings.ContainsAny(string(out), device)
 				Expect(deviceExists).To(BeTrue())
 				Expect(err).ToNot(HaveOccurred())
@@ -290,17 +290,17 @@ func checkDeviceSupport(workernodes []corev1.Node, devices map[string][]int) err
 	var err error
 	for _, node := range workernodes {
 		tunedPod := nodes.TunedForNode(&node, RunningOnSingleNode)
-		phyDevs, err := pods.ExecCommandOnPod(testclient.K8sClient, tunedPod, cmdGetPhysicalDevices)
+		phyDevs, err := pods.WaitForPodOutput(testclient.K8sClient, tunedPod, cmdGetPhysicalDevices)
 		Expect(err).ToNot(HaveOccurred())
 		for _, d := range strings.Split(string(phyDevs), " ") {
 			if d == "" {
 				continue
 			}
-			_, err := pods.ExecCommandOnPod(testclient.K8sClient, tunedPod, []string{"ethtool", "-l", d})
+			_, err := pods.WaitForPodOutput(testclient.K8sClient, tunedPod, []string{"ethtool", "-l", d})
 			if err == nil {
 				cmdCombinedChannelsCurrent := []string{"bash", "-c",
 					fmt.Sprintf("ethtool -l %s | sed -n '/Current hardware settings:/,/Combined:/{s/^Combined:\\s*//p}'", d)}
-				out, err := pods.ExecCommandOnPod(testclient.K8sClient, tunedPod, cmdCombinedChannelsCurrent)
+				out, err := pods.WaitForPodOutput(testclient.K8sClient, tunedPod, cmdCombinedChannelsCurrent)
 				if strings.Contains(string(out), "n/a") {
 					fmt.Printf("Device %s doesn't support multiple queues\n", d)
 				} else {

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -132,7 +132,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 		It("[test_id:37127] Node should point to right tuned profile", func() {
 			for _, node := range workerRTNodes {
 				tuned := nodes.TunedForNode(&node, RunningOnSingleNode)
-				activeProfile, err := pods.ExecCommandOnPod(testclient.K8sClient, tuned, []string{"cat", "/etc/tuned/active_profile"})
+				activeProfile, err := pods.WaitForPodOutput(testclient.K8sClient, tuned, []string{"cat", "/etc/tuned/active_profile"})
 				Expect(err).ToNot(HaveOccurred(), "Error getting the tuned active profile")
 				activeProfileName := string(activeProfile)
 				Expect(strings.TrimSpace(activeProfileName)).To(Equal(tunedExpectedName), "active profile name mismatch got %q expected %q", activeProfileName, tunedExpectedName)
@@ -216,7 +216,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 		It("[test_id:35363][crit:high][vendor:cnf-qe@redhat.com][level:acceptance] stalld daemon is running on the host", func() {
 			for _, node := range workerRTNodes {
 				tuned := nodes.TunedForNode(&node, RunningOnSingleNode)
-				_, err := pods.ExecCommandOnPod(testclient.K8sClient, tuned, []string{"pidof", "stalld"})
+				_, err := pods.WaitForPodOutput(testclient.K8sClient, tuned, []string{"pidof", "stalld"})
 				Expect(err).ToNot(HaveOccurred())
 			}
 		})
@@ -362,7 +362,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 
 				for _, pod := range nodePods.Items {
 					cmd := []string{"find", "/sys/devices", "-type", "f", "-name", "rps_cpus", "-exec", "cat", "{}", ";"}
-					devsRPS, err := pods.ExecCommandOnPod(testclient.K8sClient, &pod, cmd)
+					devsRPS, err := pods.WaitForPodOutput(testclient.K8sClient, &pod, cmd)
 					for _, devRPS := range strings.Split(strings.Trim(string(devsRPS), "\n"), "\n") {
 						rpsCPUs, err = components.CPUMaskToCPUSet(devRPS)
 						Expect(err).ToNot(HaveOccurred())
@@ -1168,7 +1168,7 @@ func validateTunedActiveProfile(wrknodes []corev1.Node) {
 		tunedName := tuned.ObjectMeta.Name
 		By(fmt.Sprintf("executing the command cat /etc/tuned/active_profile inside the pod %s", tunedName))
 		Eventually(func() string {
-			out, err = pods.ExecCommandOnPod(testclient.K8sClient, tuned, []string{"cat", "/etc/tuned/active_profile"})
+			out, err = pods.WaitForPodOutput(testclient.K8sClient, tuned, []string{"cat", "/etc/tuned/active_profile"})
 			return strings.TrimSpace(string(out))
 		}, cluster.ComputeTestTimeout(testTimeout*time.Second, RunningOnSingleNode), testPollInterval*time.Second).Should(Equal(activeProfileName),
 			fmt.Sprintf("active_profile is not set to %s. %v", activeProfileName, err))

--- a/functests/utils/nodes/nodes.go
+++ b/functests/utils/nodes/nodes.go
@@ -111,7 +111,7 @@ func ExecCommandOnMachineConfigDaemon(node *corev1.Node, command []string) ([]by
 	}
 	testlog.Infof("found mcd %s for node %s", mcd.Name, node.Name)
 
-	return testpods.ExecCommandOnPod(testclient.K8sClient, mcd, command)
+	return testpods.WaitForPodOutput(testclient.K8sClient, mcd, command)
 }
 
 // ExecCommandOnNode executes given command on given node and returns the result

--- a/functests/utils/pods/pods.go
+++ b/functests/utils/pods/pods.go
@@ -170,6 +170,22 @@ func ExecCommandOnPod(c *kubernetes.Clientset, pod *corev1.Pod, command []string
 	return outputBuf.Bytes(), nil
 }
 
+func WaitForPodOutput(c *kubernetes.Clientset, pod *corev1.Pod, command []string) ([]byte, error) {
+	var out []byte
+	if err := wait.PollImmediate(15*time.Second, time.Minute, func() (done bool, err error) {
+		out, err = ExecCommandOnPod(c, pod, command)
+		if err != nil {
+			return false, err
+		}
+
+		return len(out) != 0, nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
 // GetContainerIDByName returns container ID under the pod by the container name
 func GetContainerIDByName(pod *corev1.Pod, containerName string) (string, error) {
 	updatedPod := &corev1.Pod{}


### PR DESCRIPTION
Some of the tests under our CI are failing because that pod exec returns an empty output.
We do not know the reason, but we can mitigate a problem by re-running the command on the pod again as a short-term solution.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>