### PR TITLE
utils: generate machine config with hugepages settings only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,11 @@ dist-gather-sysinfo: build-output-dir
 		echo "Using pre-built gather-sysinfo helper";\
 	fi
 
+.PHONY: dist-hugepages-mc-genarator
+dist-hugepages-mc-genarator: build-output-dir
+	echo "Building hugepages machineconfig genarator tool";\
+	env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go build -ldflags="-s -w" -mod=vendor -o $(TOOLS_BIN_DIR)/hugepages-machineconfig-generator ./tools/hugepages-machineconfig-generator
+
 .PHONY: dist-csv-processor
 dist-csv-processor: build-output-dir
 	@if [ ! -x $(TOOLS_BIN_DIR)/csv-processor ]; then\

--- a/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
+++ b/pkg/controller/performanceprofile/components/machineconfig/machineconfig.go
@@ -140,7 +140,7 @@ func getIgnitionConfig(assetsDir string, profile *performancev2.PerformanceProfi
 	mode := 0700
 	for _, script := range []string{hugepagesAllocation, ociHooks, setRPSMask} {
 		src := filepath.Join(assetsDir, "scripts", fmt.Sprintf("%s.sh", script))
-		if err := addFile(ignitionConfig, src, getBashScriptPath(script), &mode); err != nil {
+		if err := AddFile(ignitionConfig, src, GetBashScriptPath(script), &mode); err != nil {
 			return nil, err
 		}
 	}
@@ -152,7 +152,7 @@ func getIgnitionConfig(assetsDir string, profile *performancev2.PerformanceProfi
 		return nil, err
 	}
 
-	if err := addContent(
+	if err := AddContent(
 		ignitionConfig,
 		crioConfigSnippetContent,
 		filepath.Join(crioConfd, crioRuntimesConfig),
@@ -169,7 +169,7 @@ func getIgnitionConfig(assetsDir string, profile *performancev2.PerformanceProfi
 		return nil, err
 	}
 
-	if err := addContent(
+	if err := AddContent(
 		ignitionConfig,
 		ociHooksConfigContent,
 		filepath.Join(OCIHooksConfigDir, config),
@@ -187,7 +187,7 @@ func getIgnitionConfig(assetsDir string, profile *performancev2.PerformanceProfi
 		rule = fmt.Sprintf("%s.rules", udevRpsRules)
 	}
 
-	if err := addFile(
+	if err := AddFile(
 		ignitionConfig,
 		filepath.Join(assetsDir, "configs", rule),
 		filepath.Join(udevRulesDir, rule),
@@ -208,7 +208,7 @@ func getIgnitionConfig(assetsDir string, profile *performancev2.PerformanceProfi
 				return nil, err
 			}
 
-			hugepagesService, err := getSystemdContent(getHugepagesAllocationUnitOptions(
+			hugepagesService, err := GetSystemdContent(GetHugepagesAllocationUnitOptions(
 				hugepagesSize,
 				page.Count,
 				*page.Node,
@@ -220,7 +220,7 @@ func getIgnitionConfig(assetsDir string, profile *performancev2.PerformanceProfi
 			ignitionConfig.Systemd.Units = append(ignitionConfig.Systemd.Units, igntypes.Unit{
 				Contents: &hugepagesService,
 				Enabled:  pointer.BoolPtr(true),
-				Name:     getSystemdService(fmt.Sprintf("%s-%skB-NUMA%d", hugepagesAllocation, hugepagesSize, *page.Node)),
+				Name:     GetSystemdService(fmt.Sprintf("%s-%skB-NUMA%d", hugepagesAllocation, hugepagesSize, *page.Node)),
 			})
 		}
 	}
@@ -231,21 +231,22 @@ func getIgnitionConfig(assetsDir string, profile *performancev2.PerformanceProfi
 			return nil, err
 		}
 
-		rpsService, err := getSystemdContent(getRPSUnitOptions(rpsMask))
+		rpsService, err := GetSystemdContent(getRPSUnitOptions(rpsMask))
 		if err != nil {
 			return nil, err
 		}
 
 		ignitionConfig.Systemd.Units = append(ignitionConfig.Systemd.Units, igntypes.Unit{
 			Contents: &rpsService,
-			Name:     getSystemdService("update-rps@"),
+			Name:     GetSystemdService("update-rps@"),
 		})
 	}
 
 	return ignitionConfig, nil
 }
 
-func getBashScriptPath(scriptName string) string {
+//GetBashScriptPath returns the script path containing teh directory and the script name
+func GetBashScriptPath(scriptName string) string {
 	return fmt.Sprintf("%s/%s.sh", bashScriptsDir, scriptName)
 }
 
@@ -253,11 +254,13 @@ func getSystemdEnvironment(key string, value string) string {
 	return fmt.Sprintf("%s=%s", key, value)
 }
 
-func getSystemdService(serviceName string) string {
+//GetSystemdService returns the service name in systemd
+func GetSystemdService(serviceName string) string {
 	return fmt.Sprintf("%s.service", serviceName)
 }
 
-func getSystemdContent(options []*unit.UnitOption) (string, error) {
+//GetSystemdContent get systemd content from list of unit options
+func GetSystemdContent(options []*unit.UnitOption) (string, error) {
 	outReader := unit.Serialize(options)
 	outBytes, err := ioutil.ReadAll(outReader)
 	if err != nil {
@@ -303,7 +306,8 @@ func GetHugepagesSizeKilobytes(hugepagesSize performancev2.HugePageSize) (string
 	}
 }
 
-func getHugepagesAllocationUnitOptions(hugepagesSize string, hugepagesCount int32, numaNode int32) []*unit.UnitOption {
+//GetHugepagesAllocationUnitOptions returns list of unit options based on the settings of the hugepage
+func GetHugepagesAllocationUnitOptions(hugepagesSize string, hugepagesCount int32, numaNode int32) []*unit.UnitOption {
 	return []*unit.UnitOption{
 		// [Unit]
 		// Description
@@ -320,7 +324,7 @@ func getHugepagesAllocationUnitOptions(hugepagesSize string, hugepagesCount int3
 		// RemainAfterExit
 		unit.NewUnitOption(systemdSectionService, systemdRemainAfterExit, systemdTrue),
 		// ExecStart
-		unit.NewUnitOption(systemdSectionService, systemdExecStart, getBashScriptPath(hugepagesAllocation)),
+		unit.NewUnitOption(systemdSectionService, systemdExecStart, GetBashScriptPath(hugepagesAllocation)),
 		// [Install]
 		// WantedBy
 		unit.NewUnitOption(systemdSectionInstall, systemdWantedBy, systemdTargetMultiUser),
@@ -328,7 +332,7 @@ func getHugepagesAllocationUnitOptions(hugepagesSize string, hugepagesCount int3
 }
 
 func getRPSUnitOptions(rpsMask string) []*unit.UnitOption {
-	cmd := fmt.Sprintf("%s %%i %s", getBashScriptPath(setRPSMask), rpsMask)
+	cmd := fmt.Sprintf("%s %%i %s", GetBashScriptPath(setRPSMask), rpsMask)
 	return []*unit.UnitOption{
 		// [Unit]
 		// Description
@@ -341,7 +345,8 @@ func getRPSUnitOptions(rpsMask string) []*unit.UnitOption {
 	}
 }
 
-func addContent(ignitionConfig *igntypes.Config, content []byte, dst string, mode *int) error {
+//AddContent appends more content to the ignition configuration
+func AddContent(ignitionConfig *igntypes.Config, content []byte, dst string, mode *int) error {
 	contentBase64 := base64.StdEncoding.EncodeToString(content)
 	ignitionConfig.Storage.Files = append(ignitionConfig.Storage.Files, igntypes.File{
 		Node: igntypes.Node{
@@ -377,11 +382,12 @@ func addCrioConfigSnippet(profile *performancev2.PerformanceProfile, src string)
 	return crioConfig.Bytes(), nil
 }
 
-func addFile(ignitionConfig *igntypes.Config, src string, dst string, mode *int) error {
+//AddFile reads the file and add the content to the destination directory
+func AddFile(ignitionConfig *igntypes.Config, src string, dst string, mode *int) error {
 	content, err := ioutil.ReadFile(src)
 	if err != nil {
 		return err
 	}
 
-	return addContent(ignitionConfig, content, dst, mode)
+	return AddContent(ignitionConfig, content, dst, mode)
 }

--- a/pkg/utils/hugepages/machineconfig.go
+++ b/pkg/utils/hugepages/machineconfig.go
@@ -1,0 +1,99 @@
+package hugepages
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+
+	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
+	comps "github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components"
+	"github.com/openshift-kni/performance-addon-operators/pkg/controller/performanceprofile/components/machineconfig"
+)
+
+const (
+	defaultIgnitionVersion       = "3.2.0"
+	defaultIgnitionContentSource = "data:text/plain;charset=utf-8;base64"
+	bashScriptsDir               = "/usr/local/bin"
+	hugepagesAllocation          = "hugepages-allocation" //script name
+)
+
+//MakeMachineConfig returns machineconfig object based on the hugepages configuration
+func MakeMachineConfig(assetsDir string, hugepages *performancev2.HugePages, nodeRole string) (*machineconfigv1.MachineConfig, error) {
+	labels := make(map[string]string)
+	labels[comps.MachineConfigRoleLabelKey] = nodeRole
+
+	mc := &machineconfigv1.MachineConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: machineconfigv1.GroupVersion.String(),
+			Kind:       "MachineConfig",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "hugepages-config",
+			Labels: labels,
+		},
+		Spec: machineconfigv1.MachineConfigSpec{},
+	}
+
+	ignitionConfig, err := getIgnitionConfig(assetsDir, hugepages)
+	if err != nil {
+		return nil, err
+	}
+
+	rawIgnition, err := json.Marshal(ignitionConfig)
+	if err != nil {
+		return nil, err
+	}
+	mc.Spec.Config = runtime.RawExtension{Raw: rawIgnition}
+
+	return mc, nil
+}
+
+func getIgnitionConfig(assetsDir string, hugepages *performancev2.HugePages) (*igntypes.Config, error) {
+	ignitionConfig := &igntypes.Config{
+		Ignition: igntypes.Ignition{
+			Version: defaultIgnitionVersion,
+		},
+		Storage: igntypes.Storage{
+			Files: []igntypes.File{},
+		},
+	}
+
+	// add hugepages allocation script file under the node /usr/local/bin directory
+	mode := 0700
+	src := filepath.Join(assetsDir, "scripts", fmt.Sprintf("%s.sh", hugepagesAllocation))
+	if err := machineconfig.AddFile(ignitionConfig, src, machineconfig.GetBashScriptPath(hugepagesAllocation), &mode); err != nil {
+		return nil, err
+	}
+
+	// add hugepages units under systemd
+	for _, page := range hugepages.Pages {
+		hugepagesSize, err := machineconfig.GetHugepagesSizeKilobytes(page.Size)
+		if err != nil {
+			return nil, err
+		}
+
+		hugepagesService, err := machineconfig.GetSystemdContent(machineconfig.GetHugepagesAllocationUnitOptions(
+			hugepagesSize,
+			page.Count,
+			*page.Node,
+		))
+		if err != nil {
+			return nil, err
+		}
+
+		ignitionConfig.Systemd.Units = append(ignitionConfig.Systemd.Units, igntypes.Unit{
+			Contents: &hugepagesService,
+			Enabled:  pointer.BoolPtr(true),
+			Name:     machineconfig.GetSystemdService(fmt.Sprintf("%s-%skB-NUMA%d", hugepagesAllocation, hugepagesSize, *page.Node)),
+		})
+	}
+
+	return ignitionConfig, nil
+}

--- a/tools/hugepages-machineconfig-generator/hugepages-machineconfig-generator.go
+++ b/tools/hugepages-machineconfig-generator/hugepages-machineconfig-generator.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/ghodss/yaml"
+
+	machineconfigv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+
+	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
+	"github.com/openshift-kni/performance-addon-operators/pkg/utils/hugepages"
+)
+
+const assetsDir = "../build/assets"
+
+var (
+	nodeRole   = flag.String("n", "worker", "node role of the machine config object")
+	inputFile  = flag.String("i", "", "performance profile yaml file")
+	outputFile = flag.String("o", "", "performance profile yaml file")
+)
+
+func main() {
+	flag.Parse()
+
+	var err error
+	var bytes []byte
+	if inputFile == nil || *inputFile == "" {
+		// reads the full content of stdin - possibly a large block of data
+		bytes, err = ioutil.ReadAll(os.Stdin)
+	} else {
+		//reads the full content of the input file
+		bytes, err = ioutil.ReadFile(*inputFile)
+	}
+	if err != nil {
+		log.Fatalf("failed to read the input: %v", err)
+	}
+	profile := &performancev2.PerformanceProfile{}
+	err = yaml.Unmarshal(bytes, profile)
+	if err != nil {
+		log.Fatalf("failed to unmarshal the input into performance profile: %v", err)
+	}
+
+	mc, err := createMachineConfig(profile, nodeRole)
+	if err != nil {
+		log.Fatalf("failed to generate a machine config with hugepages settings: %v", err)
+	}
+
+	y, err := yaml.Marshal(mc)
+	if err != nil {
+		log.Fatalf("failed to get the machine config as yaml file: %v", err)
+	}
+
+	manifest := string(y)
+	var sink io.Writer = os.Stdout
+	if outputFile != nil && *outputFile != "" {
+		f, err := os.Create(*outputFile)
+		if err != nil {
+			log.Fatalf("error opening %s: %v\n", *outputFile, err)
+		}
+		defer f.Close()
+		sink = f
+	}
+	// writes all the content to the destination file in one go
+	_, err = io.WriteString(sink, manifest)
+	if err != nil {
+		log.Fatalf("unable to write the output: %v", err)
+	}
+
+}
+
+func createMachineConfig(profile *performancev2.PerformanceProfile, noderole *string) (*machineconfigv1.MachineConfig, error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			log.Fatalf("missing page.Node: %v", rec)
+		}
+	}()
+	return hugepages.MakeMachineConfig(assetsDir, profile.Spec.HugePages, *nodeRole)
+}


### PR DESCRIPTION
There is a need to configure the OCP cluster with hugepages settings independently from PAO. Adding this utility supports generating new machine config with hugepages settings only.