### PR TITLE
Set isolated and required CPU parameter in CRD

### DIFF
--- a/api/v2/performanceprofile_types.go
+++ b/api/v2/performanceprofile_types.go
@@ -78,7 +78,7 @@ type CPUSet string
 // CPU defines a set of CPU related features.
 type CPU struct {
 	// Reserved defines a set of CPUs that will not be used for any container workloads initiated by kubelet.
-	Reserved *CPUSet `json:"reserved,omitempty"`
+	Reserved *CPUSet `json:"reserved"`
 	// Isolated defines a set of CPUs that will be used to give to application threads the most execution time possible,
 	// which means removing as many extraneous tasks off a CPU as possible.
 	// It is important to notice the CPU manager can choose any CPU to run the workload

--- a/config/crd/bases/performance.openshift.io_performanceprofiles.yaml
+++ b/config/crd/bases/performance.openshift.io_performanceprofiles.yaml
@@ -494,6 +494,7 @@ spec:
                     type: string
                 required:
                 - isolated
+                - reserved
                 type: object
               globallyDisableIrqLoadBalancing:
                 description: GloballyDisableIrqLoadBalancing toggles whether IRQ load

--- a/deploy/olm-catalog/performance-addon-operator/4.10.0/performance.openshift.io_performanceprofiles_crd.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.10.0/performance.openshift.io_performanceprofiles_crd.yaml
@@ -492,6 +492,7 @@ spec:
                     type: string
                 required:
                 - isolated
+                - reserved
                 type: object
               globallyDisableIrqLoadBalancing:
                 description: GloballyDisableIrqLoadBalancing toggles whether IRQ load

--- a/docs/performance_profile.md
+++ b/docs/performance_profile.md
@@ -27,7 +27,7 @@ CPU defines a set of CPU related features.
 
 | Field | Description | Scheme | Required |
 | ----- | ----------- | ------ | -------- |
-| reserved | Reserved defines a set of CPUs that will not be used for any container workloads initiated by kubelet. | *[CPUSet](#cpuset) | false |
+| reserved | Reserved defines a set of CPUs that will not be used for any container workloads initiated by kubelet. | *[CPUSet](#cpuset) | true |
 | isolated | Isolated defines a set of CPUs that will be used to give to application threads the most execution time possible, which means removing as many extraneous tasks off a CPU as possible. It is important to notice the CPU manager can choose any CPU to run the workload except the reserved CPUs. In order to guarantee that your workload will run on the isolated CPU:\n  1. The union of reserved CPUs and isolated CPUs should include all online CPUs\n  2. The isolated CPUs field should be the complementary to reserved CPUs field | *[CPUSet](#cpuset) | true |
 | balanceIsolated | BalanceIsolated toggles whether or not the Isolated CPU set is eligible for load balancing work loads. When this option is set to \"false\", the Isolated CPU set will be static, meaning workloads have to explicitly assign each thread to a specific cpu in order to work across multiple CPUs. Setting this to \"true\" allows workloads to be balanced across CPUs. Setting this to \"false\" offers the most predictable performance for guaranteed workloads, but it offloads the complexity of cpu load balancing to the application. Defaults to \"true\" | *bool | false |
 


### PR DESCRIPTION
## Description

Set isolated and reserved to required CPU parameters in CRD

Bug 4.7: https://bugzilla.redhat.com/show_bug.cgi?id=1986681

## Type of change

Documentation fix

## Testing steps
In performance_profile.yaml:

  cpu:
    isolated: "1-3"
    ##reserved: "0" <----       Remove reserved

Test of performanceProfile crashes in 4.7 

Besides that, must be compulsory in every Release after 4.7
