### PR TITLE
Add test_id to imagePullPolicy should be ifNotPresent tc

### DIFF
--- a/functests/1_performance/performance.go
+++ b/functests/1_performance/performance.go
@@ -1089,7 +1089,7 @@ var _ = Describe("[rfe_id:27368][performance]", func() {
 	Context("Verify containers specifications", func() {
 
 		// Automates https://bugzilla.redhat.com/show_bug.cgi?id=2055019
-		It("imagePullPolicy should be ifNotPresent", func() {
+		It("[test_id:54115] imagePullPolicy should be ifNotPresent", func() {
 			pod, err := pods.GetPerformanceOperatorPod()
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
Add missing test id to the test case that verifies that imagePullPolicy of the operator pod is ifNotPresent, this will enable clear test result reporting. 