### PR TITLE
functests: utils: add and use event reporting

### DIFF
--- a/functests/4_latency/test_suite_latency_test.go
+++ b/functests/4_latency/test_suite_latency_test.go
@@ -4,6 +4,7 @@ package __latency_test
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -39,6 +40,8 @@ var _ = AfterSuite(func() {
 
 func TestLatency(t *testing.T) {
 	RegisterFailHandler(Fail)
+
+	testlog.Infof("KUBECONFIG=%q", os.Getenv("KUBECONFIG"))
 
 	rr := []Reporter{}
 	if ginkgo_reporters.Polarion.Run {

--- a/functests/utils/events/events.go
+++ b/functests/utils/events/events.go
@@ -1,0 +1,19 @@
+package events
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetEventsForObject(cli client.Client, namespace, name, uid string) (corev1.EventList, error) {
+	eventList := corev1.EventList{}
+	match := client.MatchingFields{
+		"involvedObject.name": name,
+		"involvedObject.uid":  uid,
+	}
+	err := cli.List(context.TODO(), &eventList, &client.ListOptions{Namespace: namespace}, match)
+	return eventList, err
+}


### PR DESCRIPTION
Add a function to fetch the events associated to a object,
and use it into the 4_latency suite to troubleshoot the
pod startup issues.

Also add a trivial tester program.

Signed-off-by: Francesco Romani <fromani@redhat.com>