### PR TITLE
hack: skip tests under 5_latency_testing

### DIFF
--- a/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -37,9 +37,7 @@ var prePullNamespace = &corev1.Namespace{
 var profile *performancev2.PerformanceProfile
 
 var _ = BeforeSuite(func() {
-	if !testclient.ClientsEnabled {
-		testlog.Errorf("client not enabled")
-	}
+	Expect(testclient.ClientsEnabled).To(BeTrue())
 
 	// update PP isolated CPUs. the new cpu set for isolated should have an even number of CPUs to avoid failing the pod on SMTAlignment error,
 	// and should be greater than what is requested by the test cases in the suite so the test runs properly

--- a/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -94,7 +94,7 @@ var _ = AfterSuite(func() {
 		testlog.Info("Restore initial performance profile")
 		err = profilesupdate.ApplyProfile(profile)
 		if err != nil {
-			testlog.Error("could not restore the initial profile")
+			testlog.Errorf("could not restore the initial profile: %v", err)
 		}
 	}
 })

--- a/functests/5_latency_testing/5_latency_testing_suite_test.go
+++ b/functests/5_latency_testing/5_latency_testing_suite_test.go
@@ -3,6 +3,7 @@ package __latency_testing_test
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -29,6 +30,9 @@ import (
 	ginkgo_reporters "kubevirt.io/qe-tools/pkg/ginkgo-reporters"
 )
 
+//TODO get commonly used variables from one shared file that defines constants
+const testExecutablePath = "../../build/_output/bin/latency-e2e.test"
+
 var prePullNamespace = &corev1.Namespace{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "testing-prepull",
@@ -37,6 +41,7 @@ var prePullNamespace = &corev1.Namespace{
 var profile *performancev2.PerformanceProfile
 
 var _ = BeforeSuite(func() {
+	Expect(isTestExecutableFound()).To(BeTrue())
 	Expect(testclient.ClientsEnabled).To(BeTrue())
 
 	// update PP isolated CPUs. the new cpu set for isolated should have an even number of CPUs to avoid failing the pod on SMTAlignment error,
@@ -116,4 +121,11 @@ func createNamespace() error {
 	}
 	testlog.Infof("created namespace %q err=%v", prePullNamespace.Name, err)
 	return err
+}
+
+func isTestExecutableFound() bool {
+	if _, err := os.Stat(testExecutablePath); os.IsNotExist(err) {
+		return false
+	}
+	return true
 }

--- a/functests/5_latency_testing/latency_testing.go
+++ b/functests/5_latency_testing/latency_testing.go
@@ -20,7 +20,9 @@ import (
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profilesupdate"
 )
 
+//TODO get commonly used variables from one shared file that defines constants
 const (
+	testExecutablePath = "../../build/_output/bin/latency-e2e.test"
 	//tool to test
 	oslat       = "oslat"
 	cyclictest  = "cyclictest"
@@ -101,10 +103,10 @@ var _ = Describe("Run tests of latency measurement tools with different values o
 				clearEnv()
 				testDescription := setEnvAndGetDescription(test)
 				By(testDescription)
-				if _, err := os.Stat("../../build/_output/bin/latency-e2e.test"); os.IsNotExist(err) {
+				if _, err := os.Stat(testExecutablePath); os.IsNotExist(err) {
 					Skip("The executable test file does not exist , skipping the test.")
 				}
-				output, err := exec.Command("../../build/_output/bin/latency-e2e.test", "-ginkgo.focus", test.toolToTest).Output()
+				output, err := exec.Command(testExecutablePath, "-ginkgo.focus", test.toolToTest).Output()
 				if err != nil {
 					//we don't log Error level here because the test might be a negative check
 					testlog.Info(err.Error())
@@ -188,10 +190,10 @@ var _ = Describe("Run tests of latency measurement tools with different values o
 			clearEnv()
 			testDescription := setEnvAndGetDescription(test)
 			By(testDescription)
-			if _, err := os.Stat("../../build/_output/bin/latency-e2e.test"); os.IsNotExist(err) {
+			if _, err := os.Stat(testExecutablePath); os.IsNotExist(err) {
 				Skip("The executable test file does not exist , skipping the test.")
 			}
-			output, err := exec.Command("../../build/_output/bin/latency-e2e.test", "-ginkgo.focus", test.toolToTest).Output()
+			output, err := exec.Command(testExecutablePath, "-ginkgo.focus", test.toolToTest).Output()
 			Expect(string(output)).NotTo(MatchRegexp(unexpectedError), "Unexpected error was detected in a positive test: %v", err)
 
 			for _, msg := range test.outputMsgs {

--- a/functests/5_latency_testing/latency_testing.go
+++ b/functests/5_latency_testing/latency_testing.go
@@ -103,9 +103,6 @@ var _ = Describe("Run tests of latency measurement tools with different values o
 				clearEnv()
 				testDescription := setEnvAndGetDescription(test)
 				By(testDescription)
-				if _, err := os.Stat(testExecutablePath); os.IsNotExist(err) {
-					Skip("The executable test file does not exist , skipping the test.")
-				}
 				output, err := exec.Command(testExecutablePath, "-ginkgo.focus", test.toolToTest).Output()
 				if err != nil {
 					//we don't log Error level here because the test might be a negative check
@@ -190,9 +187,6 @@ var _ = Describe("Run tests of latency measurement tools with different values o
 			clearEnv()
 			testDescription := setEnvAndGetDescription(test)
 			By(testDescription)
-			if _, err := os.Stat(testExecutablePath); os.IsNotExist(err) {
-				Skip("The executable test file does not exist , skipping the test.")
-			}
 			output, err := exec.Command(testExecutablePath, "-ginkgo.focus", test.toolToTest).Output()
 			Expect(string(output)).NotTo(MatchRegexp(unexpectedError), "Unexpected error was detected in a positive test: %v", err)
 

--- a/functests/5_latency_testing/latency_testing.go
+++ b/functests/5_latency_testing/latency_testing.go
@@ -153,6 +153,9 @@ var _ = Describe("Run tests of latency measurement tools with different values o
 						}
 					}
 				}
+				for _, msg := range test.outputMsgs {
+					Expect(string(output)).To(MatchRegexp(msg), "The output of the executed tool is not as expected")
+				}
 			}
 		},
 			table.Entry("[test_id:42851] Latency tools shouldn't run with default environment variables values", []latencyTest{{outputMsgs: []string{skip, skipTestRun}}}, positiveTesting),

--- a/hack/run-functests.sh
+++ b/hack/run-functests.sh
@@ -27,4 +27,4 @@ echo "Running Functional Tests: ${GINKGO_SUITS}"
 # --failFast: ginkgo will stop the suite right after the first spec failure
 # --flakeAttempts: rerun the test if it fails
 # -requireSuite: fail if tests are not executed because of missing suite
-GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --failFast --flakeAttempts=2 -requireSuite ${GINKGO_SUITS} -- -junitDir /tmp/artifacts
+GOFLAGS=-mod=vendor ginkgo $NO_COLOR --v -r --failFast -skipPackage="5_latency_testing" --flakeAttempts=2 -requireSuite ${GINKGO_SUITS} -- -junitDir /tmp/artifacts


### PR DESCRIPTION
The tests in 5_latency_testing should run only on-demand and by using different make target with relevant dependencies. Skip this package using ginkgo skipPackage flag.
additionally to some cleanup and fixes, see commits for more details.