### PR TITLE
Improve pod information to check IRQ Load Balancing

### DIFF
--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -71,7 +71,7 @@ do
 
     oc exec $pod -n perf-node-gather -- gather_sysinfo snapshot --debug --root=/host --output=- > $NODE_PATH/sysinfo.tgz 2> $NODE_PATH/sysinfo.log
 
-    oc get pods -A --field-selector spec.nodeName=$node,status.phase=Running -o go-template='[{{range $idx, $item := .items}} {{if (ne $idx 0)}},{{end}}{"namespace":"{{.metadata.namespace}}", "name":"{{.metadata.name}}", "nodeName":"{{.spec.nodeName}}", "qosClass": "{{.status.qosClass}}" }{{"\n"}}{{end}}]' > $NODE_PATH/pods_info.json
+    oc get pods -A --field-selector spec.nodeName=$node,status.phase=Running -o go-template='[{{range $idx, $item := .items}} {{if (ne $idx 0)}},{{end}}{"namespace":"{{.metadata.namespace}}", "name":"{{.metadata.name}}", "nodeName":"{{.spec.nodeName}}", "qosClass": "{{.status.qosClass}}", {{if .spec.containers}}"containers": [{{range $cdx, $cont := .spec.containers}} {{if (ne $cdx 0)}},{{end}} {"name":"{{.name}}", {{if .resources}} "resources": { {{if .resources.limits.cpu}} "limits": { "cpu": "{{.resources.limits.cpu}}" }, {{end}} {{if .resources.requests.cpu}} "requests": { "cpu": "{{.resources.requests.cpu}}" } {{end}} } {{end}} } {{end}} ] {{end}} }{{"\n"}}{{end}}]' > $NODE_PATH/pods_info.json
 done
 
 # Collect journal logs for specified units for all nodes


### PR DESCRIPTION
Added "resources.requests.cpu" and "resources.limits.cpu" information
for each of the containers on each pod.
This information is required to look for exclusively assigned CPUs.

CPUs are assigned to be used exclusively only to those containers
belonging to a pod with a "Guaranteed" qosClass and with an integer cpu
request
Thats why we need to add this information to must-gather.