### PR TITLE
enable cpumanager policy options - full-pcpus-only

### DIFF
--- a/functests/utils/nodes/nodes.go
+++ b/functests/utils/nodes/nodes.go
@@ -34,6 +34,10 @@ const (
 	testPollInterval = 2
 )
 
+const (
+	sysDevicesOnlineCPUs = "/sys/devices/system/cpu/online"
+)
+
 // NumaNodes defines cpus in each numa node
 type NumaNodes struct {
 	Cpus []NodeCPU `json:"cpus"`
@@ -235,12 +239,25 @@ func GetDefaultSmpAffinitySet(node *corev1.Node) (cpuset.CPUSet, error) {
 
 // GetOnlineCPUsSet returns the list of online (being scheduled) CPUs on the node
 func GetOnlineCPUsSet(node *corev1.Node) (cpuset.CPUSet, error) {
-	command := []string{"cat", "/sys/devices/system/cpu/online"}
+	command := []string{"cat", sysDevicesOnlineCPUs}
 	onlineCPUs, err := ExecCommandOnNode(command, node)
 	if err != nil {
 		return cpuset.NewCPUSet(), err
 	}
 	return cpuset.Parse(onlineCPUs)
+}
+
+// GetSMTLevel returns the SMT level on the node using the given cpuID as target
+// Use a random cpuID from the return value of GetOnlineCPUsSet if not sure
+func GetSMTLevel(cpuID int, node *corev1.Node) int {
+	cmd := []string{"/bin/sh", "-c", fmt.Sprintf("cat /sys/devices/system/cpu/cpu%d/topology/thread_siblings_list | tr -d \"\n\r\"", cpuID)}
+	threadSiblingsList, err := ExecCommandOnNode(cmd, node)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	// how many thread sibling you have = SMT level
+	// example: 2-way SMT means 2 threads sibling for each thread
+	cpus, err := cpuset.Parse(strings.TrimSpace(string(threadSiblingsList)))
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	return cpus.Size()
 }
 
 // GetNumaNodes returns the number of numa nodes and the associated cpus as list on the node

--- a/functests/utils/pods/pods.go
+++ b/functests/utils/pods/pods.go
@@ -87,6 +87,22 @@ func WaitForCondition(pod *corev1.Pod, conditionType corev1.PodConditionType, co
 	})
 }
 
+// WaitForPredicate waits until the given predicate against the pod returns true or error.
+func WaitForPredicate(pod *corev1.Pod, timeout time.Duration, pred func(pod *corev1.Pod) (bool, error)) error {
+	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		updatedPod := &corev1.Pod{}
+		if err := testclient.Client.Get(context.TODO(), client.ObjectKeyFromObject(pod), updatedPod); err != nil {
+			return false, nil
+		}
+
+		ret, err := pred(updatedPod)
+		if err != nil {
+			return false, err
+		}
+		return ret, nil
+	})
+}
+
 // WaitForPhase waits until the pod will have specified phase
 func WaitForPhase(pod *corev1.Pod, phase corev1.PodPhase, timeout time.Duration) error {
 	key := types.NamespacedName{

--- a/pkg/controller/performanceprofile/components/kubeletconfig/kubeletconfig.go
+++ b/pkg/controller/performanceprofile/components/kubeletconfig/kubeletconfig.go
@@ -28,6 +28,7 @@ const (
 	// Please avoid specifying them and use the relevant API to configure these parameters.
 	experimentalKubeletSnippetAnnotation = "kubeletconfig.experimental"
 	cpuManagerPolicyStatic               = "static"
+	cpuManagerPolicyOptionFullPCPUsOnly  = "full-pcpus-only"
 	memoryManagerPolicyStatic            = "Static"
 	defaultKubeReservedMemory            = "500Mi"
 	defaultSystemReservedMemory          = "500Mi"
@@ -114,6 +115,17 @@ func New(profile *performancev2.PerformanceProfile, profileMCPLabels map[string]
 								corev1.ResourceMemory: *reservedMemory,
 							},
 						},
+					}
+				}
+
+				// require full physical CPUs only to ensure maximum isolation
+				if topologyPolicy == kubeletconfigv1beta1.SingleNumaNodeTopologyManagerPolicy {
+					if kubeletConfig.CPUManagerPolicyOptions == nil {
+						kubeletConfig.CPUManagerPolicyOptions = make(map[string]string)
+					}
+
+					if _, ok := kubeletConfig.CPUManagerPolicyOptions[cpuManagerPolicyOptionFullPCPUsOnly]; !ok {
+						kubeletConfig.CPUManagerPolicyOptions[cpuManagerPolicyOptionFullPCPUsOnly] = "true"
 					}
 				}
 			}

--- a/pkg/controller/performanceprofile/components/kubeletconfig/kubeletconfig_test.go
+++ b/pkg/controller/performanceprofile/components/kubeletconfig/kubeletconfig_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Kubelet Config", func() {
 		Expect(manifest).To(ContainSubstring("topologyManagerPolicy: single-numa-node"))
 		Expect(manifest).To(ContainSubstring("cpuManagerPolicy: static"))
 		Expect(manifest).To(ContainSubstring("memoryManagerPolicy: Static"))
+		Expect(manifest).To(ContainSubstring("cpuManagerPolicyOptions"))
 		Expect(manifest).To(ContainSubstring(testReservedMemory))
 	})
 
@@ -53,6 +54,21 @@ var _ = Describe("Kubelet Config", func() {
 			Expect(manifest).To(ContainSubstring("memoryManagerPolicy: Static"))
 			Expect(manifest).To(ContainSubstring(testReservedMemory))
 		})
+
+		It("should not have the cpumanager policy options set", func() {
+			profile := testutils.NewPerformanceProfile("test")
+			profile.Spec.NUMA.TopologyPolicy = pointer.String(kubeletconfigv1beta1.RestrictedTopologyManagerPolicy)
+			selectorKey, selectorValue := components.GetFirstKeyAndValue(profile.Spec.MachineConfigPoolSelector)
+			kc, err := New(profile, map[string]string{selectorKey: selectorValue})
+			Expect(err).ToNot(HaveOccurred())
+
+			y, err := yaml.Marshal(kc)
+			Expect(err).ToNot(HaveOccurred())
+
+			manifest := string(y)
+			Expect(manifest).ToNot(ContainSubstring("cpuManagerPolicyOptions"))
+		})
+
 	})
 
 	Context("with topology manager best-effort policy", func() {
@@ -133,5 +149,21 @@ var _ = Describe("Kubelet Config", func() {
 			Expect(manifest).To(ContainSubstring("net.core.somaxconn"))
 			Expect(manifest).To(ContainSubstring("memory.available: 200Mi"))
 		})
+
+		It("should allow to override the cpumanager policy options and update the kubelet config accordingly", func() {
+			profile := testutils.NewPerformanceProfile("test")
+			profile.Annotations = map[string]string{
+				experimentalKubeletSnippetAnnotation: `{"allowedUnsafeSysctls": ["net.core.somaxconn"], "cpuManagerPolicyOptions": {"full-pcpus-only": "false"}}`,
+			}
+			selectorKey, selectorValue := components.GetFirstKeyAndValue(profile.Spec.MachineConfigPoolSelector)
+			kc, err := New(profile, map[string]string{selectorKey: selectorValue})
+			data, err := yaml.Marshal(kc)
+			Expect(err).ToNot(HaveOccurred())
+
+			manifest := string(data)
+			Expect(manifest).To(ContainSubstring("net.core.somaxconn"))
+			Expect(manifest).To(ContainSubstring(`full-pcpus-only: "false"`))
+		})
+
 	})
 })

--- a/testdata/render-expected-output/manual_kubeletconfig.yaml
+++ b/testdata/render-expected-output/manual_kubeletconfig.yaml
@@ -21,6 +21,8 @@ spec:
         cacheAuthorizedTTL: 0s
         cacheUnauthorizedTTL: 0s
     cpuManagerPolicy: static
+    cpuManagerPolicyOptions:
+      full-pcpus-only: "true"
     cpuManagerReconcilePeriod: 5s
     evictionHard:
       memory.available: 100Mi


### PR DESCRIPTION
When we require the strictest NUMA alignment, we also enable the cpumanager policy option to require full physical cores only,
a feature available in kube >= 1.23.

Reprises https://github.com/openshift-kni/performance-addon-operators/pull/790