### PR TITLE
Latency testing:  enable LATENCY_TEST_DELAY tests; delete namespace if image pre-pulling failed 

### DIFF
--- a/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -28,11 +28,7 @@ var prePullNamespace = &corev1.Namespace{
 }
 
 var _ = AfterSuite(func() {
-	prePullNamespaceName := prePullNamespace.Name
-	err := testclient.Client.Delete(context.TODO(), prePullNamespace)
-	testlog.Infof("deleted namespace %q err=%v", prePullNamespace.Name, err)
-	Expect(err).ToNot(HaveOccurred())
-	err = namespaces.WaitForDeletion(prePullNamespaceName, 5*time.Minute)
+	deleteNamespace()
 })
 
 func Test5LatencyTesting(t *testing.T) {
@@ -50,6 +46,7 @@ func Test5LatencyTesting(t *testing.T) {
 	if err != nil {
 		data, _ := json.Marshal(ds) // we can safely skip errors
 		testlog.Infof("DaemonSet %s/%s image=%q status:\n%s", ds.Namespace, ds.Name, images.Test(), string(data))
+		deleteNamespace()
 		t.Fatalf("cannot prepull image %q: %v", images.Test(), err)
 	}
 
@@ -69,4 +66,13 @@ func createNamespace() error {
 	}
 	testlog.Infof("created namespace %q err=%v", prePullNamespace.Name, err)
 	return err
+}
+
+func deleteNamespace() {
+	prePullNamespaceName := prePullNamespace.Name
+	err := testclient.Client.Delete(context.TODO(), prePullNamespace)
+	testlog.Infof("deleted namespace %q err=%v", prePullNamespace.Name, err)
+	Expect(err).ToNot(HaveOccurred())
+	err = namespaces.WaitForDeletion(prePullNamespaceName, 5*time.Minute)
+	Expect(err).ToNot(HaveOccurred())
 }

--- a/functests/5_latency_testing/latency_testing.go
+++ b/functests/5_latency_testing/latency_testing.go
@@ -208,11 +208,8 @@ func getValidValuesTests(toolToTest string) []latencyTest {
 	var testSet []latencyTest
 	testSet = append(testSet, latencyTest{testDelay: "0", testRun: "true", testRuntime: "5", testMaxLatency: guaranteedLatency, testCpus: "2", outputMsgs: []string{success}, toolToTest: toolToTest})
 	testSet = append(testSet, latencyTest{testDelay: "0", testRun: "true", testRuntime: "1", testMaxLatency: guaranteedLatency, testCpus: "5", outputMsgs: []string{success}, toolToTest: toolToTest})
-	//BZ https://bugzilla.redhat.com/show_bug.cgi?id=2006675
-	if toolToTest == oslat {
-		testSet = append(testSet, latencyTest{testDelay: "1", testRun: "true", testRuntime: "2", testMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
-		testSet = append(testSet, latencyTest{testDelay: "60", testRun: "true", testRuntime: "2", testMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
-	}
+	testSet = append(testSet, latencyTest{testDelay: "1", testRun: "true", testRuntime: "2", testMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
+	testSet = append(testSet, latencyTest{testDelay: "60", testRun: "true", testRuntime: "2", testMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
 	if toolToTest != hwlatdetect {
 		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "5", outputMsgs: []string{skip, skipMaxLatency}, toolToTest: toolToTest})
 	}


### PR DESCRIPTION
Now that BZ 200667 is resolved, enable the tests that set LATENCY_TEST_DELAY to a non-zero value for cyclictest and hwlatdetect.

Fatalf calls os.Exit(1) thus AfterSuite won't be reached to delete the namespace.
Delete the namespace before logging fatal to guarantee cleaning the cluster from the suite's configuration.