### PR TITLE
e2e: latency: Update PP isolated cpus to match test requirement

### DIFF
--- a/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -3,6 +3,7 @@ package __latency_testing_test
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -12,12 +13,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 
+	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
+	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
 	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/images"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/junit"
 	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/namespaces"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/nodes"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/profilesupdate"
+
 	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
 
@@ -26,32 +34,73 @@ var prePullNamespace = &corev1.Namespace{
 		Name: "testing-prepull",
 	},
 }
+var profile *performancev2.PerformanceProfile
 
-var _ = AfterSuite(func() {
-	prePullNamespaceName := prePullNamespace.Name
-	err := testclient.Client.Delete(context.TODO(), prePullNamespace)
-	testlog.Infof("deleted namespace %q err=%v", prePullNamespace.Name, err)
-	Expect(err).ToNot(HaveOccurred())
-	err = namespaces.WaitForDeletion(prePullNamespaceName, 5*time.Minute)
-})
-
-func Test5LatencyTesting(t *testing.T) {
-	RegisterFailHandler(Fail)
-
+var _ = BeforeSuite(func() {
 	if !testclient.ClientsEnabled {
-		t.Fatalf("client not enabled")
+		testlog.Errorf("client not enabled")
+	}
+
+	// update PP isolated CPUs. the new cpu set for isolated should have an even number of CPUs to avoid failing the pod on SMTAlignment error,
+	// and should be greater than what is requested by the test cases in the suite so the test runs properly
+	var err error
+	profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
+	Expect(err).ToNot(HaveOccurred())
+	workerNodes, err := nodes.GetByLabels(testutils.NodeSelectorLabels)
+	Expect(err).ToNot(HaveOccurred())
+
+	initialIsolated := profile.Spec.CPU.Isolated
+	initialReserved := profile.Spec.CPU.Reserved
+	//updated both sets to ensure there is no overlap
+	latencyIsolatedSet := performancev2.CPUSet("1-9")
+	latencyReservedSet := performancev2.CPUSet("0")
+
+	totalCpus := cpuset.MustParse(string(latencyIsolatedSet)).Size() + cpuset.MustParse(string(latencyReservedSet)).Size()
+	nodesWithSufficientCpu := nodes.GetByCpuAllocatable(workerNodes, totalCpus)
+	//before applying the changes verify that there are compute nodes with sufficient cpus
+	if len(nodesWithSufficientCpu) != 0 {
+		if *initialIsolated != latencyIsolatedSet || *initialReserved != latencyReservedSet {
+			testlog.Info("Update the isolated and reserved cpus sets of the profile")
+			err = profilesupdate.UpdateIsolatedReservedCpus(latencyIsolatedSet, latencyReservedSet)
+			if err != nil {
+				testlog.Error("could not update the profile with the desired CPUs sets")
+			}
+		}
 	}
 
 	if err := createNamespace(); err != nil {
-		t.Fatalf("cannot create the namespace: %v", err)
+		testlog.Errorf("cannot create the namespace: %v", err)
 	}
 
 	ds, err := images.PrePull(testclient.Client, images.Test(), prePullNamespace.Name, "cnf-tests")
 	if err != nil {
 		data, _ := json.Marshal(ds) // we can safely skip errors
 		testlog.Infof("DaemonSet %s/%s image=%q status:\n%s", ds.Namespace, ds.Name, images.Test(), string(data))
-		t.Fatalf("cannot prepull image %q: %v", images.Test(), err)
+		testlog.Errorf("cannot prepull image %q: %v", images.Test(), err)
 	}
+})
+
+var _ = AfterSuite(func() {
+	prePullNamespaceName := prePullNamespace.Name
+	err := testclient.Client.Delete(context.TODO(), prePullNamespace)
+	if err != nil {
+		testlog.Errorf("namespace %q could not be deleted err=%v", prePullNamespace.Name, err)
+	}
+	namespaces.WaitForDeletion(prePullNamespaceName, 5*time.Minute)
+
+	currentProfile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
+	Expect(err).ToNot(HaveOccurred())
+	if reflect.DeepEqual(currentProfile.Spec, profile.Spec) != true {
+		testlog.Info("Restore initial performance profile")
+		err = profilesupdate.ApplyProfile(profile)
+		if err != nil {
+			testlog.Error("could not restore the initial profile")
+		}
+	}
+})
+
+func Test5LatencyTesting(t *testing.T) {
+	RegisterFailHandler(Fail)
 
 	rr := []Reporter{}
 	if ginkgo_reporters.Polarion.Run {

--- a/functests/5_latency_testing/latency_testing.go
+++ b/functests/5_latency_testing/latency_testing.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
 	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
 )
 
@@ -145,9 +146,6 @@ var _ = table.DescribeTable("Test latency measurement tools tests", func(testGro
 					Expect(strings.Contains(string(output), argument)).To(BeTrue(), "The tool command didn't pass the argument %q", argument)
 				}
 			}
-		}
-		for _, msg := range test.outputMsgs {
-			Expect(string(output)).To(MatchRegexp(msg), "The output of the executed tool is not as expected")
 		}
 	}
 },

--- a/functests/utils/profilesupdate/profile_update.go
+++ b/functests/utils/profilesupdate/profile_update.go
@@ -1,0 +1,79 @@
+package profilesupdate
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	mcv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
+	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
+	testclient "github.com/openshift-kni/performance-addon-operators/functests/utils/client"
+	testlog "github.com/openshift-kni/performance-addon-operators/functests/utils/log"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/mcps"
+	"github.com/openshift-kni/performance-addon-operators/functests/utils/profiles"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
+	profilecontroller "github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/profile"
+)
+
+//UpdateIsolatedReservedCpus Updates the current performance profile with new sets of isolated and reserved cpus, and returns true if the update was successfull and false otherwise
+func UpdateIsolatedReservedCpus(isolatedSet performancev2.CPUSet, reservedSet performancev2.CPUSet) error {
+	profile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
+	if err != nil {
+		return fmt.Errorf("could not get the performance profile: %v", err)
+	}
+	updatedProfile := profile.DeepCopy()
+	updatedProfile.Spec.CPU = &performancev2.CPU{
+		Isolated: &isolatedSet,
+		Reserved: &reservedSet,
+	}
+
+	err = ApplyProfile(updatedProfile)
+	if err == nil {
+		testlog.Infof("successfully updated performance profile %q with new isolated cpus set: %q and new reserved cpus set: %q", profile.Name, updatedProfile.Spec.CPU.Isolated, updatedProfile.Spec.CPU.Reserved)
+	}
+	return err
+}
+
+//ApplyProfile applies the new profile and returns true if the changes were applied indeed and false otherwise
+func ApplyProfile(profile *performancev2.PerformanceProfile) error {
+	testlog.Info("Getting MCP for profile")
+	mcpLabel := profilecontroller.GetMachineConfigLabel(profile)
+	key, value := components.GetFirstKeyAndValue(mcpLabel)
+	mcpsByLabel, err := mcps.GetByLabel(key, value)
+	if err != nil {
+		return fmt.Errorf("Failed getting MCP by label key %v value %v: %v", key, value, err)
+	}
+	if len(mcpsByLabel) != 1 {
+		return fmt.Errorf("Unexpected number of MCPs found: %v", len(mcpsByLabel))
+	}
+	performanceMCP := &mcpsByLabel[0]
+	testlog.Info("Verifying that mcp is ready for update")
+	mcps.WaitForCondition(performanceMCP.Name, mcv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
+
+	testlog.Info("Applying changes in performance profile and waiting until mcp will start updating")
+	profiles.UpdateWithRetry(profile)
+	mcps.WaitForCondition(performanceMCP.Name, mcv1.MachineConfigPoolUpdating, corev1.ConditionTrue)
+
+	testlog.Info("Waiting when mcp finishes updates")
+	mcps.WaitForCondition(performanceMCP.Name, mcv1.MachineConfigPoolUpdated, corev1.ConditionTrue)
+
+	//check if the values were indeed updated
+	profilekey := types.NamespacedName{
+		Name:      profile.Name,
+		Namespace: profile.Namespace,
+	}
+	updatedProfile := &performancev2.PerformanceProfile{}
+	if err = testclient.Client.Get(context.TODO(), profilekey, updatedProfile); err != nil {
+		return fmt.Errorf("could not fetch the profile: %v", err)
+	}
+
+	if reflect.DeepEqual(updatedProfile.Spec, profile.Spec) != true {
+		return fmt.Errorf("the profile %q was not updated as expected", updatedProfile.Name)
+	}
+	return nil
+}


### PR DESCRIPTION
Some tests in the suites require setting the number of CPUs to be used by the latency pod. If the available cpus is not sufficient, the tests will be skipped.
The goal of the suite is to verify that the main tests of the latency tools are executed as expected.
 So to overcome this, update the isolated CPUs for this suite to CPU set that guarantees to execute the tests properly, and restore the initial set when finished.