### PR TITLE
Revert "Bug 2006675: Test delay needs units to be valid duration"

### DIFF
--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -363,8 +363,7 @@ func getLatencyTestPod(profile *performancev2.PerformanceProfile, node *corev1.N
 	latencyTestRunnerArgs = append(latencyTestRunnerArgs, testSpecificArgs...)
 
 	if latencyTestDelay > 0 {
-		// The runner expects a Duration
-		latencyTestRunnerArgs = append(latencyTestRunnerArgs, fmt.Sprintf("-%s-start-delay=%ds", testName, latencyTestDelay))
+		latencyTestRunnerArgs = append(latencyTestRunnerArgs, fmt.Sprintf("-%s-start-delay=%d", testName, latencyTestDelay))
 	}
 
 	volumeTypeDirectory := corev1.HostPathDirectory


### PR DESCRIPTION
Reverts openshift-kni/performance-addon-operators#736

Agreed to keep the parameter as an Int instead of Duration in order to keep the backward compatibility of oslat tool which is using Int as well.

After this PR will get merged, we'll need to change cyclictest and hwlatdetect runners to accept Int instead of Duration type.