### PR TITLE
Latency e2e: Verify node has sufficient cpu

### DIFF
--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -99,7 +99,15 @@ var _ = Describe("[performance] Latency Test", func() {
 		Expect(err).ToNot(HaveOccurred(), "error looking for the optional selector: %v", err)
 
 		Expect(workerRTNodes).ToNot(BeEmpty())
-		workerRTNode = &workerRTNodes[0]
+
+		//At least one worker node should have cpu.Allocatable greater than the quantity requested by each test, else skip the test
+		workerRTNodesWithSufficientCpu := nodes.GetByCpuAllocatable(workerRTNodes, latencyTestCpus)
+		if len(workerRTNodesWithSufficientCpu) == 0 {
+			Skip("Insufficient cpu to run the test")
+
+		}
+		workerRTNode = &workerRTNodesWithSufficientCpu[0]
+
 	})
 
 	AfterEach(func() {
@@ -452,7 +460,7 @@ func createLatencyTestPod(testPod *corev1.Pod, node *corev1.Node, logName string
 		By("Checking actual CPUs number for the running pod")
 		limitsCpusQuantity := testPod.Spec.Containers[0].Resources.Limits.Cpu()
 		RequestsCpusQuantity := testPod.Spec.Containers[0].Resources.Requests.Cpu()
-		//letancy pod is guaranteed
+		//latency pod is guaranteed
 		Expect(isEqual(limitsCpusQuantity, latencyTestCpus)).To(BeTrue(), fmt.Sprintf("actual limits of cpus number used for the latency pod is not as set in LATENCY_TEST_CPUS, actual number is: %s", limitsCpusQuantity))
 		Expect(isEqual(RequestsCpusQuantity, latencyTestCpus)).To(BeTrue(), fmt.Sprintf("actual requests of cpus number used for the latency pod is not as set in LATENCY_TEST_CPUS, actual number is: %s", RequestsCpusQuantity))
 	}

--- a/functests/utils/nodes/nodes.go
+++ b/functests/utils/nodes/nodes.go
@@ -299,3 +299,14 @@ func TunedForNode(node *corev1.Node, sno bool) *corev1.Pod {
 
 	return &tunedList.Items[0]
 }
+
+func GetByCpuAllocatable(nodesList []corev1.Node, cpuQty int) []corev1.Node {
+	nodesWithSufficientCpu := []corev1.Node{}
+	for _, node := range nodesList {
+		allocatableCPU, _ := node.Status.Allocatable.Cpu().AsInt64()
+		if allocatableCPU >= int64(cpuQty) {
+			nodesWithSufficientCpu = append(nodesWithSufficientCpu, node)
+		}
+	}
+	return nodesWithSufficientCpu
+}


### PR DESCRIPTION
The machines on which CI runs have few cpus (1-2 typically) for cost/scalability reasons.
Our tests want to exclusively allocate 1 or more cpus, which is impossible or impractical.
Trying to run our tests in these machines will lead to false negatives.

To keep the lane reliable, we add a check for worker nodes to verify nodes have sufficient
cpu amount to run the tests. Should not be the case, we skip the test (instead of failing).
