### PR TITLE
e2e: stabilize performance update tests

### DIFF
--- a/functests/2_performance_update/kubelet.go
+++ b/functests/2_performance_update/kubelet.go
@@ -2,6 +2,7 @@ package __performance_update
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -55,12 +56,19 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", fun
 	})
 	Context("Additional kubelet arguments", func() {
 		It("[test_id:45488]Test performance profile annotation for changing multiple kubelet settings", func() {
-			sysctlAnnotations := map[string]string{
+			profile.Annotations = map[string]string{
 				"kubeletconfig.experimental": "{\"allowedUnsafeSysctls\":[\"net.core.somaxconn\",\"kernel.msg*\"],\"systemReserved\":{\"memory\":\"300Mi\"},\"kubeReserved\":{\"memory\":\"768Mi\"},\"imageMinimumGCAge\":\"3m\"}",
 			}
-			profile.SetAnnotations(sysctlAnnotations)
+			annotations, err := json.Marshal(profile.Annotations)
+			Expect(err).ToNot(HaveOccurred())
+
 			By("Applying changes in performance profile and waiting until mcp will start updating")
-			profiles.UpdateWithRetry(profile)
+			Expect(testclient.Client.Patch(context.TODO(), profile,
+				client.RawPatch(
+					types.JSONPatchType,
+					[]byte(fmt.Sprintf(`[{ "op": "replace", "path": "/metadata/annotations", "value": %s }]`, annotations)),
+				),
+			)).ToNot(HaveOccurred())
 			mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdating, corev1.ConditionTrue)
 			By("Waiting when mcp finishes updates")
 			mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
@@ -102,13 +110,21 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", fun
 			// In this test case we are testing if after applying reserving memory for
 			// systemReserved and KubeReserved, the allocatable is reduced and Allocatable
 			// Verify that Allocatable = Node capacity - (kubereserved + systemReserved + EvictionMemory)
-			memoryAnnotation := map[string]string{
+			profile.Annotations = map[string]string{
 				"kubeletconfig.experimental": "{\"systemReserved\":{\"memory\":\"300Mi\"},\"kubeReserved\":{\"memory\":\"768Mi\"}}",
 			}
-			profile.SetAnnotations(memoryAnnotation)
+			annotations, err := json.Marshal(profile.Annotations)
+			Expect(err).ToNot(HaveOccurred())
+
 			By("Applying changes in performance profile and waiting until mcp will start updating")
-			profiles.UpdateWithRetry(profile)
+			Expect(testclient.Client.Patch(context.TODO(), profile,
+				client.RawPatch(
+					types.JSONPatchType,
+					[]byte(fmt.Sprintf(`[{ "op": "replace", "path": "/metadata/annotations", "value": %s }]`, annotations)),
+				),
+			)).ToNot(HaveOccurred())
 			mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdating, corev1.ConditionTrue)
+
 			By("Waiting when mcp finishes updates")
 			mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
 			for _, node := range workerRTNodes {
@@ -129,12 +145,19 @@ var _ = Describe("[ref_id: 45487][performance]additional kubelet arguments", fun
 			}
 		})
 		It("[test_id:45495] Test setting PAO managed parameters", func() {
-			paoAnnotation := map[string]string{
+			profile.Annotations = map[string]string{
 				"kubeletconfig.experimental": "{\"topologyManagerPolicy\":\"single-numa-node\"}",
 			}
-			profile.SetAnnotations(paoAnnotation)
+			annotations, err := json.Marshal(profile.Annotations)
+			Expect(err).ToNot(HaveOccurred())
+
 			By("Applying changes in performance profile and waiting until mcp will start updating")
-			profiles.UpdateWithRetry(profile)
+			Expect(testclient.Client.Patch(context.TODO(), profile,
+				client.RawPatch(
+					types.JSONPatchType,
+					[]byte(fmt.Sprintf(`[{ "op": "replace", "path": "/metadata/annotations", "value": %s }]`, annotations)),
+				),
+			)).ToNot(HaveOccurred())
 			mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdating, corev1.ConditionTrue)
 			By("Waiting when mcp finishes updates")
 			mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue)

--- a/functests/2_performance_update/updating_profile.go
+++ b/functests/2_performance_update/updating_profile.go
@@ -143,8 +143,17 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			irqLoadBalancingDisabled = !irqLoadBalancingDisabled
 			profile.Spec.GloballyDisableIrqLoadBalancing = &irqLoadBalancingDisabled
 
-			By("Updating the performance profile")
-			profiles.UpdateWithRetry(profile)
+			spec, err := json.Marshal(profile.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Applying changes in performance profile and waiting until mcp will start updating")
+			Expect(testclient.Client.Patch(context.TODO(), profile,
+				client.RawPatch(
+					types.JSONPatchType,
+					[]byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, spec)),
+				),
+			)).ToNot(HaveOccurred())
+
 			defer func() { // return initial configuration
 				spec, err := json.Marshal(initialProfile.Spec)
 				Expect(err).ToNot(HaveOccurred())
@@ -207,8 +216,16 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			By("Verifying that mcp is ready for update")
 			mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
 
+			spec, err := json.Marshal(profile.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
 			By("Applying changes in performance profile and waiting until mcp will start updating")
-			profiles.UpdateWithRetry(profile)
+			Expect(testclient.Client.Patch(context.TODO(), profile,
+				client.RawPatch(
+					types.JSONPatchType,
+					[]byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, spec)),
+				),
+			)).ToNot(HaveOccurred())
 			mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdating, corev1.ConditionTrue)
 
 			By("Waiting when mcp finishes updates")
@@ -286,8 +303,16 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			By("Verifying that mcp is ready for update")
 			mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
 
+			spec, err := json.Marshal(profile.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
 			By("Applying changes in performance profile and waiting until mcp will start updating")
-			profiles.UpdateWithRetry(profile)
+			Expect(testclient.Client.Patch(context.TODO(), profile,
+				client.RawPatch(
+					types.JSONPatchType,
+					[]byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, spec)),
+				),
+			)).ToNot(HaveOccurred())
 			mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdating, corev1.ConditionTrue)
 
 			By("Waiting when mcp finishes updates")
@@ -355,7 +380,16 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 
 			By("Applying changes in performance profile")
 			profile.Spec.RealTimeKernel = nil
-			profiles.UpdateWithRetry(profile)
+			spec, err := json.Marshal(profile.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Applying changes in performance profile and waiting until mcp will start updating")
+			Expect(testclient.Client.Patch(context.TODO(), profile,
+				client.RawPatch(
+					types.JSONPatchType,
+					[]byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, spec)),
+				),
+			)).ToNot(HaveOccurred())
 
 			Expect(profile.Spec.RealTimeKernel).To(BeNil(), "real time kernel setting expected in profile spec but missing")
 			By("Checking that the updating MCP status will consistently stay false")
@@ -384,6 +418,8 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		})
 	})
 
+	// TODO: we have a dependency between tests(that in general bad practice, but saves us some tests run time),
+	// once we will want to run tests in the random order or without failFast we will need to refactor tests
 	Context("Updating of nodeSelector parameter and node labels", func() {
 		var mcp *machineconfigv1.MachineConfigPool
 		var newCnfNode *corev1.Node
@@ -418,7 +454,16 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 
 			By("Updating Node Selector performance profile")
 			profile.Spec.NodeSelector = newNodeSelector
-			profiles.UpdateWithRetry(profile)
+			spec, err := json.Marshal(profile.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Applying changes in performance profile and waiting until mcp will start updating")
+			Expect(testclient.Client.Patch(context.TODO(), profile,
+				client.RawPatch(
+					types.JSONPatchType,
+					[]byte(fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, spec)),
+				),
+			)).ToNot(HaveOccurred())
 			mcps.WaitForCondition(newRole, machineconfigv1.MachineConfigPoolUpdating, corev1.ConditionTrue)
 
 			By("Waiting when MCP finishes updates and verifying new node has updated configuration")
@@ -480,7 +525,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 		})
 
 		It("Reverts back nodeSelector and cleaning up leftovers", func() {
-			selectorLabels := []string{}
+			var selectorLabels []string
 			for k, v := range testutils.NodeSelectorLabels {
 				selectorLabels = append(selectorLabels, fmt.Sprintf(`"%s":"%s"`, k, v))
 			}
@@ -499,7 +544,7 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 					Namespace: profile.Namespace,
 				}
 				Expect(testclient.Client.Get(context.TODO(), key, updatedProfile)).ToNot(HaveOccurred())
-				updatedSelectorLabels := []string{}
+				var updatedSelectorLabels []string
 				for k, v := range updatedProfile.Spec.NodeSelector {
 					updatedSelectorLabels = append(updatedSelectorLabels, fmt.Sprintf(`"%s":"%s"`, k, v))
 				}
@@ -511,6 +556,9 @@ var _ = Describe("[rfe_id:28761][performance] Updating parameters in performance
 			Expect(err).ToNot(HaveOccurred())
 			Expect(testclient.Client.Delete(context.TODO(), mcp)).ToNot(HaveOccurred())
 			mcps.WaitForCondition(performanceMCP, machineconfigv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
+
+			// revert node label to have the expected value
+			nodeLabel = testutils.NodeSelectorLabels
 		})
 	})
 })


### PR DESCRIPTION
- use patch instead of update to prevent resource update conflicts
- restore correct node labels

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>