### PR TITLE
kubelet: cpumanager: add pcpus-only

### DIFF
--- a/functests/utils/pods/pods.go
+++ b/functests/utils/pods/pods.go
@@ -87,7 +87,7 @@ func WaitForCondition(pod *corev1.Pod, conditionType corev1.PodConditionType, co
 	})
 }
 
-// WaitForPredicate waits until the fiven predicate against the pod returns true or error.
+// WaitForPredicate waits until the given predicate against the pod returns true or error.
 func WaitForPredicate(pod *corev1.Pod, timeout time.Duration, pred func(pod *corev1.Pod) (bool, error)) error {
 	key := types.NamespacedName{
 		Name:      pod.Name,

--- a/functests/utils/pods/pods.go
+++ b/functests/utils/pods/pods.go
@@ -87,6 +87,26 @@ func WaitForCondition(pod *corev1.Pod, conditionType corev1.PodConditionType, co
 	})
 }
 
+// WaitForPredicate waits until the fiven predicate against the pod returns true or error.
+func WaitForPredicate(pod *corev1.Pod, timeout time.Duration, pred func(pod *corev1.Pod) (bool, error)) error {
+	key := types.NamespacedName{
+		Name:      pod.Name,
+		Namespace: pod.Namespace,
+	}
+	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		updatedPod := &corev1.Pod{}
+		if err := testclient.Client.Get(context.TODO(), key, updatedPod); err != nil {
+			return false, nil
+		}
+
+		ret, err := pred(updatedPod)
+		if err != nil {
+			return false, err
+		}
+		return ret, nil
+	})
+}
+
 // WaitForPhase waits until the pod will have specified phase
 func WaitForPhase(pod *corev1.Pod, phase corev1.PodPhase, timeout time.Duration) error {
 	key := types.NamespacedName{

--- a/pkg/controller/performanceprofile/components/kubeletconfig/kubeletconfig.go
+++ b/pkg/controller/performanceprofile/components/kubeletconfig/kubeletconfig.go
@@ -28,6 +28,7 @@ const (
 	// Please avoid specifying them and use the relevant API to configure these parameters.
 	experimentalKubeletSnippetAnnotation = "kubeletconfig.experimental"
 	cpuManagerPolicyStatic               = "static"
+	cpuManagerPolicyOptionFullPCPUsOnly  = "full-pcpus-only"
 	memoryManagerPolicyStatic            = "Static"
 	defaultKubeReservedMemory            = "500Mi"
 	defaultSystemReservedMemory          = "500Mi"
@@ -114,6 +115,17 @@ func New(profile *performancev2.PerformanceProfile, profileMCPLabels map[string]
 								corev1.ResourceMemory: *reservedMemory,
 							},
 						},
+					}
+				}
+
+				// require full physical CPUs only to ensure maximum isolation
+				if topologyPolicy == kubeletconfigv1beta1.SingleNumaNodeTopologyManagerPolicy {
+					if kubeletConfig.CPUManagerPolicyOptions == nil {
+						kubeletConfig.CPUManagerPolicyOptions = make(map[string]string)
+					}
+
+					if _, ok := kubeletConfig.CPUManagerPolicyOptions[cpuManagerPolicyOptionFullPCPUsOnly]; !ok {
+						kubeletConfig.CPUManagerPolicyOptions[cpuManagerPolicyOptionFullPCPUsOnly] = "true"
 					}
 				}
 			}

--- a/testdata/render-expected-output/manual_kubeletconfig.yaml
+++ b/testdata/render-expected-output/manual_kubeletconfig.yaml
@@ -21,6 +21,8 @@ spec:
         cacheAuthorizedTTL: 0s
         cacheUnauthorizedTTL: 0s
     cpuManagerPolicy: static
+    cpuManagerPolicyOptions:
+      full-pcpus-only: "true"
     cpuManagerReconcilePeriod: 5s
     evictionHard:
       memory.available: 100Mi


### PR DESCRIPTION
When we require the strictest NUMA alignment, we also enable
the cpumanager policy option to require full physical cores only,
a feature available in kube >= 1.23.

Signed-off-by: Francesco Romani <fromani@redhat.com>