### PR TITLE
e2e: override profile selectors during the profile copy

### DIFF
--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -574,6 +574,8 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 			v1Profile.Name = "v1"
 			v1Profile.ResourceVersion = ""
 			v1Profile.Spec.NodeSelector = map[string]string{"v1/v1": "v1"}
+			v1Profile.Spec.MachineConfigPoolSelector = nil
+			v1Profile.Spec.MachineConfigLabel = nil
 			Expect(testclient.Client.Create(context.TODO(), v1Profile)).ToNot(HaveOccurred())
 
 			defer func() {
@@ -620,6 +622,8 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 			v1alpha1Profile.Name = "v1alpha"
 			v1alpha1Profile.ResourceVersion = ""
 			v1alpha1Profile.Spec.NodeSelector = map[string]string{"v1alpha/v1alpha": "v1alpha"}
+			v1alpha1Profile.Spec.MachineConfigPoolSelector = nil
+			v1alpha1Profile.Spec.MachineConfigLabel = nil
 			Expect(testclient.Client.Create(context.TODO(), v1alpha1Profile)).ToNot(HaveOccurred())
 
 			key = types.NamespacedName{
@@ -655,6 +659,8 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				profile.ResourceVersion = ""
 				profile.Spec.NodeSelector = map[string]string{"test/test": "test"}
 				profile.Spec.GloballyDisableIrqLoadBalancing = pointer.BoolPtr(globallyDisableIrqLoadBalancing)
+				profile.Spec.MachineConfigPoolSelector = nil
+				profile.Spec.MachineConfigLabel = nil
 
 				err = testclient.Client.Create(context.TODO(), profile)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create profile")
@@ -713,6 +719,8 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				profile.ResourceVersion = ""
 				profile.Spec.NodeSelector = map[string]string{"withoutNUMA/withoutNUMA": "withoutNUMA"}
 				profile.Spec.NUMA = nil
+				profile.Spec.MachineConfigPoolSelector = nil
+				profile.Spec.MachineConfigLabel = nil
 
 				err = testclient.Client.Create(context.TODO(), profile)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create profile without NUMA")


### PR DESCRIPTION
The code is coping the profile during the test and creates a new one with modified fields, the problem is that we do not unset relevant selectors under the performance profile that can lead to an update of the MCP and node reboot, because KubeletConfig will point to the existing MCP.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>