### PR TITLE
E2e latency fixes

### DIFF
--- a/functests/4_latency/latency.go
+++ b/functests/4_latency/latency.go
@@ -89,6 +89,10 @@ var _ = Describe("[performance] Latency Test", func() {
 			Skip("Discovery mode enabled, performance profile not found")
 		}
 
+		if isOddCpuNumber(latencyTestCpus, profile) {
+			Skip("Skip the test, the requested number of CPUs should be even to avoid noisy neighbor situation")
+		}
+
 		profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -508,4 +512,13 @@ func removeLogfile(node *corev1.Node, logName string) {
 
 func isEqual(qty *resource.Quantity, amount int) bool {
 	return qty.CmpInt64(int64(amount)) == 0
+}
+
+func isOddCpuNumber(cpusNum int, profile *performancev2.PerformanceProfile) bool {
+	if cpusNum == defaultTestCpus {
+		isolatedCpus := cpuset.MustParse(string(*profile.Spec.CPU.Isolated))
+		isolatedCpusNum := isolatedCpus.Size() - 1
+		return isolatedCpusNum%2 != 0
+	}
+	return cpusNum%2 != 0
 }

--- a/functests/5_latency_testing/latency_testing.go
+++ b/functests/5_latency_testing/latency_testing.go
@@ -66,6 +66,7 @@ const (
 	skipOslatCpuNumber  = `Skip the oslat test, LATENCY_TEST_CPUS is less than the minimum CPUs amount ` + minimumCpuForOslat
 	skip                = `SUCCESS.*0 Passed.*0 Failed.*3 Skipped`
 	skipInsufficientCpu = `Insufficient cpu to run the test`
+	skipOddCpuNumber    = `Skip the test, the requested number of CPUs should be even to avoid noisy neighbor situation`
 
 	//used values parameters
 	guaranteedLatency = "20000"
@@ -205,6 +206,7 @@ func getValidValuesTests(toolToTest string) []latencyTest {
 	testSet = append(testSet, latencyTest{testDelay: "0", testRun: "true", testRuntime: "10", testMaxLatency: guaranteedLatency, testCpus: "6", outputMsgs: []string{success}, toolToTest: toolToTest})
 	testSet = append(testSet, latencyTest{testDelay: "1", testRun: "true", testRuntime: "10", testMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
 	testSet = append(testSet, latencyTest{testDelay: "60", testRun: "true", testRuntime: "2", testMaxLatency: guaranteedLatency, outputMsgs: []string{success}, toolToTest: toolToTest})
+	testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "2", testCpus: "5", testMaxLatency: guaranteedLatency, outputMsgs: []string{skip, skipOddCpuNumber}, toolToTest: toolToTest})
 
 	if toolToTest != hwlatdetect {
 		testSet = append(testSet, latencyTest{testRun: "true", testRuntime: "1", outputMsgs: []string{skip, skipMaxLatency}, toolToTest: toolToTest})
@@ -233,7 +235,7 @@ func getNegativeTests(toolToTest string) []latencyTest {
 	if toolToTest == hwlatdetect {
 		latencyFailureMsg = hwlatdetectFail
 	}
-	//TODO: add test to check odd CPU request.
+
 	testSet = append(testSet, latencyTest{testDelay: "0", testRun: "true", testRuntime: "5", testMaxLatency: "1", outputMsgs: []string{latencyFailureMsg, fail}, toolToTest: toolToTest})
 	testSet = append(testSet, latencyTest{testRun: "yes", testRuntime: "5", testMaxLatency: "1", outputMsgs: []string{incorrectTestRun, fail}, toolToTest: toolToTest})
 	testSet = append(testSet, latencyTest{testRun: "true", testRuntime: fmt.Sprint(math.MaxInt32 + 1), outputMsgs: []string{invalidNumberRuntime, fail}, toolToTest: toolToTest})


### PR DESCRIPTION
- fix expected runtime flag of cyclictest.
- latency: skip the test when requested cpus number is odd 
please find the commits for more details.