### PR TITLE
Revert "drone.io: remove"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,170 @@
+kind: pipeline
+type: docker
+name: release
+
+workspace:
+  # This should align with WORKDIR of openshift-ci/Dockerfile.tools
+  path: /go/src/github.com/openshift-kni/performance-addon-operators
+
+trigger:
+  ref:
+    include:
+    # Only release on tags with semver
+    # But glob pattern is a bit limited for this, and extended glob does not seem to work
+    # With this we will be fine for m.m.pp-bb[.pre], but we do not catch all invalid tags
+    - refs/tags/[0-9].[0-9].[0-9]-[0-9]*
+    - refs/tags/[0-9].[0-9].[0-9][0-9]-[0-9]*
+    - refs/tags/[0-9].[0-9].[0-9]-[0-9][0-9]*
+    - refs/tags/[0-9].[0-9].[0-9][0-9]-[0-9][0-9]*
+
+steps:
+  - name: build-tools-image
+    image: plugins/docker
+    settings:
+      dockerfile: openshift-ci/Dockerfile.tools
+      username:
+        from_secret: QUAY_USER
+      password:
+        from_secret: QUAY_PASSWORD
+      registry: quay.io
+      # This only works if github user == quay user!
+      repo: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-build-tools
+      tags:
+      - ${DRONE_TAG:-notset}
+
+  - name: build
+    image: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-build-tools:${DRONE_TAG:-notset}
+    environment:
+      CSV_VERSION: ${DRONE_SEMVER_SHORT}
+      REGISTRY_NAMESPACE: ${DRONE_REPO_NAMESPACE}
+      IMAGE_TAG: ${DRONE_TAG}
+    commands:
+      - git fetch --tags # Needed for the release note
+      - TAG=${DRONE_TAG} make build generate-csv release-note generate-release-tags
+
+  - name: build-operator-image
+    image: plugins/docker
+    settings:
+      dockerfile: openshift-ci/Dockerfile.deploy
+      username:
+        from_secret: QUAY_USER
+      password:
+        from_secret: QUAY_PASSWORD
+      build_args:
+      - BIN_DIR=build/_output/bin/
+      - ASSETS_DIR=build/assets
+      registry: quay.io
+      # This only works if github user == quay user!
+      repo: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator
+
+  - name: validate-operator-imgage
+    image: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator:${DRONE_TAG:-notset}
+    commands:
+      - ls /usr/local/bin/performance-operator
+      - "/usr/local/bin/performance-operator 2>&1 | grep \"Operator Version: ${DRONE_TAG}\""
+      - "/usr/local/bin/performance-operator 2>&1 | grep \"Git Commit: ${DRONE_COMMIT}\""
+
+  - name: build-must-gather-image
+    image: plugins/docker
+    settings:
+      dockerfile: openshift-ci/Dockerfile.must-gather
+      username:
+        from_secret: QUAY_USER
+      password:
+        from_secret: QUAY_PASSWORD
+      build_args:
+        - COLLECTION_SCRIPTS_DIR=must-gather/collection-scripts
+      registry: quay.io
+      # This only works if github user == quay user!
+      repo: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-must-gather
+
+  - name: validate-must-gather-image
+    image: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-must-gather:${DRONE_TAG:-notset}
+    commands:
+      # This is simplistic, need to figure out something smarter
+      - grep performance /usr/bin/gather
+
+  - name: github-release
+    image: plugins/github-release
+    settings:
+      api_key:
+        from_secret: GITHUB_TOKEN
+      title: ${DRONE_TAG}
+      note: build/_output/release-note.md
+      files:
+        - build/_output/olm-catalog/performance-addon-operator/${DRONE_SEMVER_SHORT}/*
+      checksum:
+        - sha256
+      draft: false # Setting this to true does not assign the release note to a tag...
+      prerelease: true # So use prerelease
+      overwrite: false
+    when:
+      ref:
+        exclude:
+          # do not create github releases when the tag contains the word "test"
+          - refs/tags/*test*
+
+---
+
+# This pipeline builds the build tool image for each branch, so it does not need to be build for every PR update
+# Builds based on changed files are supported by drone.io extensions only, which can't be installed on cloud.drone.io
+# See https://github.com/drone/drone/issues/1021#issuecomment-596127812
+
+kind: pipeline
+type: docker
+name: build-tools
+
+trigger:
+  event:
+    include:
+      - push
+  branch:
+    include:
+      - master
+      - release-*
+
+steps:
+  - name: build-tools-image
+    image: plugins/docker
+    settings:
+      dockerfile: openshift-ci/Dockerfile.tools
+      username:
+        from_secret: QUAY_USER
+      password:
+        from_secret: QUAY_PASSWORD
+      registry: quay.io
+      # This only works if github user == quay user!
+      repo: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-build-tools
+      tags:
+        - ${DRONE_BRANCH:-notset}
+
+---
+
+# This pipeline runs unit tests and creates coverage reports for coveralls.io
+kind: pipeline
+type: docker
+name: coverage
+
+workspace:
+  # This should align with WORKDIR of openshift-ci/Dockerfile.tools
+  path: /go/src/github.com/openshift-kni/performance-addon-operators
+
+trigger:
+  event:
+    include:
+      - push
+      - pull_request
+  branch:
+    include:
+      - master
+      - release-*
+
+steps:
+  - name: coverage
+    image: quay.io/${DRONE_REPO_NAMESPACE}/performance-addon-operator-build-tools:${DRONE_BRANCH:-notset}
+    environment:
+      COVERALLS_TOKEN:
+        from_secret: COVERALLS_REPO_TOKEN
+    commands:
+      - make unittests
+


### PR DESCRIPTION
This reverts commit 2c70aa9276442a44597ec7719028ecf6b60926e1.

Turns out the removal PR was merged too hastily, and we want to keep drone.io integration.