### PR TITLE
[Release 4.7] Download ginkgo 1.21 directly in CI tools

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -6,6 +6,7 @@ ENV GOVERSION 1.13.5
 ENV GOPATH /go
 ENV GOBIN ${GOPATH}/bin
 ENV PATH=${PATH}:${GOROOT}/bin:${GOBIN}
+ENV GO111MODULE=on
 
 ARG GO_PACKAGE_PATH=github.com/openshift-kni/performance-addon-operators
 
@@ -19,14 +20,14 @@ RUN yum --setopt=install_weak_deps=False -y install \
     findutils \
     python2 \
     && yum clean all
-#test docker tools
+
 RUN mkdir -p $HOME && \
     # install go
     curl -JL https://dl.google.com/go/go${GOVERSION}.linux-amd64.tar.gz -o go.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz && \
     # get required golang tools and OC client
-    go get github.com/onsi/ginkgo/ginkgo && \
+    go get github.com/onsi/ginkgo/ginkgo@v1.12.1 && \
     go get golang.org/x/lint/golint && \
     go get github.com/mattn/goveralls && \
     go clean -cache -modcache && \


### PR DESCRIPTION
This is a test PR to check the status of docker.tools build in 4.7 