### PR TITLE
Bug 2021202: Enable PAO image precaching

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,7 +31,6 @@ spec:
           image: REPLACE_IMAGE
           command:
           - performance-operator
-          imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/deploy/olm-catalog/performance-addon-operator/4.10.0/performance-addon-operator.v4.10.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/performance-addon-operator/4.10.0/performance-addon-operator.v4.10.0.clusterserviceversion.yaml
@@ -252,7 +252,6 @@ spec:
                 - name: OPERATOR_NAME
                   value: performance-operator
                 image: REPLACE_IMAGE
-                imagePullPolicy: Always
                 name: performance-operator
                 resources:
                   requests:


### PR DESCRIPTION
## Motivation ##
In the Telco far edge use case, a cluster might have limited management bandwidth. Upgrading such a cluster is expected to be 
time-constrained (capped by a maintenance window), and will involve container image pre-caching on the node before the upgrade.
Image pre-caching solution for SNOs relies on the assumption, that workloads can use locally stored images without contacting a registry.  This is only possible if container image pull policy is set to "IfNotPresent".
Current PAO image pull policy is explicitly set to "Always", which impairs the benefits of pre-caching
## Possible side effects ##
### Impact on operator upgrades ###
While solves a particular problem for SNO, this solution does not affect upgrades of any other deployment configuration in a negative way. Since all operator images are referenced by sha256 digest, any image update will have the digest changed, and the new image will be pulled. 
The solution might also improve the performance by eliminating unnecessary image pulls, for example every time the pod restarts.
### Impact on security ###
The security risk here, is if an adversary  manages to push a hacked local copy to the node. 
However, most of the operators are using imagePullPolicy "IfNotPresent". The attack surface increase by this particular change is negligible 