### PR TITLE
Use new `podinfo` command to gather pod data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/jaypipes/ghw v0.8.1-0.20210605191321-eb162add542b
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
-	github.com/openshift-kni/debug-tools v0.1.3
+	github.com/openshift-kni/debug-tools v0.1.7
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/cluster-node-tuning-operator v0.0.0-20200914165052-a39511828cf0
 	github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca

--- a/go.sum
+++ b/go.sum
@@ -799,8 +799,8 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.m
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
-github.com/openshift-kni/debug-tools v0.1.3 h1:DYcF3ZMR5tJEO1smZMkW+lZ1fhnOcnttyqqewhPZ2g4=
-github.com/openshift-kni/debug-tools v0.1.3/go.mod h1:HW2qp9MZgRM8mmzEbWoeoJxQH7A0kbqOMzSa9/dktcQ=
+github.com/openshift-kni/debug-tools v0.1.7 h1:FCg1xY94Zi3WB04dMKZdTn/OVEsKYEwpVJfgdO+JbR4=
+github.com/openshift-kni/debug-tools v0.1.7/go.mod h1:oq0XTqe9bAYyQUXZdHwRmRrMqHZTEC+yuJbipYzvqvI=
 github.com/openshift/api v0.0.0-20210610130314-a6ac319a7eed h1:8Q94GlNfhBoMqQFw9gCNQ0Q9V1B+tw5VBn+M4e5ooaI=
 github.com/openshift/api v0.0.0-20210610130314-a6ac319a7eed/go.mod h1:izBmoXbUu3z5kUa4FjZhvekTsyzIWiOoaIgJiZBBMQs=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
@@ -891,6 +891,7 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
+github.com/safchain/ethtool v0.2.0/go.mod h1:WkKB1DnNtvsMlDmQ50sgwowDJV/hGbJSOvJoEXs1AJQ=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/securego/gosec v0.0.0-20191002120514-e680875ea14d/go.mod h1:w5+eXa0mYznDkHaMCXA4XYffjlH+cy1oyKbfzJXa2Do=

--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -71,7 +71,7 @@ do
 
     oc exec $pod -n perf-node-gather -- gather_sysinfo snapshot --debug --root=/host --output=- > $NODE_PATH/sysinfo.tgz 2> $NODE_PATH/sysinfo.log
 
-    oc get pods -A --field-selector spec.nodeName=$node,status.phase=Running -o go-template='[{{range $idx, $item := .items}} {{if (ne $idx 0)}},{{end}}{"namespace":"{{.metadata.namespace}}", "name":"{{.metadata.name}}", "nodeName":"{{.spec.nodeName}}", "qosClass": "{{.status.qosClass}}" }{{"\n"}}{{end}}]' > $NODE_PATH/pods_info.json
+    oc exec $pod -n perf-node-gather -- gather_sysinfo podinfo --node-name $node > $NODE_PATH/pods_info.json
 done
 
 # Collect journal logs for specified units for all nodes

--- a/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/k8s/podinfo.go
+++ b/vendor/github.com/openshift-kni/debug-tools/pkg/knit/cmd/k8s/podinfo.go
@@ -1,0 +1,206 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ */
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"path/filepath"
+	"text/template"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/openshift-kni/debug-tools/pkg/knit/cmd"
+	"github.com/spf13/cobra"
+)
+
+type podInfoOptions struct {
+	nodeName string
+}
+
+//Only need some info about the pod.
+// Right now is:
+// - pod name
+// - pod namespace
+// - node name
+// - status.qosClass
+// - containers
+//   - requests cpu
+//   - limits cpu
+// Note this output format could change but it would be parsed on insight rules
+// so the change should be sync with it.
+// Caution: We filter the data from pods to avoid exposing sensible information
+// (like environment variables or input parameters which can contain passwords)
+// so take care of that when changing this template.
+const defaultTemplate string = `
+[
+	{{- range $idx, $item := .Items}}
+	{{- if (ne $idx 0)}},{{end}}
+	{
+		"namespace":"{{.ObjectMeta.Namespace}}", 
+		"name":"{{.ObjectMeta.Name}}", 
+		"nodeName":"{{.Spec.NodeName}}", 
+		"qosClass": "{{.Status.QOSClass}}", 
+		{{- if .Spec.Containers }}
+		"containers": [
+		{{- range $cdx, $cont := .Spec.Containers -}}
+			{{- if (ne $cdx 0) }},{{ end }} 
+			{
+				"name":"{{.Name}}"
+				{{- if or .Resources.Requests .Resources.Limits -}}
+				,
+				"resources": {
+					{{- if .Resources.Limits}} {{if .Resources.Limits.Cpu}} 
+					"limits": {
+						"cpu": "{{.Resources.Limits.Cpu}}"
+					}
+					{{- end }}{{end}}
+					{{- if .Resources.Requests}}{{if .Resources.Requests.Cpu -}}
+					,
+					"requests": {
+						"cpu": "{{.Resources.Requests.Cpu}}"
+					}
+					{{- end }}{{end}}
+				} 
+				{{- end }} 
+			} 
+		{{- end }} 
+		]
+		{{- end }} 
+	}
+	{{- end }}
+]`
+
+func NewPodInfoCommand(knitOpts *cmd.KnitOptions) *cobra.Command {
+
+	opts := &podInfoOptions{}
+	podInfo := &cobra.Command{
+		Use:   "podinfo",
+		Short: "get pod information complementing podresources data",
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			clientset, err := getClientSetFromClusterConfig()
+			if err != nil {
+				return fmt.Errorf("unable to get clientset: %w", err)
+			}
+
+			podInfoTemplate, err := createOutputTemplate("pod_info", defaultTemplate)
+			if err != nil {
+				return fmt.Errorf("unable to get output template: %w", err)
+			}
+
+			nodeFieldSelector := buildNodeFieldSelector(opts.nodeName)
+
+			return showPodInfo(nodeFieldSelector, clientset, podInfoTemplate, os.Stdout)
+		},
+	}
+
+	podInfo.Flags().StringVar(&opts.nodeName, "node-name", "", "node name to get pod info from.")
+
+	return podInfo
+}
+
+// GetConfig creates a *rest.Config for talking to a Kubernetes apiserver.
+//
+// Config precedence
+//
+// - KUBECONFIG environment variable pointing at a file
+// - $HOME/.kube/config if exists
+// - In-cluster config if running in cluster
+func getKubeConfig() (*rest.Config, error) {
+	kubeconfigFromFilePath := func(kubeConfigFilePath string) (*rest.Config, error) {
+		if _, err := os.Stat(kubeConfigFilePath); err != nil {
+			return nil, fmt.Errorf("cannot stat kubeconfig '%s'", kubeConfigFilePath)
+		}
+		return clientcmd.BuildConfigFromFlags("", kubeConfigFilePath)
+	}
+
+	// If an env variable is specified with the config location, use that
+	kubeConfig := os.Getenv("KUBECONFIG")
+	if len(kubeConfig) > 0 {
+		return kubeconfigFromFilePath(kubeConfig)
+	}
+
+	// try the default location in the user's home directory
+	if usr, err := user.Current(); err == nil {
+		kubeConfig := filepath.Join(usr.HomeDir, ".kube", "config")
+		return kubeconfigFromFilePath(kubeConfig)
+	}
+
+	// try the in-cluster config
+	if c, err := rest.InClusterConfig(); err == nil {
+		return c, nil
+	}
+
+	return nil, fmt.Errorf("could not locate a kubeconfig")
+}
+
+func getClientSetFromClusterConfig() (kubernetes.Interface, error) {
+
+	config, err := getKubeConfig()
+	if err != nil {
+		return nil, err
+	}
+	// creates the clientset
+	return kubernetes.NewForConfig(config)
+}
+
+func createOutputTemplate(name string, tmplStr string) (*template.Template, error) {
+	podInfoTemplate, err := template.New(name).Parse(tmplStr)
+	if err != nil {
+		return nil, err
+	}
+	return podInfoTemplate, nil
+}
+
+func buildNodeFieldSelector(nodeName string) string {
+	fieldSelector := ""
+	if len(nodeName) != 0 {
+		fieldSelector = fmt.Sprintf("spec.nodeName=%s,", nodeName)
+	}
+	fieldSelector += "status.phase=Running"
+
+	return fieldSelector
+}
+
+func showPodInfo(nodeFieldSelector string, clientset kubernetes.Interface, podInfoTemplate *template.Template, output io.Writer) error {
+
+	if nil == podInfoTemplate {
+		return fmt.Errorf("wrong incoming params: need an output template")
+	}
+
+	listOptions := metav1.ListOptions{
+		FieldSelector: nodeFieldSelector,
+	}
+	// get pods in all the namespaces by omitting namespace
+	// Or specify namespace to get pods in particular namespace
+	pods, err := clientset.CoreV1().Pods("").List(context.TODO(), listOptions)
+	if err != nil {
+		return fmt.Errorf("error while getting pods list: %w", err)
+	}
+
+	if err := podInfoTemplate.Execute(output, pods); err != nil {
+		return fmt.Errorf("error while trying to format output: %w", err)
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -305,8 +305,8 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openshift-kni/debug-tools v0.1.3
-## explicit; go 1.17
+# github.com/openshift-kni/debug-tools v0.1.7
+## explicit; go 1.18
 github.com/openshift-kni/debug-tools/pkg/fswrap
 github.com/openshift-kni/debug-tools/pkg/irqs
 github.com/openshift-kni/debug-tools/pkg/irqs/soft


### PR DESCRIPTION
From v1.7 `debug-tools` has a new `podinfo` command to help us to gather
info from pods to complement PodResourcesAPI info.
The information gathered is the same that was gotten with the current
`oc` command.