### PR TITLE
Bug 2018159: must-gather: fix run when using two images

### DIFF
--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -24,7 +24,9 @@ NAMESPACE_MANIFEST="/etc/node-gather/namespace.yaml"
 SERVICEACCOUNT_MANIFEST="/etc/node-gather/serviceaccount.yaml"
 DAEMONSET_MANIFEST="/etc/node-gather/daemonset.yaml"
 NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
-POD_NAME=$(oc get pods -l 'app=must-gather' -n $NAMESPACE -o'custom-columns=name:metadata.name' --no-headers)
+# Once you start the pod, the Kubernetes will set the pod hostname to the name of the pod
+# https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-hostname-and-subdomain-fields
+POD_NAME=${HOSTNAME}
 MUST_GATHER_IMAGE=$(oc get pod -n $NAMESPACE $POD_NAME -o jsonpath="{.spec.containers[0].image}")
 
 POD_IP=$(hostname -I |  tr -d "[:blank:]" )


### PR DESCRIPTION
    Fix bug identified when launch cmd:
    oc adm must-gather --image="" --image=""
    
    The fix takes POD_NAME from hostname instead of oc get pods
    
    Tested on 4.8 and 4.9 both SNO and standard one
