### PR TITLE
Bug 2006675: Test delay needs units to be valid duration

### DIFF
--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -357,7 +357,8 @@ func getLatencyTestPod(profile *performancev2.PerformanceProfile, node *corev1.N
 	latencyTestRunnerArgs = append(latencyTestRunnerArgs, testSpecificArgs...)
 
 	if latencyTestDelay > 0 {
-		latencyTestRunnerArgs = append(latencyTestRunnerArgs, fmt.Sprintf("-%s-start-delay=%d", testName, latencyTestDelay))
+		// The runner expects a Duration
+		latencyTestRunnerArgs = append(latencyTestRunnerArgs, fmt.Sprintf("-%s-start-delay=%ds", testName, latencyTestDelay))
 	}
 
 	volumeTypeDirectory := corev1.HostPathDirectory


### PR DESCRIPTION
The latency test is passing the delay value to the runner container
https://github.com/openshift-kni/cnf-features-deploy/blob/6285b110359a63ebd72fd46d2ab8c6a9d019fc37/cnf-tests/pod-utils/cyclictest-runner/main.go#L22
as plain integer. However flag.Duration needs a Duration format
for which unit is mandatory.

This patch adds the "s" suffix to "scale" the value to seconds.