### PR TITLE
utils: use updated profile, not original

### DIFF
--- a/functests/utils/profiles/profiles.go
+++ b/functests/utils/profiles/profiles.go
@@ -111,7 +111,7 @@ func UpdateWithRetry(profile *performancev2.PerformanceProfile) {
 		}
 
 		updatedProfile.Spec = *profile.Spec.DeepCopy()
-		if err := testclient.Client.Update(context.TODO(), profile); err != nil {
+		if err := testclient.Client.Update(context.TODO(), updatedProfile); err != nil {
 			if !errors.IsConflict(err) {
 				testlog.Errorf("failed to update the profile %q: %v", profile.Name, err)
 			}


### PR DESCRIPTION
UpdateWithRetry wants to get a fresh copy of the profile
to update to avoid conflicts; because of a copy/paste
mistake, it was trying to reapply the original profile,
not the updated copy, thus defeating the purpose of the function.

Signed-off-by: Francesco Romani <fromani@redhat.com>
