### PR TITLE
Pin ginkgo version in Dockerfile.tools

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -6,6 +6,7 @@ ENV GOVERSION=1.16.3
 ENV GOPATH=/go
 ENV GOBIN=${GOPATH}/bin
 ENV PATH=${PATH}:${GOROOT}/bin:${GOBIN}
+ENV GINKGO_VERSION v1.12.1
 
 ARG GO_PACKAGE_PATH=github.com/openshift-kni/performance-addon-operators
 
@@ -26,7 +27,7 @@ RUN mkdir -p $HOME && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz && \
     # get required golang tools and OC client
-    go get github.com/onsi/ginkgo/ginkgo && \
+    go get github.com/onsi/ginkgo/ginkgo@${GINKGO_VERSION} && \
     go get golang.org/x/lint/golint && \
     go get github.com/mattn/goveralls && \
     go clean -cache -modcache && \

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -7,7 +7,7 @@ ENV GOPATH=/go
 ENV GOBIN=${GOPATH}/bin
 ENV PATH=${PATH}:${GOROOT}/bin:${GOBIN}
 ENV GO111MODULE=on
-ENV GINKGO_VERSION v1.12.1
+ENV GINKGO_VERSION=v1.12.1
 
 ARG GO_PACKAGE_PATH=github.com/openshift-kni/performance-addon-operators
 

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -6,6 +6,7 @@ ENV GOVERSION=1.16.3
 ENV GOPATH=/go
 ENV GOBIN=${GOPATH}/bin
 ENV PATH=${PATH}:${GOROOT}/bin:${GOBIN}
+ENV GO111MODULE=on
 ENV GINKGO_VERSION v1.12.1
 
 ARG GO_PACKAGE_PATH=github.com/openshift-kni/performance-addon-operators


### PR DESCRIPTION
The build system is trying to download and compile the latest ginkgo
version, which is too new and doesn't work anymore with the golang
version we use