### PR TITLE
Bug 2013147: Merge pull request #750 from openshift-cherrypick-robot/cherry-pick-745-to-release-4.9

### DIFF
--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -519,6 +519,8 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 			v1Profile.Name = "v1"
 			v1Profile.ResourceVersion = ""
 			v1Profile.Spec.NodeSelector = map[string]string{"v1/v1": "v1"}
+			v1Profile.Spec.MachineConfigPoolSelector = nil
+			v1Profile.Spec.MachineConfigLabel = nil
 			Expect(testclient.Client.Create(context.TODO(), v1Profile)).ToNot(HaveOccurred())
 
 			key = types.NamespacedName{
@@ -563,6 +565,8 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 			v1alpha1Profile.Name = "v1alpha"
 			v1alpha1Profile.ResourceVersion = ""
 			v1alpha1Profile.Spec.NodeSelector = map[string]string{"v1alpha/v1alpha": "v1alpha"}
+			v1alpha1Profile.Spec.MachineConfigPoolSelector = nil
+			v1alpha1Profile.Spec.MachineConfigLabel = nil
 			Expect(testclient.Client.Create(context.TODO(), v1alpha1Profile)).ToNot(HaveOccurred())
 
 			key = types.NamespacedName{
@@ -594,6 +598,8 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 				profile.ResourceVersion = ""
 				profile.Spec.NodeSelector = map[string]string{"withoutNUMA/withoutNUMA": "withoutNUMA"}
 				profile.Spec.NUMA = nil
+				profile.Spec.MachineConfigPoolSelector = nil
+				profile.Spec.MachineConfigLabel = nil
 
 				err = testclient.Client.Create(context.TODO(), profile)
 				Expect(err).ToNot(HaveOccurred(), "Failed to create profile without NUMA")


### PR DESCRIPTION
[release-4.9] Bug 2012962: e2e: override profile selectors during the profile copy

(cherry picked from commit 89ff078c5ccc9d9a1c8e387ec642b72da234726b)
Signed-off-by: Artyom Lukianov <alukiano@redhat.com>