### PR TITLE
e2e: latency: skip the tests earlier in the suite

### DIFF
--- a/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -43,6 +43,10 @@ var profile *performancev2.PerformanceProfile
 func Test5LatencyTesting(t *testing.T) {
 	RegisterFailHandler(Fail)
 
+	if !testclient.ClientsEnabled {
+		t.Fatal("client not enabled")
+	}
+
 	if _, err := os.Stat(testExecutablePath); os.IsNotExist(err) {
 		testlog.Infof("The test executable file %q does not exist, skipping the suite.", testExecutablePath)
 		t.Skip()
@@ -70,10 +74,6 @@ func createNamespace() error {
 }
 
 func setup() {
-	if !testclient.ClientsEnabled {
-		testlog.Errorf("client not enabled")
-	}
-
 	// update PP isolated CPUs. the new cpu set for isolated should have an even number of CPUs to avoid failing the pod on SMTAlignment error,
 	// and should be greater than what is requested by the test cases in the suite so the test runs properly
 	var err error

--- a/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -45,9 +45,15 @@ var _ = BeforeSuite(func() {
 	// and should be greater than what is requested by the test cases in the suite so the test runs properly
 	var err error
 	profile, err = profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
-	Expect(err).ToNot(HaveOccurred())
+	if err != nil {
+		testlog.Errorf("error while getting the performance profile: %v", err)
+		return
+	}
 	workerNodes, err := nodes.GetByLabels(testutils.NodeSelectorLabels)
-	Expect(err).ToNot(HaveOccurred())
+	if err != nil {
+		testlog.Errorf("error while getting the worker nodes: %v", err)
+		return
+	}
 
 	initialIsolated := profile.Spec.CPU.Isolated
 	initialReserved := profile.Spec.CPU.Reserved
@@ -89,7 +95,10 @@ var _ = AfterSuite(func() {
 	namespaces.WaitForDeletion(prePullNamespaceName, 5*time.Minute)
 
 	currentProfile, err := profiles.GetByNodeLabels(testutils.NodeSelectorLabels)
-	Expect(err).ToNot(HaveOccurred())
+	if err != nil {
+		testlog.Errorf("error while getting the performance profile: %v", err)
+		return
+	}
 	if reflect.DeepEqual(currentProfile.Spec, profile.Spec) != true {
 		testlog.Info("Restore initial performance profile")
 		err = profilesupdate.ApplyProfile(profile)

--- a/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -3,6 +3,7 @@ package __latency_testing_test
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -29,6 +30,9 @@ import (
 	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
 
+//TODO get commonly used variables from one shared file that defines constants
+const testExecutablePath = "../../build/_output/bin/latency-e2e.test"
+
 var prePullNamespace = &corev1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "testing-prepull",
@@ -39,7 +43,10 @@ var profile *performancev2.PerformanceProfile
 func Test5LatencyTesting(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	//TODO Skip the suite before setup steps in case the executable is not found
+	if _, err := os.Stat(testExecutablePath); os.IsNotExist(err) {
+		testlog.Infof("The test executable file %q does not exist, skipping the suite.", testExecutablePath)
+		t.Skip()
+	}
 
 	setup()
 	defer teardown()

--- a/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -136,7 +136,7 @@ func teardown() {
 		testlog.Info("Restore initial performance profile")
 		err = profilesupdate.ApplyProfile(profile)
 		if err != nil {
-			testlog.Error("could not restore the initial profile")
+			testlog.Errorf("could not restore the initial profile: %v", err)
 		}
 	}
 }

--- a/functests/5_latency_testing/latency_testing.go
+++ b/functests/5_latency_testing/latency_testing.go
@@ -20,7 +20,9 @@ import (
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profilesupdate"
 )
 
+//TODO get commonly used variables from one shared file that defines constants
 const (
+	testExecutablePath = "../../build/_output/bin/latency-e2e.test"
 	//tool to test
 	oslat       = "oslat"
 	cyclictest  = "cyclictest"
@@ -101,10 +103,7 @@ var _ = Describe("Run tests of latency measurement tools with different values o
 				clearEnv()
 				testDescription := setEnvAndGetDescription(test)
 				By(testDescription)
-				if _, err := os.Stat("../../build/_output/bin/latency-e2e.test"); os.IsNotExist(err) {
-					Skip("The executable test file does not exist , skipping the test.")
-				}
-				output, err := exec.Command("../../build/_output/bin/latency-e2e.test", "-ginkgo.focus", test.toolToTest).Output()
+				output, err := exec.Command(testExecutablePath, "-ginkgo.focus", test.toolToTest).Output()
 				if err != nil {
 					//we don't log Error level here because the test might be a negative check
 					testlog.Info(err.Error())


### PR DESCRIPTION
This suite works properly only if the test executable exists. Currently each test checks for the existence of this common executable.
The suite performs some setup steps that are relevant for this set of tests, without considering whether the file exists or not. To avoid extra unneeded execution time, skip the suite at an early stage if the executable file does not exist.