### PR TITLE
e2e: Add missing TCs IDs

### DIFF
--- a/functests/1_performance/cpu_management.go
+++ b/functests/1_performance/cpu_management.go
@@ -220,8 +220,8 @@ var _ = Describe("[rfe_id:27363][performance] CPU Management", func() {
 
 			Expect(cpu).To(BeElementOf(listCPU))
 		},
-			table.Entry("Non-guaranteed POD can work on any CPU", false),
-			table.Entry("Guaranteed POD should work on isolated cpu", true),
+			table.Entry("[test_id:37860] Non-guaranteed POD can work on any CPU", false),
+			table.Entry("[test_id:27492] Guaranteed POD should work on isolated cpu", true),
 		)
 	})
 


### PR DESCRIPTION
Added missing TCs ids so that their results will be reported to Polarion automatically.