### PR TITLE
Makefile: modify suits for target functests-latency-testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ functests-latency: cluster-label-worker-cnf
 
 .PHONY: functests-latency-testing
 functests-latency-testing: dist-latency-tests
-	GINKGO_SUITS="functests/5_latency_testing" hack/run-latency-testing.sh
+	GINKGO_SUITS="functests/0_config functests/5_latency_testing" hack/run-latency-testing.sh
 
 .PHONY: operator-upgrade-tests
 operator-upgrade-tests:


### PR DESCRIPTION
Latency tests will fail if discovery mode is disabled and performance profile is not found on the cluster.

To allow proper latency testing, we add functests/0_config suit to ginkgo suits of the target functests-latency-testing, a suit that will handle creating the profile in case it doesn't exist or continue executing the tests directly if exists.