### PR TITLE
tests: images prepull using daemonsets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,10 @@ dist-docs-generator: build-output-dir
 		echo "Using pre-built docs-generator tool";\
 	fi
 
+.PHONY: dist-imgpull-tool
+dist-imgpull-tool: build-output-dir
+	env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go build -ldflags="-s -w" -mod=vendor -o $(TOOLS_BIN_DIR)/imgpull-tool ./tools/imgpull-tool
+
 .PHONY: dist-functests
 dist-functests:
 	./hack/build-test-bin.sh

--- a/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -1,17 +1,57 @@
 package __latency_testing_test
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/images"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/junit"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/namespaces"
 	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
 
+var prePullNamespace = &corev1.Namespace{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "testing-prepull",
+	},
+}
+
+var _ = AfterSuite(func() {
+	prePullNamespaceName := prePullNamespace.Name
+	err := testclient.Client.Delete(context.TODO(), prePullNamespace)
+	testlog.Infof("deleted namespace %q err=%v", prePullNamespace.Name, err)
+	Expect(err).ToNot(HaveOccurred())
+	err = namespaces.WaitForDeletion(prePullNamespaceName, 5*time.Minute)
+})
+
 func Test5LatencyTesting(t *testing.T) {
 	RegisterFailHandler(Fail)
+
+	if !testclient.ClientsEnabled {
+		t.Fatalf("client not enabled")
+	}
+
+	if err := createNamespace(); err != nil {
+		t.Fatalf("cannot create the namespace: %v", err)
+	}
+
+	ds, err := images.PrePull(testclient.Client, images.Test(), prePullNamespace.Name, "cnf-tests")
+	if err != nil {
+		data, _ := json.Marshal(ds) // we can safely skip errors
+		testlog.Infof("DaemonSet %s/%s image=%q status:\n%s", ds.Namespace, ds.Name, images.Test(), string(data))
+		t.Fatalf("cannot prepull image %q: %v", images.Test(), err)
+	}
 
 	rr := []Reporter{}
 	if ginkgo_reporters.Polarion.Run {
@@ -19,4 +59,14 @@ func Test5LatencyTesting(t *testing.T) {
 	}
 	rr = append(rr, junit.NewJUnitReporter("latency_testing"))
 	RunSpecsWithDefaultAndCustomReporters(t, "Performance Addon Operator latency tools testing", rr)
+}
+
+func createNamespace() error {
+	err := testclient.Client.Create(context.TODO(), prePullNamespace)
+	if errors.IsAlreadyExists(err) {
+		testlog.Warningf("%q namespace already exists, that is unexpected", prePullNamespace.Name)
+		return nil
+	}
+	testlog.Infof("created namespace %q err=%v", prePullNamespace.Name, err)
+	return err
 }

--- a/functests/utils/daemonset/daemonset.go
+++ b/functests/utils/daemonset/daemonset.go
@@ -1,0 +1,48 @@
+package daemonset
+
+import (
+	"context"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
+)
+
+func WaitToBeRunning(cli client.Client, namespace, name string) error {
+	return WaitToBeRunningWithTimeout(cli, namespace, name, 5*time.Minute)
+}
+
+func WaitToBeRunningWithTimeout(cli client.Client, namespace, name string, timeout time.Duration) error {
+	testlog.Infof("wait for the daemonset %q %q to be running", namespace, name)
+	return wait.PollImmediate(10*time.Second, timeout, func() (bool, error) {
+		return IsRunning(cli, namespace, name)
+	})
+}
+
+func GetByName(cli client.Client, namespace, name string) (*appsv1.DaemonSet, error) {
+	key := client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}
+	var ds appsv1.DaemonSet
+	err := cli.Get(context.TODO(), key, &ds)
+	return &ds, err
+}
+
+func IsRunning(cli client.Client, namespace, name string) (bool, error) {
+	ds, err := GetByName(cli, namespace, name)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			testlog.Warningf("daemonset %q %q not found - retrying", namespace, name)
+			return false, nil
+		}
+		return false, err
+	}
+	testlog.Infof("daemonset %q %q desired %d scheduled %d ready %d", namespace, name, ds.Status.DesiredNumberScheduled, ds.Status.CurrentNumberScheduled, ds.Status.NumberReady)
+	return (ds.Status.DesiredNumberScheduled > 0 && ds.Status.DesiredNumberScheduled == ds.Status.NumberReady), nil
+}

--- a/functests/utils/images/prepull.go
+++ b/functests/utils/images/prepull.go
@@ -1,0 +1,94 @@
+package images
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strconv"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	testds "github.com/openshift-kni/performance-addon-operators/functests/utils/daemonset"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
+)
+
+const (
+	PrePullPrefix                = "prepull"
+	PrePullDefaultTimeoutMinutes = "5"
+)
+
+// GetPullTimeout returns the pull timeout
+func GetPullTimeout() (time.Duration, error) {
+	prePullTimeoutMins, ok := os.LookupEnv("PREPULL_IMAGE_TIMEOUT_MINUTES")
+	if !ok {
+		prePullTimeoutMins = PrePullDefaultTimeoutMinutes
+	}
+	timeout, err := strconv.Atoi(prePullTimeoutMins)
+	return time.Duration(timeout) * time.Minute, err
+}
+
+// PrePull makes sure the image is pre-pulled on the relevant nodes.
+func PrePull(cli client.Client, pullSpec, namespace, tag string) (*appsv1.DaemonSet, error) {
+	name := PrePullPrefix + tag
+	ds := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": "prepull-daemonset-" + tag,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"name": "prepull-daemonset-" + tag,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "prepullcontainer",
+							Image:           pullSpec,
+							Command:         []string{"/bin/sleep"},
+							Args:            []string{"inf"},
+							ImagePullPolicy: corev1.PullAlways,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	prePullTimeout, err := GetPullTimeout()
+	if err != nil {
+		return &ds, err
+	}
+	testlog.Infof("pull timeout: %v", prePullTimeout)
+
+	testlog.Infof("creating daemonset %s/%s to prepull %q", namespace, name, pullSpec)
+	ts := time.Now()
+	err = cli.Create(context.TODO(), &ds)
+	if err != nil {
+		return &ds, err
+	}
+	data, _ := json.Marshal(ds)
+	testlog.Infof("created daemonset %s/%s to prepull %q:\n%s", namespace, name, pullSpec, string(data))
+
+	err = testds.WaitToBeRunningWithTimeout(testclient.Client, ds.Namespace, ds.Name, prePullTimeout)
+	if err != nil {
+		// if this fails, no big deal, we are just trying to make the troubleshooting easier
+		updatedDs, _ := testds.GetByName(testclient.Client, ds.Namespace, ds.Name)
+		return updatedDs, err
+	}
+	testlog.Infof("prepulled %q in %v", pullSpec, time.Since(ts))
+	return nil, nil
+}

--- a/tools/imgpull-tool/imgpull-tool.go
+++ b/tools/imgpull-tool/imgpull-tool.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/onsi/ginkgo"
+
+	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/images"
+)
+
+var (
+	namespace = flag.String("namespace", "default", "pnamespace to use for helper daemonset")
+)
+
+func main() {
+	flag.Parse()
+	if namespace == nil || *namespace == "" {
+		log.Fatal("missing namespace for the helper daemonset")
+	}
+
+	if !testclient.ClientsEnabled {
+		os.Exit(1)
+	}
+
+	// ugly hack to get logs from utils
+	ginkgo.GinkgoWriter = os.Stderr
+
+	ds, err := images.PrePull(testclient.Client, images.Test(), *namespace, "imgpull-tool-cnf-tests")
+	if err != nil {
+		log.Printf("DaemonSet %q %q for %q status: %v", ds.Namespace, ds.Name, images.Test(), ds.Status)
+		log.Fatal(fmt.Sprintf("prepull image %q failed: %v", images.Test(), err))
+	}
+}


### PR DESCRIPTION
In order to pre-pull container images on the worker nodes, we create bogus, extremely cheap daemonsets which pull the images as side effect in order to run.
We just sleep in these daemonsets, so they are as cheap as a container can be.

We run these daemonsets in the testing namespace, so, once the tests are all done, the daemonsets will be cleaned up explicitly; no explicit cleanup (albeit nice) is required.

Other alternatives are running jobs to pull images as side effects, but they don't seem to be much simpler than daemonsets.

Daemonsets need to be named explicitely from the caller, which must also ensure their name is unique. This is awkward, but automatic naming would make the code too complex for the task at hand: there is no immediate need, because the number of images we should pre pull is (and should be kept) limited.

Finally, it's worth pointing out that this solution, while it nicely reuses the kubernetes primitives and follows some already established pattern in the community isn't too great, because pre pulling images should be done as part as the cluster preparation stage; so, it is better done in the test setup stage, not in the test running stage.