### PR TITLE
e2e: latency: skip the tests earlier in the suite

### DIFF
--- a/functests/5_latency_testing/latency_testing.go
+++ b/functests/5_latency_testing/latency_testing.go
@@ -20,7 +20,9 @@ import (
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profilesupdate"
 )
 
+//TODO get commonly used variables from one shared file that defines constants
 const (
+	filePath = "../../build/_output/bin/latency-e2e.test"
 	//tool to test
 	oslat       = "oslat"
 	cyclictest  = "cyclictest"
@@ -101,10 +103,7 @@ var _ = Describe("Run tests of latency measurement tools with different values o
 				clearEnv()
 				testDescription := setEnvAndGetDescription(test)
 				By(testDescription)
-				if _, err := os.Stat("../../build/_output/bin/latency-e2e.test"); os.IsNotExist(err) {
-					Skip("The executable test file does not exist , skipping the test.")
-				}
-				output, err := exec.Command("../../build/_output/bin/latency-e2e.test", "-ginkgo.focus", test.toolToTest).Output()
+				output, err := exec.Command(filePath, "-ginkgo.focus", test.toolToTest).Output()
 				if err != nil {
 					//we don't log Error level here because the test might be a negative check
 					testlog.Info(err.Error())


### PR DESCRIPTION
This suite works properly only if the test executable exists. Currently each test checks for the existence of this common executable.
The suite performs some setup steps that are relevant for this set of tests, without considering whether the file exists or not. To avoid extra unneeded execution time, skip the suite at an early stage if the executable file does not exist.

Signed-off-by: shereenH <shajmakh@redhat.com>