### PR TITLE
must-gather:podinfo: Add RBAC elements to list pods

### DIFF
--- a/must-gather/collection-scripts/gather_nodes
+++ b/must-gather/collection-scripts/gather_nodes
@@ -23,6 +23,8 @@ mkdir -p ${NODES_PATH}
 NAMESPACE_MANIFEST="/etc/node-gather/namespace.yaml"
 SERVICEACCOUNT_MANIFEST="/etc/node-gather/serviceaccount.yaml"
 DAEMONSET_MANIFEST="/etc/node-gather/daemonset.yaml"
+CLUSTER_ROLE_MANIFEST="/etc/node-gather/clusterrole.yaml"
+CLUSTER_ROLE_BINDING_MANIFEST="/etc/node-gather/clusterrolebinding.yaml"
 NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
 # Once you start the pod, the Kubernetes will set the pod hostname to the name of the pod
 # https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-hostname-and-subdomain-fields
@@ -38,6 +40,8 @@ sed -i -e "s#MUST_GATHER_IMAGE#$MUST_GATHER_IMAGE#" $DAEMONSET_MANIFEST
 oc create -f $NAMESPACE_MANIFEST
 oc create -f $SERVICEACCOUNT_MANIFEST
 oc adm policy add-scc-to-user privileged -n perf-node-gather -z perf-node-gather
+oc create -f $CLUSTER_ROLE_MANIFEST
+oc create -f $CLUSTER_ROLE_BINDING_MANIFEST
 oc create -f $DAEMONSET_MANIFEST
 
 COUNTER=0
@@ -88,5 +92,7 @@ done
 wait "${ADM_PIDS[@]}"
 
 oc delete -f $DAEMONSET_MANIFEST
+oc delete -f $CLUSTER_ROLE_BINDING_MANIFEST
+oc delete -f $CLUSTER_ROLE_MANIFEST
 oc delete -f $SERVICEACCOUNT_MANIFEST
 oc delete -f $NAMESPACE_MANIFEST

--- a/must-gather/node-gather/clusterrole.yaml
+++ b/must-gather/node-gather/clusterrole.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: perf-node-gather-pods-reader
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get","list"]
+  

--- a/must-gather/node-gather/clusterrolebinding.yaml
+++ b/must-gather/node-gather/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: perf-node-gather-pods-reader
+subjects:
+- kind: ServiceAccount
+  name: perf-node-gather
+  namespace: perf-node-gather
+  apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: perf-node-gather-pods-reader
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
podinfo command need to list all pods in all namespaces scheduled to a
certain node. In order to do that it needs to have the proper
permissions.

Add a new ClusterRole,adding read permisions over pods in all namespaces,
and a ClusterRoleBinding to bind those persmissions to the
ServiceAccount used by the must-gather daemonset pods.

podinfo in pao: #907 
podinfo command: openshift-kni/debug-tools#64
