### PR TITLE
Makefile: Add latency executable prerequisite for functests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ cluster-clean:
 functests: cluster-label-worker-cnf functests-only
 
 .PHONY: functests-only
-functests-only:
+functests-only: dist-latency-tests
 	hack/run-functests.sh
 
 .PHONY: functests-latency

--- a/functests/utils/images/images.go
+++ b/functests/utils/images/images.go
@@ -13,7 +13,7 @@ func init() {
 	cnfTestsImage = os.Getenv("CNF_TESTS_IMAGE")
 
 	if cnfTestsImage == "" {
-		cnfTestsImage = "cnf-tests:4.7"
+		cnfTestsImage = "cnf-tests:4.9"
 	}
 
 	if registry == "" {


### PR DESCRIPTION
1)In order not to skip the tests in 5_latency_testing suite, a prerequisite was added for the functest-only target, that creates the executable test generated from 4_latency, so it will be used in 5_latency_testing.
2)Adjust cnf-tests image version to 4.9