### PR TITLE
must-gather: numaresources: Avoid error messages when NRO is not installed

### DIFF
--- a/must-gather/collection-scripts/gather_nro
+++ b/must-gather/collection-scripts/gather_nro
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
 
-# get crds
-for crd_name in numaresourcesschedulers.nodetopology.openshift.io numaresourcesoperators.nodetopology.openshift.io noderesourcetopologies.topology.node.k8s.io
-do
-    # get crd definition
-    oc adm inspect --dest-dir must-gather crd/${crd_name}
-
-    # get crd instances
-    oc adm inspect --dest-dir must-gather ${crd_name}
-done
-
 # Get NRO namespace and gather all the data there
 . namespace
 NRO_NAMESPACE=$(nro_namespace)
 
-oc adm inspect --dest-dir must-gather ns/${NRO_NAMESPACE}
+if [ -z "$NRO_NAMESPACE" ]
+then
+    echo "Numaresources Operator namespace not detected. Skipping NRO data gathering"
+else
+    # get crds
+    for crd_name in numaresourcesschedulers.nodetopology.openshift.io numaresourcesoperators.nodetopology.openshift.io noderesourcetopologies.topology.node.k8s.io
+    do
+        # get crd definition
+        oc adm inspect --dest-dir must-gather crd/${crd_name}
+
+        # get crd instances
+        oc adm inspect --dest-dir must-gather ${crd_name}
+    done
+
+    oc adm inspect --dest-dir must-gather ns/${NRO_NAMESPACE}
+fi

--- a/must-gather/collection-scripts/namespace
+++ b/must-gather/collection-scripts/namespace
@@ -22,8 +22,5 @@ function nro_namespace() {
   # namespace suggested by the documentation. This is a fancier way to check for its existence
   [ -z "${ns}" ] && ns=$(oc get ns openshift-numaresources -o=jsonpath='{.metadata.name}{"\n"}' 2> /dev/null )
 
-  # we should never get there. This is the last resort.
-  [ -z "${ns}" ] && ns="openshift-numaresources"
-
   echo ${ns}
 }


### PR DESCRIPTION
must-gather is trying to get NRO related information (CRDs, and
namespaced artifacts) no matter what and so, when NRO is not installed
in the cluster some nasty error messages appear because those elements
are not found.

These are not errors but to avoid missleading the users it is better to
avoid them by not gathering the NRO information if we cannot detect the
NRO namespace.
A small message appears in console in this case.