### PR TITLE
gh actions: add workflow to build tool

### DIFF
--- a/.github/workflows/release-hp-mc-generator.yml
+++ b/.github/workflows/release-hp-mc-generator.yml
@@ -1,0 +1,40 @@
+
+name: Build hugepages-machineconfig-generator tool binary
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 
+
+      - name: setup golang
+        uses: actions/setup-go@v2
+        id: go
+        with:
+          go-version: 1.17
+  build:
+    needs: [setup]
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 
+
+      - name: build machineconfig generator tool for hugepages
+        run: make dist-hugepages-mc-genarator
+
+      - name: release the tool binary 
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: build/_output/bin/hugepages-machineconfig-generator


### PR DESCRIPTION
Add new workflow to build and release binary for tools/hugepages-machineconfig-generator to enable using it externally.