### PR TITLE
Add clean to make generate to avoid _output garbage issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ govet:
 	go vet ./...
 
 .PHONY: generate
-generate: deps-update gofmt manifests generate-code generate-latest-dev-csv generate-docs
+generate: clean deps-update gofmt manifests generate-code generate-latest-dev-csv generate-docs
 	@echo Updating generated files
 	@echo
 


### PR DESCRIPTION
Sometimes make generate works incorrectly and generate garbage files due to old /build/_output files. 

Usually this happens when cherry picking and generating new files between releases. 

Signed-off-by: Mario Fernandez <mariofer@redhat.com>