### PR TITLE
controller: fix kubeletconfig predicates

### DIFF
--- a/controllers/performanceprofile_controller.go
+++ b/controllers/performanceprofile_controller.go
@@ -87,7 +87,8 @@ func (r *PerformanceProfileReconciler) SetupWithManager(mgr ctrl.Manager) error 
 			kubeletOld := e.ObjectOld.(*mcov1.KubeletConfig)
 			kubeletNew := e.ObjectNew.(*mcov1.KubeletConfig)
 
-			return !reflect.DeepEqual(kubeletOld.Status.Conditions, kubeletNew.Status.Conditions)
+			return kubeletOld.GetGeneration() != kubeletNew.GetGeneration() ||
+				!reflect.DeepEqual(kubeletOld.Status.Conditions, kubeletNew.Status.Conditions)
 		},
 	}
 


### PR DESCRIPTION
The controller should react to changes under our own
KubeletConfig and restore it to the desired state.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>