### PR TITLE
Embed assets under the go compiled code

### DIFF
--- a/build/assets/assets.go
+++ b/build/assets/assets.go
@@ -1,0 +1,19 @@
+package assets
+
+import (
+	"embed"
+)
+
+var (
+	// Configs contains all files that placed under the configs directory
+	//go:embed configs
+	Configs embed.FS
+
+	// Scripts contains all files that placed under the scripts directory
+	//go:embed scripts
+	Scripts embed.FS
+
+	// Tuned contains all files that placed under the tuned directory
+	//go:embed tuned
+	Tuned embed.FS
+)

--- a/controllers/performanceprofile_controller.go
+++ b/controllers/performanceprofile_controller.go
@@ -57,9 +57,8 @@ const finalizer = "foreground-deletion"
 // PerformanceProfileReconciler reconciles a PerformanceProfile object
 type PerformanceProfileReconciler struct {
 	client.Client
-	Scheme    *runtime.Scheme
-	Recorder  record.EventRecorder
-	AssetsDir string
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 // SetupWithManager creates a new PerformanceProfile Controller and adds it to the Manager.
@@ -392,7 +391,7 @@ func (r *PerformanceProfileReconciler) applyComponents(profile *performancev2.Pe
 		return nil, nil
 	}
 
-	components, err := manifestset.GetNewComponents(profile, profileMCP, &r.AssetsDir)
+	components, err := manifestset.GetNewComponents(profile, profileMCP)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/performanceprofile_controller_test.go
+++ b/controllers/performanceprofile_controller_test.go
@@ -37,8 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const assetsDir = "../build/assets"
-
 var _ = Describe("Controller", func() {
 	var request reconcile.Request
 	var profile *performancev2.PerformanceProfile
@@ -243,13 +241,13 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should remove outdated tuned objects", func() {
-			tunedOutdatedA, err := tuned.NewNodePerformance(assetsDir, profile)
+			tunedOutdatedA, err := tuned.NewNodePerformance(profile)
 			Expect(err).ToNot(HaveOccurred())
 			tunedOutdatedA.Name = "outdated-a"
 			tunedOutdatedA.OwnerReferences = []metav1.OwnerReference{
 				{Name: profile.Name},
 			}
-			tunedOutdatedB, err := tuned.NewNodePerformance(assetsDir, profile)
+			tunedOutdatedB, err := tuned.NewNodePerformance(profile)
 			Expect(err).ToNot(HaveOccurred())
 			tunedOutdatedB.Name = "outdated-b"
 			tunedOutdatedB.OwnerReferences = []metav1.OwnerReference{
@@ -334,14 +332,14 @@ var _ = Describe("Controller", func() {
 			BeforeEach(func() {
 				var err error
 
-				mc, err = machineconfig.New(assetsDir, profile)
+				mc, err = machineconfig.New(profile)
 				Expect(err).ToNot(HaveOccurred())
 
 				mcpSelectorKey, mcpSelectorValue := components.GetFirstKeyAndValue(profile.Spec.MachineConfigPoolSelector)
 				kc, err = kubeletconfig.New(profile, map[string]string{mcpSelectorKey: mcpSelectorValue})
 				Expect(err).ToNot(HaveOccurred())
 
-				tunedPerformance, err = tuned.NewNodePerformance(assetsDir, profile)
+				tunedPerformance, err = tuned.NewNodePerformance(profile)
 				Expect(err).ToNot(HaveOccurred())
 
 				runtimeClass = runtimeclass.New(profile, machineconfig.HighPerformanceRuntime)
@@ -782,14 +780,14 @@ var _ = Describe("Controller", func() {
 		})
 
 		It("should remove all components and remove the finalizer on first reconcile loop", func() {
-			mc, err := machineconfig.New(assetsDir, profile)
+			mc, err := machineconfig.New(profile)
 			Expect(err).ToNot(HaveOccurred())
 
 			mcpSelectorKey, mcpSelectorValue := components.GetFirstKeyAndValue(profile.Spec.MachineConfigPoolSelector)
 			kc, err := kubeletconfig.New(profile, map[string]string{mcpSelectorKey: mcpSelectorValue})
 			Expect(err).ToNot(HaveOccurred())
 
-			tunedPerformance, err := tuned.NewNodePerformance(assetsDir, profile)
+			tunedPerformance, err := tuned.NewNodePerformance(profile)
 			Expect(err).ToNot(HaveOccurred())
 
 			runtimeClass := runtimeclass.New(profile, machineconfig.HighPerformanceRuntime)
@@ -879,9 +877,8 @@ func newFakeReconciler(initObjects ...runtime.Object) *PerformanceProfileReconci
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(initObjects...).Build()
 	fakeRecorder := record.NewFakeRecorder(10)
 	return &PerformanceProfileReconciler{
-		Client:    fakeClient,
-		Scheme:    scheme.Scheme,
-		Recorder:  fakeRecorder,
-		AssetsDir: assetsDir,
+		Client:   fakeClient,
+		Scheme:   scheme.Scheme,
+		Recorder: fakeRecorder,
 	}
 }

--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -359,7 +359,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 
 			expectedRPSCPUs, err := cpuset.Parse(string(*profile.Spec.CPU.Reserved))
 			Expect(err).ToNot(HaveOccurred())
-			ociHookPath := filepath.Join("/rootfs", machineconfig.OCIHooksConfigDir, machineconfig.OCIHooksConfig+".json")
+			ociHookPath := filepath.Join("/rootfs", machineconfig.OCIHooksConfigDir, machineconfig.OCIHooksConfig)
 			Expect(err).ToNot(HaveOccurred())
 			for _, node := range workerRTNodes {
 				// Verify the OCI RPS hook uses the correct RPS mask

--- a/main.go
+++ b/main.go
@@ -160,10 +160,9 @@ func runPAO() {
 	}
 
 	if err = (&controllers.PerformanceProfileReconciler{
-		Client:    mgr.GetClient(),
-		Scheme:    mgr.GetScheme(),
-		Recorder:  mgr.GetEventRecorderFor("performance-profile-controller"),
-		AssetsDir: components.AssetsDir,
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("performance-profile-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		klog.Exitf("unable to create PerformanceProfile controller : %v", err)
 	}

--- a/openshift-ci/Dockerfile.deploy
+++ b/openshift-ci/Dockerfile.deploy
@@ -1,11 +1,9 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ARG BIN_DIR=
-ARG ASSETS_DIR=build/assets
 
 ENV LANG=en_US.utf8
 
-COPY ${ASSETS_DIR} /assets
 COPY ${BIN_DIR}performance-addon-operators /usr/local/bin/performance-operator
 COPY ${BIN_DIR}performance-profile-creator /usr/local/bin/performance-profile-creator
 USER 1001

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -132,7 +132,7 @@ func (r *renderOpts) Run() error {
 			return err
 		}
 
-		components, err := manifestset.GetNewComponents(profile, nil, &r.assetsInDir)
+		components, err := manifestset.GetNewComponents(profile, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig_test.go
@@ -13,7 +13,6 @@ import (
 	testutils "github.com/openshift-kni/performance-addon-operators/pkg/utils/testing"
 )
 
-const testAssetsDir = "../../../../../build/assets"
 const hugepagesAllocationService = `
       - contents: |
           [Unit]
@@ -37,14 +36,12 @@ const hugepagesAllocationService = `
 var _ = Describe("Machine Config", func() {
 
 	Context("machine config creation ", func() {
-		It("should create machine config with valid assests", func() {
+		It("should create machine config with valid assets", func() {
 			profile := testutils.NewPerformanceProfile("test")
 			profile.Spec.HugePages.Pages[0].Node = pointer.Int32Ptr(0)
 
-			_, err := New(testAssetsDir, profile)
+			_, err := New(profile)
 			Expect(err).ToNot(HaveOccurred())
-			_, err = New("../../../../../build/invalid/assets", profile)
-			Expect(err).Should(HaveOccurred(), "should fail with missing CPU")
 		})
 	})
 
@@ -56,7 +53,7 @@ var _ = Describe("Machine Config", func() {
 			profile.Spec.HugePages.Pages[0].Node = pointer.Int32Ptr(0)
 
 			labelKey, labelValue := components.GetFirstKeyAndValue(profile.Spec.MachineConfigLabel)
-			mc, err := New(testAssetsDir, profile)
+			mc, err := New(profile)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(mc.Spec.KernelType).To(Equal(MCKernelRT))
 

--- a/pkg/controller/performanceprofile/components/manifestset/manifestset.go
+++ b/pkg/controller/performanceprofile/components/manifestset/manifestset.go
@@ -49,10 +49,10 @@ func (ms *ManifestResultSet) ToManifestTable() ManifestTable {
 }
 
 // GetNewComponents return a list of all component's instances that should be created according to profile
-func GetNewComponents(profile *performancev2.PerformanceProfile, profileMCP *mcov1.MachineConfigPool, assetDir *string) (*ManifestResultSet, error) {
+func GetNewComponents(profile *performancev2.PerformanceProfile, profileMCP *mcov1.MachineConfigPool) (*ManifestResultSet, error) {
 	machineConfigPoolSelector := profilecomponent.GetMachineConfigPoolSelector(profile, profileMCP)
 
-	mc, err := machineconfig.New(*assetDir, profile)
+	mc, err := machineconfig.New(profile)
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func GetNewComponents(profile *performancev2.PerformanceProfile, profileMCP *mco
 		return nil, err
 	}
 
-	performanceTuned, err := tuned.NewNodePerformance(*assetDir, profile)
+	performanceTuned, err := tuned.NewNodePerformance(profile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/performanceprofile/components/tuned/tuned_test.go
+++ b/pkg/controller/performanceprofile/components/tuned/tuned_test.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-const testAssetsDir = "../../../../../build/assets"
 const expectedMatchSelector = `
   - machineConfigLabels:
       mcKey: mcValue
@@ -43,7 +42,7 @@ var _ = Describe("Tuned", func() {
 	})
 
 	getTunedManifest := func(profile *performancev2.PerformanceProfile) string {
-		tuned, err := NewNodePerformance(testAssetsDir, profile)
+		tuned, err := NewNodePerformance(profile)
 		Expect(err).ToNot(HaveOccurred())
 		y, err := yaml.Marshal(tuned)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Instead of copying assets under the operator image and loading them during the run, we can embed them during the compilation.
The PR should improve a number of things:
- caching of files, the code will not need to read files from the filesystem for every reconcile loop.
- vendoring performance-addon-operator under the NTO. We do not need to change the NTO image to include PAO assets.

/hold wait for 4.10 branching