### PR TITLE
Bug:1992710 Latency tests: Pass latencyTestRuntime as an argument to the test

### DIFF
--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -183,7 +183,10 @@ var _ = Describe("[performance] Latency Test", func() {
 		})
 
 		It("should succeed", func() {
-			latencyTestPod = getLatencyTestPod(profile, workerRTNode, testName, []string{})
+			cyclictestArgs := []string{
+				fmt.Sprintf("-duration=%s", latencyTestRuntime),
+			}
+			latencyTestPod = getLatencyTestPod(profile, workerRTNode, testName, cyclictestArgs)
 			createLatencyTestPod(latencyTestPod)
 
 			// verify the maximum latency only when it requested, because this value can be very different
@@ -225,6 +228,7 @@ var _ = Describe("[performance] Latency Test", func() {
 
 			hwlatdetectArgs := []string{
 				fmt.Sprintf("-hardlimit=%d", hardLimit),
+				fmt.Sprintf("-duration=%s", latencyTestRuntime),
 			}
 
 			// set the maximum latency for the test if needed


### PR DESCRIPTION
We need to pass latencyTestRuntime (which is originally the LATENCY_TEST_RUNTIME env variable) as an argument before running the latency test pod.
Without it the user won't be able to control for how long the test will run.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>