### PR TITLE
tuned: remove inline comments

### DIFF
--- a/build/assets/tuned/openshift-node-performance
+++ b/build/assets/tuned/openshift-node-performance
@@ -12,28 +12,31 @@ include=openshift-node,cpu-partitioning
 # Different values will override the original values in parent profiles.
 
 [variables]
-# isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7
+#> isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7
 {{if .IsolatedCpus}}
-isolated_cores={{.IsolatedCpus}} 
+isolated_cores={{.IsolatedCpus}}
 {{end}}
 
 not_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}
 
 [cpu]
-force_latency=cstate.id:1|3                   #  latency-performance  (override)
-governor=performance                          #  latency-performance 
-energy_perf_bias=performance                  #  latency-performance 
-min_perf_pct=100                              #  latency-performance 
+#> latency-performance
+#> (override)
+force_latency=cstate.id:1|3
+governor=performance
+energy_perf_bias=performance
+min_perf_pct=100
 
 [service]
 service.stalld=start,enable
 
 [vm]
-transparent_hugepages=never                   #  network-latency
+#> network-latency
+transparent_hugepages=never
 
 {{if not .GloballyDisableIrqLoadBalancing}}
 [irqbalance]
-# Override the value set by cpu-partitioning with an empty one
+#> Override the value set by cpu-partitioning with an empty one
 banned_cpus=""
 {{end}}
 
@@ -46,21 +49,28 @@ default_irq_smp_affinity = ignore
 {{end}}
 
 [sysctl]
-kernel.hung_task_timeout_secs = 600           # cpu-partitioning #realtime
-kernel.nmi_watchdog = 0                       # cpu-partitioning #realtime
-kernel.sched_rt_runtime_us = -1               # realtime 
-kernel.timer_migration = 0                    # cpu-partitioning (= 1) #realtime (= 0)
-kernel.numa_balancing=0                       # network-latency
-net.core.busy_read=50                         # network-latency
-net.core.busy_poll=50                         # network-latency
-net.ipv4.tcp_fastopen=3                       # network-latency
-vm.stat_interval = 10                         # cpu-partitioning  #realtime
+#> cpu-partitioning #realtime
+kernel.hung_task_timeout_secs = 600
+#> cpu-partitioning #realtime
+kernel.nmi_watchdog = 0
+#> realtime
+kernel.sched_rt_runtime_us = -1
+#> cpu-partitioning (= 1) #realtime (= 0)
+kernel.timer_migration = 0
+#> network-latency
+kernel.numa_balancing=0
+net.core.busy_read=50
+net.core.busy_poll=50
+net.ipv4.tcp_fastopen=3
+#> cpu-partitioning  #realtime
+vm.stat_interval = 10
 
 # ktune sysctl settings for rhel6 servers, maximizing i/o throughput
 #
 # Minimal preemption granularity for CPU-bound tasks:
 # (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
-kernel.sched_min_granularity_ns=10000000      # latency-performance
+#> latency-performance
+kernel.sched_min_granularity_ns=10000000
 
 # If a workload mostly uses anonymous memory and it hits this limit, the entire
 # working set is buffered for I/O, and any more write buffering would require
@@ -69,11 +79,13 @@ kernel.sched_min_granularity_ns=10000000      # latency-performance
 #
 # The generator of dirty data starts writeback at this percentage (system default
 # is 20%)
-vm.dirty_ratio=10                             # latency-performance
+#> latency-performance
+vm.dirty_ratio=10
 
 # Start background writeback (via writeback threads) at this percentage (system
 # default is 10%)
-vm.dirty_background_ratio=3                   # latency-performance
+#> latency-performance
+vm.dirty_background_ratio=3
 
 # The swappiness parameter controls the tendency of the kernel to move
 # processes out of physical memory and onto the swap disk.
@@ -81,23 +93,26 @@ vm.dirty_background_ratio=3                   # latency-performance
 # for as long as possible
 # 100 tells the kernel to aggressively swap processes out of physical memory
 # and move them to swap cache
-vm.swappiness=10                              # latency-performance
+#> latency-performance
+vm.swappiness=10
 
 # The total time the scheduler will consider a migrated process
 # "cache hot" and thus less likely to be re-migrated
 # (system default is 500000, i.e. 0.5 ms)
-kernel.sched_migration_cost_ns=5000000        # latency-performance
+#> latency-performance
+kernel.sched_migration_cost_ns=5000000
 
 [selinux]
-avc_cache_threshold=8192                      # Custom (atomic host)
+#> Custom (atomic host)
+avc_cache_threshold=8192
 
 {{if .NetDevices}}
-{{.NetDevices}} 
+{{.NetDevices}}
 {{end}}
 
 [bootloader]
-# set empty values to disable RHEL initrd setting in cpu-partitioning 
-initrd_remove_dir=     
+# set empty values to disable RHEL initrd setting in cpu-partitioning
+initrd_remove_dir=
 initrd_dst_img=
 initrd_add_dir=
 # overrides cpu-partitioning cmdline

--- a/testdata/render-expected-output/manual_tuned.yaml
+++ b/testdata/render-expected-output/manual_tuned.yaml
@@ -11,7 +11,50 @@ metadata:
     uid: ""
 spec:
   profile:
-  - data: "[main]\nsummary=Openshift node optimized for deterministic performance at the cost of increased power consumption, focused on low latency network performance. Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n# Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n# https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n# https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n# All values are mapped with a comment where a parent profile contains them.\n# Different values will override the original values in parent profiles.\n\n[variables]\n# isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1-3 \n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n[cpu]\nforce_latency=cstate.id:1|3                   #  latency-performance  (override)\ngovernor=performance                          #  latency-performance \nenergy_perf_bias=performance                  #  latency-performance \nmin_perf_pct=100                              #  latency-performance \n\n[service]\nservice.stalld=start,enable\n\n[vm]\ntransparent_hugepages=never                   #  network-latency\n\n\n[irqbalance]\n# Override the value set by cpu-partitioning with an empty one\nbanned_cpus=\"\"\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\n\ndefault_irq_smp_affinity = ignore\n\n\n[sysctl]\nkernel.hung_task_timeout_secs = 600           # cpu-partitioning #realtime\nkernel.nmi_watchdog = 0                       # cpu-partitioning #realtime\nkernel.sched_rt_runtime_us = -1               # realtime \nkernel.timer_migration = 0                    # cpu-partitioning (= 1) #realtime (= 0)\nkernel.numa_balancing=0                       # network-latency\nnet.core.busy_read=50                         # network-latency\nnet.core.busy_poll=50                         # network-latency\nnet.ipv4.tcp_fastopen=3                       # network-latency\nvm.stat_interval = 10                         # cpu-partitioning  #realtime\n\n# ktune sysctl settings for rhel6 servers, maximizing i/o throughput\n#\n# Minimal preemption granularity for CPU-bound tasks:\n# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)\nkernel.sched_min_granularity_ns=10000000      # latency-performance\n\n# If a workload mostly uses anonymous memory and it hits this limit, the entire\n# working set is buffered for I/O, and any more write buffering would require\n# swapping, so it's time to throttle writes until I/O can catch up.  Workloads\n# that mostly use file mappings may be able to use even higher values.\n#\n# The generator of dirty data starts writeback at this percentage (system default\n# is 20%)\nvm.dirty_ratio=10                             # latency-performance\n\n# Start background writeback (via writeback threads) at this percentage (system\n# default is 10%)\nvm.dirty_background_ratio=3                   # latency-performance\n\n# The swappiness parameter controls the tendency of the kernel to move\n# processes out of physical memory and onto the swap disk.\n# 0 tells the kernel to avoid swapping processes out of physical memory\n# for as long as possible\n# 100 tells the kernel to aggressively swap processes out of physical memory\n# and move them to swap cache\nvm.swappiness=10                              # latency-performance\n\n# The total time the scheduler will consider a migrated process\n# \"cache hot\" and thus less likely to be re-migrated\n# (system default is 500000, i.e. 0.5 ms)\nkernel.sched_migration_cost_ns=5000000        # latency-performance\n\n[selinux]\navc_cache_threshold=8192                      # Custom (atomic host)\n\n\n[net]\nnf_conntrack_hashsize=131072 \n\n\n[bootloader]\n# set empty values to disable RHEL initrd setting in cpu-partitioning \ninitrd_remove_dir=     \ninitrd_dst_img=\ninitrd_add_dir=\n# overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores} tuned.non_isolcpus=${not_isolated_cpumask} intel_pstate=disable nosoftlockup\n\ncmdline_realtime=+tsc=nowatchdog intel_iommu=on iommu=pt isolcpus=managed_irq,${isolated_cores} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\ncmdline_hugepages=+ default_hugepagesz=1G   hugepagesz=2M hugepages=128 \ncmdline_additionalArg=+ nmi_watchdog=0 audit=0 mce=off processor.max_cstate=1 idle=poll intel_idle.max_cstate=0 \n"
+  - data: "[main]\nsummary=Openshift node optimized for deterministic performance
+      at the cost of increased power consumption, focused on low latency network performance.
+      Based on Tuned 2.11 and Cluster node tuning (oc 4.5)\ninclude=openshift-node,cpu-partitioning\n\n#
+      Inheritance of base profiles legend:\n# cpu-partitioning -> network-latency
+      -> latency-performance\n# https://github.com/redhat-performance/tuned/blob/master/profiles/latency-performance/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/network-latency/tuned.conf\n#
+      https://github.com/redhat-performance/tuned/blob/master/profiles/cpu-partitioning/tuned.conf\n\n#
+      All values are mapped with a comment where a parent profile contains them.\n#
+      Different values will override the original values in parent profiles.\n\n[variables]\n#>
+      isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1-3\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n[cpu]\n#>
+      latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n[service]\nservice.stalld=start,enable\n\n[vm]\n#>
+      network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n#> Override
+      the value set by cpu-partitioning with an empty one\nbanned_cpus=\"\"\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\n\ndefault_irq_smp_affinity
+      = ignore\n\n\n[sysctl]\n#> cpu-partitioning #realtime\nkernel.hung_task_timeout_secs
+      = 600\n#> cpu-partitioning #realtime\nkernel.nmi_watchdog = 0\n#> realtime\nkernel.sched_rt_runtime_us
+      = -1\n#> cpu-partitioning (= 1) #realtime (= 0)\nkernel.timer_migration = 0\n#>
+      network-latency\nkernel.numa_balancing=0\nnet.core.busy_read=50\nnet.core.busy_poll=50\nnet.ipv4.tcp_fastopen=3\n#>
+      cpu-partitioning  #realtime\nvm.stat_interval = 10\n\n# ktune sysctl settings
+      for rhel6 servers, maximizing i/o throughput\n#\n# Minimal preemption granularity
+      for CPU-bound tasks:\n# (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)\n#>
+      latency-performance\nkernel.sched_min_granularity_ns=10000000\n\n# If a workload
+      mostly uses anonymous memory and it hits this limit, the entire\n# working set
+      is buffered for I/O, and any more write buffering would require\n# swapping,
+      so it's time to throttle writes until I/O can catch up.  Workloads\n# that mostly
+      use file mappings may be able to use even higher values.\n#\n# The generator
+      of dirty data starts writeback at this percentage (system default\n# is 20%)\n#>
+      latency-performance\nvm.dirty_ratio=10\n\n# Start background writeback (via
+      writeback threads) at this percentage (system\n# default is 10%)\n#> latency-performance\nvm.dirty_background_ratio=3\n\n#
+      The swappiness parameter controls the tendency of the kernel to move\n# processes
+      out of physical memory and onto the swap disk.\n# 0 tells the kernel to avoid
+      swapping processes out of physical memory\n# for as long as possible\n# 100
+      tells the kernel to aggressively swap processes out of physical memory\n# and
+      move them to swap cache\n#> latency-performance\nvm.swappiness=10\n\n# The total
+      time the scheduler will consider a migrated process\n# \"cache hot\" and thus
+      less likely to be re-migrated\n# (system default is 500000, i.e. 0.5 ms)\n#>
+      latency-performance\nkernel.sched_migration_cost_ns=5000000\n\n[selinux]\n#>
+      Custom (atomic host)\navc_cache_threshold=8192\n\n\n[net]\nnf_conntrack_hashsize=131072\n\n\n[bootloader]\n#
+      set empty values to disable RHEL initrd setting in cpu-partitioning\ninitrd_remove_dir=\ninitrd_dst_img=\ninitrd_add_dir=\n#
+      overrides cpu-partitioning cmdline\ncmdline_cpu_part=+nohz=on rcu_nocbs=${isolated_cores}
+      tuned.non_isolcpus=${not_isolated_cpumask} intel_pstate=disable nosoftlockup\n\ncmdline_realtime=+tsc=nowatchdog
+      intel_iommu=on iommu=pt isolcpus=managed_irq,${isolated_cores} systemd.cpu_affinity=${not_isolated_cores_expanded}\n\ncmdline_hugepages=+
+      default_hugepagesz=1G   hugepagesz=2M hugepages=128 \ncmdline_additionalArg=+
+      nmi_watchdog=0 audit=0 mce=off processor.max_cstate=1 idle=poll intel_idle.max_cstate=0
+      \n"
     name: openshift-node-performance-manual
   recommend:
   - machineConfigLabels:


### PR DESCRIPTION
The tuned config parser doesn't really like inline comments
(see:
https://github.com/openshift/cluster-node-tuning-operator/pull/271)

We don't really need inline comments, we can thus trivially rearrange
the comments to convey the same information but keeping them on their
own line. No intended changes of behaviour.

Signed-off-by: Francesco Romani <fromani@redhat.com>