### PR TITLE
tuned base profile to support new scheduler nobs

### DIFF
--- a/build/assets/tuned/openshift-node-performance
+++ b/build/assets/tuned/openshift-node-performance
@@ -44,6 +44,10 @@ banned_cpus=""
 runtime=0
 group.ksoftirqd=0:f:11:*:ksoftirqd.*
 group.rcuc=0:f:11:*:rcuc.*
+sched_rt_runtime_us=-1
+sched_min_granularity_ns=10000000
+sched_migration_cost_ns=5000000
+numa_balancing=0
 {{if not .GloballyDisableIrqLoadBalancing}}
 default_irq_smp_affinity = ignore
 {{end}}

--- a/testdata/render-expected-output/manual_tuned.yaml
+++ b/testdata/render-expected-output/manual_tuned.yaml
@@ -23,7 +23,7 @@ spec:
       isolated_cores take a list of ranges; e.g. isolated_cores=2,4-7\n\nisolated_cores=1-3\n\n\nnot_isolated_cores_expanded=${f:cpulist_invert:${isolated_cores_expanded}}\n\n[cpu]\n#>
       latency-performance\n#> (override)\nforce_latency=cstate.id:1|3\ngovernor=performance\nenergy_perf_bias=performance\nmin_perf_pct=100\n\n[service]\nservice.stalld=start,enable\n\n[vm]\n#>
       network-latency\ntransparent_hugepages=never\n\n\n[irqbalance]\n#> Override
-      the value set by cpu-partitioning with an empty one\nbanned_cpus=\"\"\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\n\ndefault_irq_smp_affinity
+      the value set by cpu-partitioning with an empty one\nbanned_cpus=\"\"\n\n\n[scheduler]\nruntime=0\ngroup.ksoftirqd=0:f:11:*:ksoftirqd.*\ngroup.rcuc=0:f:11:*:rcuc.*\nsched_rt_runtime_us=-1\nsched_min_granularity_ns=10000000\nsched_migration_cost_ns=5000000\nnuma_balancing=0\n\ndefault_irq_smp_affinity
       = ignore\n\n\n[sysctl]\n#> cpu-partitioning #realtime\nkernel.hung_task_timeout_secs
       = 600\n#> cpu-partitioning #realtime\nkernel.nmi_watchdog = 0\n#> realtime\nkernel.sched_rt_runtime_us
       = -1\n#> cpu-partitioning (= 1) #realtime (= 0)\nkernel.timer_migration = 0\n#>


### PR DESCRIPTION
tuned was updated to handle new kernels (5.13 and newer) 
see https://github.com/redhat-performance/tuned/pull/365
the new kernels moved some sched_ and numa_ knobs from
the sysctl to the debugfs, thus add and abstract these knobs under the
scheduler plugin. With help of this abstraction it will write
the tuning to the correct place according to the kernel used.

Example:
[scheduler]
sched_migration_cost_ns = 500000

Will work on the old kernel the same way as:
[sysctl]
kernel.sched_migration_cost_ns = 500000

all occurences of sched_ and numa_ knobs were added
under the [scheduler] section in the base tuned profile in PAO

Signed-off-by: Yanir Quinn <yquinn@redhat.com>