### PR TITLE
Images: adjust cnf-tests image to 4.10

### DIFF
--- a/functests/utils/images/images.go
+++ b/functests/utils/images/images.go
@@ -13,7 +13,7 @@ func init() {
 	cnfTestsImage = os.Getenv("CNF_TESTS_IMAGE")
 
 	if cnfTestsImage == "" {
-		cnfTestsImage = "cnf-tests:4.9"
+		cnfTestsImage = "cnf-tests:4.10"
 	}
 
 	if registry == "" {


### PR DESCRIPTION
Cnf-tests image is used in latency test, update the image to 4.10 version.