### PR TITLE
Gather all pods information.

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -20,6 +20,9 @@ resources+=(performanceprofile)
 # machine/node resources
 resources+=(nodes machineconfigs machineconfigpools featuregates kubeletconfigs tuneds)
 
+# pods information
+resources+=(pods)
+
 # run the collection of resources using must-gather
 for resource in ${resources[@]}; do
   /usr/bin/oc adm inspect --dest-dir must-gather --all-namespaces ${resource}


### PR DESCRIPTION
To be able to check if IRQs affinity lists collide with those CPUs exclusively assigned to a "Guaranteed" pod we need to have the QoSClass for each pod in the cluster.

This change will save each of the pods manifests in `must-gather/namespaces/<namespace>/core/pods/*.yaml`

see [here](https://gitlab.cee.redhat.com/ccx/ccx-ocp-core/-/merge_requests/480) for more info 