### PR TITLE
OCPBUGS-25819: Bump openshift-kni/debug-tools to 0.1.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/jaypipes/ghw v0.8.1-0.20210605191321-eb162add542b
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
-	github.com/openshift-kni/debug-tools v0.1.7
+	github.com/openshift-kni/debug-tools v0.1.8
 	github.com/openshift/api v3.9.1-0.20191111211345-a27ff30ebf09+incompatible
 	github.com/openshift/cluster-node-tuning-operator v0.0.0-20200914165052-a39511828cf0
 	github.com/openshift/custom-resource-status v0.0.0-20200602122900-c002fd1547ca

--- a/go.sum
+++ b/go.sum
@@ -799,8 +799,8 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.m
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
-github.com/openshift-kni/debug-tools v0.1.7 h1:FCg1xY94Zi3WB04dMKZdTn/OVEsKYEwpVJfgdO+JbR4=
-github.com/openshift-kni/debug-tools v0.1.7/go.mod h1:oq0XTqe9bAYyQUXZdHwRmRrMqHZTEC+yuJbipYzvqvI=
+github.com/openshift-kni/debug-tools v0.1.8 h1:QZDiKyuHWm5uqZp0nr3MiQipbFdsTZ6X28+BYialGfo=
+github.com/openshift-kni/debug-tools v0.1.8/go.mod h1:oq0XTqe9bAYyQUXZdHwRmRrMqHZTEC+yuJbipYzvqvI=
 github.com/openshift/api v0.0.0-20210610130314-a6ac319a7eed h1:8Q94GlNfhBoMqQFw9gCNQ0Q9V1B+tw5VBn+M4e5ooaI=
 github.com/openshift/api v0.0.0-20210610130314-a6ac319a7eed/go.mod h1:izBmoXbUu3z5kUa4FjZhvekTsyzIWiOoaIgJiZBBMQs=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -305,7 +305,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openshift-kni/debug-tools v0.1.7
+# github.com/openshift-kni/debug-tools v0.1.8
 ## explicit; go 1.18
 github.com/openshift-kni/debug-tools/pkg/fswrap
 github.com/openshift-kni/debug-tools/pkg/irqs


### PR DESCRIPTION
This version introduces a solution for not collecting pod_info file by Must Gather. More info here: https://github.com/openshift-kni/debug-tools/releases/tag/v0.1.8

Fixes OCPBUGS-25819