### PR TITLE
functests: bump cnf-tests image to 4.9

### DIFF
--- a/functests/utils/images/images.go
+++ b/functests/utils/images/images.go
@@ -13,7 +13,7 @@ func init() {
 	cnfTestsImage = os.Getenv("CNF_TESTS_IMAGE")
 
 	if cnfTestsImage == "" {
-		cnfTestsImage = "cnf-tests:4.7"
+		cnfTestsImage = "cnf-tests:4.9"
 	}
 
 	if registry == "" {


### PR DESCRIPTION
it seems we just forgot to update it previously

Signed-off-by: Francesco Romani <fromani@redhat.com>