### PR TITLE
Bug 2061676: latency tests: disable cpu cfs quota

### DIFF
--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -382,6 +382,7 @@ func getLatencyTestPod(profile *performancev2.PerformanceProfile, node *corev1.N
 			Annotations: map[string]string{
 				"irq-load-balancing.crio.io": "disable",
 				"cpu-load-balancing.crio.io": "disable",
+				"cpu-quota.crio.io":          "disable",
 			},
 			Namespace: testutils.NamespaceTesting,
 		},


### PR DESCRIPTION
Quota accounting takes resources and cause throttling which in turns casue latency, hence, we want to disabling it.

Signed-off-by: Talor Itzhak <titzhak@redhat.com>