### PR TITLE
hack: show cluster version before to run functests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,8 @@ functests: cluster-label-worker-cnf functests-only
 
 .PHONY: functests-only
 functests-only:
+	@echo "Cluster Version"
+	hack/show-cluster-version.sh
 	hack/run-functests.sh
 
 .PHONY: functests-latency
@@ -313,6 +315,8 @@ ci-job: verify build unittests
 
 .PHONY: ci-tools-job
 ci-tools-job:
+	@echo "Cluster Version"
+	hack/show-cluster-version.sh
 	@echo "Verifying tools operation"
 	hack/verify-tools.sh
 	

--- a/hack/show-cluster-version.sh
+++ b/hack/show-cluster-version.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# expect oc to be in PATH by default
+OC_TOOL="${OC_TOOL:-oc}"
+
+echo "Cluster version"
+${OC_TOOL} version || :
+${OC_TOOL} get nodes -o custom-columns=VERSION:.status.nodeInfo.kubeletVersion || :
+${OC_TOOL} get clusterversion || :


### PR DESCRIPTION
For debug purposes, to doublcheck the reported cluster version

Signed-off-by: Francesco Romani <fromani@redhat.com>