### PR TITLE
e2e: latency testing: increase the expected threshold and fix gomega truncating output

### DIFF
--- a/functests/5_latency_testing/latency_testing.go
+++ b/functests/5_latency_testing/latency_testing.go
@@ -20,7 +20,7 @@ import (
 	"github.com/openshift-kni/performance-addon-operators/functests/utils/profilesupdate"
 )
 
-//TODO get commonly used variables from one shared file that defines constants
+// TODO get commonly used variables from one shared file that defines constants
 const (
 	testExecutablePath = "../../build/_output/bin/latency-e2e.test"
 	//tool to test
@@ -77,12 +77,15 @@ const (
 	skipOddCpuNumber         = `Skip the test, the requested number of CPUs should be even to avoid noisy neighbor situation`
 	skipOslatForIsolatedCpus = `Skip the oslat test, the profile .* has less than 2 isolated CPUs`
 	//used values parameters
-	guaranteedLatency = "20000"
+
+	// we do not care about the actual system latency because CI systems are not tuned well enough to be an example for
+	// latency measuring, besides this suite only cares about testing the test executable with different values of env vars.
+	guaranteedLatency = "900000"
 	negativeTesting   = false
 	positiveTesting   = true
 )
 
-//Struct to hold each test parameters
+// Struct to hold each test parameters
 type latencyTest struct {
 	testDelay             string
 	testRun               string

--- a/functests/5_latency_testing/latency_testing.go
+++ b/functests/5_latency_testing/latency_testing.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 
 	performancev2 "github.com/openshift-kni/performance-addon-operators/api/v2"
 	testutils "github.com/openshift-kni/performance-addon-operators/functests/utils"
@@ -100,6 +101,7 @@ type latencyTest struct {
 }
 
 var _ = Describe("Run tests of latency measurement tools with different values of latency environment variables", func() {
+	format.MaxLength = 0
 	Context("Verify tests output with existed performance profile", func() {
 		table.DescribeTable("Test latency measurement tools tests", func(testGroup []latencyTest, isPositiveTest bool) {
 			for _, test := range testGroup {


### PR DESCRIPTION
lately some of the latency tests were failing and it turned out that the failure is due to that the maximum latency found was greater than anticipated. The tests in this suite do not care about the measured latency because we do not care to tune the systems in the first place. Its only goal is to run the tests of the latency tools with different values of environment variables and validate that the tool actually runs with these parameters.

Increase the maximum latency threshold so that the test doesn't fail in case of a high latency result.

