### PR TITLE
Latency tests: skip running open BZ scenarios

### DIFF
--- a/functests/5_latency_testing/latency_testing.go
+++ b/functests/5_latency_testing/latency_testing.go
@@ -207,8 +207,11 @@ func getValidValuesTests(toolToTest string) []latencyTest {
 	var testSet []latencyTest
 	testSet = append(testSet, latencyTest{testDelay: "0", testRun: "true", testRuntime: "5", testMaxLatency: guaranteedLatency, testCpus: "2", outputMsgs: []string{success}, toolToTest: toolToTest})
 	testSet = append(testSet, latencyTest{testDelay: "0", testRun: "true", testRuntime: "1", testMaxLatency: guaranteedLatency, testCpus: "5", outputMsgs: []string{success}, toolToTest: toolToTest})
-	testSet = append(testSet, latencyTest{testDelay: "1", testRun: "true", testRuntime: "2", testMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
-	testSet = append(testSet, latencyTest{testDelay: "60", testRun: "true", testRuntime: "2", testMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
+	//BZ https://bugzilla.redhat.com/show_bug.cgi?id=2006675
+	if toolToTest == oslat {
+		testSet = append(testSet, latencyTest{testDelay: "1", testRun: "true", testRuntime: "2", testMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
+		testSet = append(testSet, latencyTest{testDelay: "60", testRun: "true", testRuntime: "2", testMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
+	}
 	if toolToTest != hwlatdetect {
 		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "5", outputMsgs: []string{skip, skipMaxLatency}, toolToTest: toolToTest})
 	}


### PR DESCRIPTION
Due to bugzilla 2006675, cyclictest & hwlatdetec fail with parsing error resulting in pipelines failure.

To avoid failing the pipelines caused by known bugs & up until it is fixed, skip executing these two test scenarios & run them only with oslat.