### PR TITLE
Latency e2e: fix skipping report when cpus amount is less than minimum

### DIFF
--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -146,7 +146,7 @@ var _ = Describe("[performance] Latency Test", func() {
 				Skip(fmt.Sprintf("Skip the oslat test, the profile %q has less than %d isolated CPUs", profile.Name, minCpuAmountForOslat))
 			}
 			if latencyTestCpus < minCpuAmountForOslat && latencyTestCpus != defaultTestCpus {
-				Skip("Skip the oslat test, LATENCY_TEST_CPUS is less than the minimum CPUs amount %d", minCpuAmountForOslat)
+				Skip(fmt.Sprintf("Skip the oslat test, LATENCY_TEST_CPUS is less than the minimum CPUs amount %d", minCpuAmountForOslat))
 			}
 		})
 

--- a/functests/5_latency_testing/latency_testing.go
+++ b/functests/5_latency_testing/latency_testing.go
@@ -35,6 +35,7 @@ const (
 	incorrectMsgPart2                  = " has incorrect value"
 	invalidNumber                      = " has an invalid number"
 	maxInt                             = "2147483647"
+	minimumCpuForOslat                 = "2"
 	mustBePositiveInt                  = ".*it must be a positive integer with maximum value of " + maxInt
 	mustBeNonNegativeInt               = ".*it must be a non-negative integer with maximum value of " + maxInt
 	incorrectCpuNumber                 = incorrectMsgPart1 + latencyTestCpus + incorrectMsgPart2 + mustBePositiveInt
@@ -62,7 +63,7 @@ const (
 	//skip messages regex
 	skipTestRun         = `Skip the latency test, the LATENCY_TEST_RUN set to false`
 	skipMaxLatency      = `no maximum latency value provided, skip buckets latency check`
-	skipOslatCpuNumber  = `Skip the oslat test, LATENCY_TEST_CPUS is less than the minimum CPUs amount`
+	skipOslatCpuNumber  = `Skip the oslat test, LATENCY_TEST_CPUS is less than the minimum CPUs amount ` + minimumCpuForOslat
 	skip                = `SUCCESS.*0 Passed.*0 Failed.*3 Skipped`
 	skipInsufficientCpu = `Insufficient cpu to run the test`
 


### PR DESCRIPTION
Missing fmt.Sprintf in the skip message leads to outputting the conversion character %d instead of minCpuAmountForOslat actual value.

Fix the message formatting by outputting fmt.Sprintf value and validate that in Latency_testing.go.