### PR TITLE
tools: generate machine config with hugepages settings only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,11 @@ dist-gather-sysinfo: build-output-dir
 		echo "Using pre-built gather-sysinfo helper";\
 	fi
 
+.PHONY: dist-hugepages-mc-genarator
+dist-hugepages-mc-genarator: build-output-dir
+	echo "Building hugepages machineconfig genarator tool";\
+	env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go build -ldflags="-s -w" -mod=vendor -o $(TOOLS_BIN_DIR)/hugepages-machineconfig-generator ./tools/hugepages-machineconfig-generator
+
 .PHONY: dist-csv-processor
 dist-csv-processor: build-output-dir
 	@if [ ! -x $(TOOLS_BIN_DIR)/csv-processor ]; then\

--- a/pkg/utils/hugepages/machineconfig.go
+++ b/pkg/utils/hugepages/machineconfig.go
@@ -1,0 +1,101 @@
+package hugepages
+
+import (
+	"encoding/json"
+	"fmt"
+
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+
+	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
+	"github.com/openshift-kni/performance-addon-operators/build/assets"
+	comps "github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/machineconfig"
+)
+
+const (
+	defaultIgnitionVersion       = "3.2.0"
+	defaultIgnitionContentSource = "data:text/plain;charset=utf-8;base64"
+	bashScriptsDir               = "/usr/local/bin"
+	hugepagesAllocation          = "hugepages-allocation" //script name
+)
+
+//MakeMachineConfig returns machineconfig object based on the hugepages configuration
+func MakeMachineConfig(hugepages *performancev2.HugePages, nodeRole string) (*machineconfigv1.MachineConfig, error) {
+	labels := make(map[string]string)
+	labels[comps.MachineConfigRoleLabelKey] = nodeRole
+
+	mc := &machineconfigv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: machineconfigv1.GroupVersion.String(),
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "hugepages-config",
+			Labels: labels,
+		},
+		Spec: machineconfigv1.MachineConfigSpec{},
+	}
+
+	ignitionConfig, err := getIgnitionConfig(hugepages)
+	if err != nil {
+		return nil, err
+	}
+
+	rawIgnition, err := json.Marshal(ignitionConfig)
+	if err != nil {
+		return nil, err
+	}
+	mc.Spec.Config = runtime.RawExtension{Raw: rawIgnition}
+
+	return mc, nil
+}
+
+func getIgnitionConfig(hugepages *performancev2.HugePages) (*igntypes.Config, error) {
+	ignitionConfig := &igntypes.Config{
+		Ignition: igntypes.Ignition{
+			Version: defaultIgnitionVersion,
+		},
+		Storage: igntypes.Storage{
+			Files: []igntypes.File{},
+		},
+	}
+
+	// add hugepages allocation script file under the node /usr/local/bin directory
+	mode := 0700
+	dst := machineconfig.GetBashScriptPath(hugepagesAllocation)
+	content, err := assets.Scripts.ReadFile(fmt.Sprintf("scripts/%s.sh", hugepagesAllocation))
+	if err != nil {
+		return nil, err
+	}
+	machineconfig.AddContent(ignitionConfig, content, dst, &mode)
+
+	// add hugepages units under systemd
+	for _, page := range hugepages.Pages {
+		hugepagesSize, err := machineconfig.GetHugepagesSizeKilobytes(page.Size)
+		if err != nil {
+			return nil, err
+		}
+
+		hugepagesService, err := machineconfig.GetSystemdContent(machineconfig.GetHugepagesAllocationUnitOptions(
+			hugepagesSize,
+			page.Count,
+			*page.Node,
+		))
+		if err != nil {
+			return nil, err
+		}
+
+		ignitionConfig.Systemd.Units = append(ignitionConfig.Systemd.Units, igntypes.Unit{
+			Contents: &hugepagesService,
+			Enabled:  pointer.BoolPtr(true),
+			Name:     machineconfig.GetSystemdService(fmt.Sprintf("%s-%skB-NUMA%d", hugepagesAllocation, hugepagesSize, *page.Node)),
+		})
+	}
+
+	return ignitionConfig, nil
+}

--- a/tools/hugepages-machineconfig-generator/hugepages-machineconfig-generator.go
+++ b/tools/hugepages-machineconfig-generator/hugepages-machineconfig-generator.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/ghodss/yaml"
+
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
+	"github.com/openshift-kni/performance-addon-operators/pkg/utils/hugepages"
+)
+
+var (
+	nodeRole   = flag.String("n", "worker", "node role of the machine config object")
+	inputFile  = flag.String("i", "", "performance profile yaml file")
+	outputFile = flag.String("o", "", "performance profile yaml file")
+)
+
+func main() {
+	flag.Parse()
+
+	var err error
+	var bytes []byte
+	if inputFile == nil || *inputFile == "" {
+		// reads the full content of stdin - possibly a large block of data
+		bytes, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		//reads the full content of the input file
+		bytes, err = ioutil.ReadFile(*inputFile)
+	}
+	if err != nil {
+		log.Fatalf("failed to read the input: %v", err)
+	}
+	profile := &performancev2.PerformanceProfile{}
+	err = yaml.Unmarshal(bytes, profile)
+	if err != nil {
+		log.Fatalf("failed to unmarshal the input into performance profile: %v", err)
+	}
+
+	mc, err := createMachineConfig(profile, nodeRole)
+	if err != nil {
+		log.Fatalf("failed to generate a machine config with hugepages settings: %v", err)
+	}
+
+	y, err := yaml.Marshal(mc)
+	if err != nil {
+		log.Fatalf("failed to get the machine config as yaml file: %v", err)
+	}
+
+	manifest := string(y)
+	var sink io.Writer = os.Stdout
+	if outputFile != nil && *outputFile != "" {
+		f, err := os.Create(*outputFile)
+		if err != nil {
+			log.Fatalf("error opening %s: %v\n", *outputFile, err)
+		}
+		defer f.Close()
+		sink = f
+	}
+	// writes all the content to the destination file in one go
+	_, err = io.WriteString(sink, manifest)
+	if err != nil {
+		log.Fatalf("unable to write the output: %v", err)
+	}
+
+}
+
+func createMachineConfig(profile *performancev2.PerformanceProfile, noderole *string) (*machineconfigv1.MachineConfig, error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			log.Fatalf("missing page.Node: %v", rec)
+		}
+	}()
+	return hugepages.MakeMachineConfig(profile.Spec.HugePages, *nodeRole)
+}


### PR DESCRIPTION
There is a need to configure the OCP cluster with hugepages settings independently from PAO. Adding this utility supports generating new machine config with hugepages settings only.